### PR TITLE
name proto conversion extensions more consistently

### DIFF
--- a/bd-pgv/src/proto_validate_test.rs
+++ b/bd-pgv/src/proto_validate_test.rs
@@ -54,7 +54,7 @@ fn duration() {
     "negative proto duration not supported");
 
   let message = Duration {
-    field: 1.seconds().to_proto(),
+    field: 1.seconds().into_proto(),
     ..Default::default()
   };
   assert!(validate(&message).is_ok());

--- a/bd-test-helpers/src/test_api_server.rs
+++ b/bd-test-helpers/src/test_api_server.rs
@@ -147,7 +147,7 @@ impl RequestProcessor {
           .stream_state
           .ping_interval
           .map(|d| StreamSettings {
-            ping_interval: d.to_proto(),
+            ping_interval: d.into_proto(),
             ..Default::default()
           })
           .into();

--- a/bd-time/src/lib.rs
+++ b/bd-time/src/lib.rs
@@ -149,17 +149,17 @@ impl ProtoDurationExt for protobuf::well_known_types::duration::Duration {
 //
 
 pub trait ToProtoDuration {
-  fn to_proto(self) -> MessageField<protobuf::well_known_types::duration::Duration>;
+  fn into_proto(self) -> MessageField<protobuf::well_known_types::duration::Duration>;
 }
 
 impl ToProtoDuration for Duration {
-  fn to_proto(self) -> MessageField<protobuf::well_known_types::duration::Duration> {
+  fn into_proto(self) -> MessageField<protobuf::well_known_types::duration::Duration> {
     Some(self.into()).into()
   }
 }
 
 impl ToProtoDuration for time::Duration {
-  fn to_proto(self) -> MessageField<protobuf::well_known_types::duration::Duration> {
+  fn into_proto(self) -> MessageField<protobuf::well_known_types::duration::Duration> {
     Some(protobuf::well_known_types::duration::Duration {
       seconds: self.whole_seconds(),
       nanos: self.subsec_nanoseconds(),


### PR DESCRIPTION
Instead of one being `to_proto` and the other `into_proto`, make them both `into_proto` as they take `self` by value