### PR TITLE
app update: fix ootb app update event

### DIFF
--- a/bd-logger/src/app_version_test.rs
+++ b/bd-logger/src/app_version_test.rs
@@ -22,7 +22,13 @@ fn app_version_repo() {
     app_version: "1.0.0".to_string(),
     app_version_extra: AppVersionExtra::BuildNumber("1".to_string()),
   }));
-  // Initial update
+  // Consecutive check after app update
+  assert!(repo.has_changed(&AppVersion {
+    app_version: "1.0.0".to_string(),
+    app_version_extra: AppVersionExtra::BuildNumber("2".to_string()),
+  }));
+
+  // Initial app version
   assert!(repo
     .set(&AppVersion {
       app_version: "1.0.0".to_string(),


### PR DESCRIPTION
Fix out-of-the-box "App Update" event for apps that haven't emitted any App Update event yet. In their case we ended up calling `has_changed` on every app open and each time the return value from the method was `false` which prevented the emission of the app update event. 

After the changes from this PR, we bootstrap the app version change detection logic while calling `has_changed` by storing current app version in the store so that it's available for the comparison on next app open.