### PR TITLE
hyper network: move back to ring as the default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -1921,15 +1921,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2017,7 +2008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2709,6 +2700,7 @@ checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ axum            = { version = "0.7.5", features = ["http2"] }
 axum-server     = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
 backoff         = "0.4.0"
 base64          = "0.22.1"
-base64ct        = { version = "1.6.0", features = ["alloc", "std"] }
 base64-url      = "3.0.0"
+base64ct        = { version = "1.6.0", features = ["alloc", "std"] }
 bincode         = "1.3.3"
 bytes           = "1.7.1"
 clap            = { version = "4.5.16", features = ["derive", "env"] }
@@ -72,7 +72,11 @@ http-body       = "1.0.1"
 http-body-util  = "0.1.2"
 hyper           = "1.4.1"
 
-hyper-rustls = { version = "0.27.2", default-features = false, features = ["http1", "http2", "aws-lc-rs", "webpki-tokio"] }
+hyper-rustls = { version = "0.27.2", default-features = false, features = [
+  "http1",
+  "http2",
+  "webpki-tokio",
+] }
 
 hyper-util            = { version = "0.1.7", features = ["client", "client-legacy"] }
 intrusive-collections = "0.9.6"

--- a/bd-hyper-network/Cargo.toml
+++ b/bd-hyper-network/Cargo.toml
@@ -5,6 +5,11 @@ name         = "bd-hyper-network"
 publish      = false
 version      = "1.0.0"
 
+[features]
+aws-lc-rs = ["hyper-rustls/aws-lc-rs"]
+default   = ["ring"]
+ring      = ["hyper-rustls/ring"]
+
 [dependencies]
 anyhow.workspace         = true
 async-trait.workspace    = true


### PR DESCRIPTION
This removes CI issues for cross compiling in the SDK. We can explicitly enable elsewhere if needed (if we use this again in Pulse.)