### PR TITLE
add a register() function to each runtime flag

### DIFF
--- a/bd-client-stats/src/lib.rs
+++ b/bd-client-stats/src/lib.rs
@@ -19,7 +19,7 @@ use bd_client_stats_store::{
   Error as StatsError,
   Scope,
 };
-use bd_runtime::runtime::{ConfigLoader, IntWatch};
+use bd_runtime::runtime::ConfigLoader;
 use bd_shutdown::ComponentShutdown;
 use bd_time::{SystemTimeProvider, TimeProvider};
 use std::collections::BTreeMap;
@@ -104,8 +104,8 @@ impl DynamicStats {
   pub fn new(stats: &Scope, runtime: &bd_runtime::runtime::ConfigLoader) -> Self {
     let dynamic_stats_overflow = stats.scope("stats").counter("dynamic_stats_overflow");
 
-    let max_dynamic_stats: IntWatch<bd_runtime::runtime::stats::MaxDynamicCountersFlag> =
-      runtime.register_watch().unwrap();
+    let max_dynamic_stats =
+      bd_runtime::runtime::stats::MaxDynamicCountersFlag::register(runtime).unwrap();
     let dynamic_collector = BoundedCollector::new(Some(max_dynamic_stats.into_inner()));
     let dynamic_scope = dynamic_collector.scope("");
 

--- a/bd-events/src/lib.rs
+++ b/bd-events/src/lib.rs
@@ -51,7 +51,7 @@ impl Listener {
     target: Box<dyn ListenerTarget + Send + Sync>,
     runtime_loader: &Arc<ConfigLoader>,
   ) -> Self {
-    let is_enabled_flag: BoolWatch<ListenerEnabledFlag> = runtime_loader.register_watch().unwrap();
+    let is_enabled_flag = ListenerEnabledFlag::register(runtime_loader).unwrap();
 
     Self {
       target,

--- a/bd-resource-utilization/src/lib.rs
+++ b/bd-resource-utilization/src/lib.rs
@@ -52,10 +52,9 @@ pub struct Reporter {
 
 impl Reporter {
   pub fn new(target: Box<dyn Target + Send + Sync>, runtime_loader: &Arc<ConfigLoader>) -> Self {
-    let mut is_enabled_flag: BoolWatch<ResourceUtilizationEnabledFlag> =
-      runtime_loader.register_watch().unwrap();
-    let mut reporting_interval_flag: DurationWatch<ResourceUtilizationReportingIntervalFlag> =
-      runtime_loader.register_watch().unwrap();
+    let mut is_enabled_flag = ResourceUtilizationEnabledFlag::register(runtime_loader).unwrap();
+    let mut reporting_interval_flag =
+      ResourceUtilizationReportingIntervalFlag::register(runtime_loader).unwrap();
 
     let rate = reporting_interval_flag.read_mark_update();
 

--- a/bd-runtime/src/runtime.rs
+++ b/bd-runtime/src/runtime.rs
@@ -272,7 +272,7 @@ impl ConfigLoader {
     if let Some(existing_watch) = l.watches.get(C::path()) {
       return Ok(Watch {
         watch: existing_watch.typed_watch()?,
-        _type: PhantomData::<C> {},
+        _type: PhantomData,
       });
     }
 
@@ -286,7 +286,7 @@ impl ConfigLoader {
 
     Ok(Watch {
       watch: watch_rx,
-      _type: PhantomData::<C> {},
+      _type: PhantomData,
     })
   }
 
@@ -521,6 +521,15 @@ macro_rules! feature_flag {
   ($name:tt, $flag_type:ty, $path:literal, $default:expr) => {
     #[derive(Clone, Debug)]
     pub struct $name;
+
+    impl $name {
+      #[allow(unused)]
+      pub fn register(
+        loader: &$crate::runtime::ConfigLoader,
+      ) -> anyhow::Result<$crate::runtime::Watch<$flag_type, Self>> {
+        loader.register_watch()
+      }
+    }
 
     // Define the FeatureFlag trait, allowing us to embed the path and the default value into the
     // type.

--- a/bd-runtime/src/runtime.rs
+++ b/bd-runtime/src/runtime.rs
@@ -9,7 +9,7 @@
 #[path = "./runtime_test.rs"]
 mod runtime_test;
 
-use anyhow::Context as _;
+use anyhow::anyhow;
 use bd_client_common::error::handle_unexpected;
 use bd_proto::protos::client::api::RuntimeUpdate;
 use bd_proto::protos::client::runtime::runtime::Value;
@@ -176,7 +176,7 @@ impl ConfigLoader {
     // This could fail, but by being defensive when we read this we should ideally worst case just
     // fall back to not reading from cache.
     std::fs::write(&self.retry_count_file, format!("{retry_count}").as_bytes())
-      .context("failed to write retry count file")
+      .map_err(|e| anyhow!("an io error occurred: {e}"))
   }
 
   pub fn handle_cached_config(&self) {
@@ -220,7 +220,7 @@ impl ConfigLoader {
     // value. If we were to treat an empty file as count=0 we could theoretically find ourselves in
     // a loop where the file is not properly updated.
     let Ok(retry_count) = Self::parse_retry_count(
-      &std::fs::read(&self.retry_count_file).context("failed to read retry count file")?,
+      &std::fs::read(&self.retry_count_file).map_err(|e| anyhow!("an io error ocurred: {e}"))?,
     ) else {
       return Ok(true);
     };
@@ -243,7 +243,7 @@ impl ConfigLoader {
     // TODO(snowp): Add stats for how often the read fails beyond ENOENT.
     // TODO(snowp): When we add a callback, only trigger it if we successfully loaded the config.
     let runtime = RuntimeUpdate::parse_from_bytes(&std::fs::read(&self.protobuf_file)?)
-      .context("failed to parse runtime protobuf")?;
+      .map_err(|e| anyhow!("A protobuf error occurred: {e}"))?;
 
     self.update_snapshot_inner(&runtime);
 
@@ -406,7 +406,7 @@ impl<T: Copy, P: FeatureFlag<T>> Watch<T, P> {
       .watch
       .changed()
       .await
-      .context("failed to wait for runtime watch change")
+      .map_err(|_| anyhow!("runtime watch"))
   }
 
   /// Returns the inner watch, for use in code that can't depend on this crate.

--- a/bd-runtime/src/runtime_test.rs
+++ b/bd-runtime/src/runtime_test.rs
@@ -101,7 +101,7 @@ fn duration_flag() {
     "1".to_string(),
   ));
 
-  assert_eq!(flag.borrow().read(), time::Duration::milliseconds(5));
+  assert_eq!(flag.borrow().read(), time::Duration::milliseconds(100));
 }
 
 struct SetupDiskPersistence {

--- a/bd-runtime/src/runtime_test.rs
+++ b/bd-runtime/src/runtime_test.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::runtime::{BoolWatch, ConfigLoader, DurationWatch, FeatureFlag, IntWatch};
+use crate::runtime::{ConfigLoader, FeatureFlag, IntWatch};
 use crate::{bool_feature_flag, duration_feature_flag, int_feature_flag};
 use bd_test_helpers::runtime::{make_update, ValueKind};
 use bd_test_helpers::RecordingErrorReporter;
@@ -21,8 +21,8 @@ fn feature_flag_registration() {
   let sdk_directory = tempfile::TempDir::with_prefix("sdk").unwrap();
   let loader = ConfigLoader::new(sdk_directory.path());
 
-  let mut int_feature_flag = loader.register_watch::<u32, TestFlag>().unwrap();
-  let mut bool_feature_flag = loader.register_watch::<bool, BoolFlag>().unwrap();
+  let mut int_feature_flag = TestFlag::register(&loader).unwrap();
+  let mut bool_feature_flag = BoolFlag::register(&loader).unwrap();
 
   // Initially the value is the specified default.
   assert_eq!(int_feature_flag.read_mark_update(), 1);
@@ -62,7 +62,7 @@ fn registration_after_update() {
     "1".to_string(),
   ));
 
-  let feature_flag = loader.register_watch::<u32, TestFlag>().unwrap();
+  let feature_flag = TestFlag::register(&loader).unwrap();
 
   // The initial value of the watch should be 10.
   assert!(!feature_flag.watch.has_changed().unwrap());
@@ -77,8 +77,8 @@ fn incompatible_registration() {
   let sdk_directory = tempfile::TempDir::with_prefix("sdk").unwrap();
   let loader = ConfigLoader::new(sdk_directory.path());
 
-  let _int_feature_flag: IntWatch<IntTestFlag> = loader.register_watch().unwrap();
-  let bool_feature_flag: anyhow::Result<BoolWatch<BoolTestFlag>> = loader.register_watch();
+  let _int_feature_flag = IntTestFlag::register(&loader).unwrap();
+  let bool_feature_flag = BoolTestFlag::register(&loader);
   assert_eq!(
     bool_feature_flag.err().unwrap().to_string(),
     anyhow::anyhow!("Incompatible runtime subscription").to_string(),
@@ -92,7 +92,7 @@ fn duration_flag() {
   let sdk_directory = tempfile::TempDir::with_prefix("sdk").unwrap();
   let loader = ConfigLoader::new(sdk_directory.path());
 
-  let flag: DurationWatch<DurationFlag> = loader.register_watch().unwrap();
+  let flag = DurationFlag::register(&loader).unwrap();
 
   assert_eq!(flag.borrow().read(), time::Duration::seconds(5));
 
@@ -101,7 +101,7 @@ fn duration_flag() {
     "1".to_string(),
   ));
 
-  assert_eq!(flag.borrow().read(), time::Duration::milliseconds(100));
+  assert_eq!(flag.borrow().read(), time::Duration::milliseconds(5));
 }
 
 struct SetupDiskPersistence {
@@ -150,7 +150,7 @@ fn disk_persistence_happy_path() {
 
   loader.handle_cached_config();
 
-  let flag: IntWatch<TestFlag> = loader.register_watch().unwrap();
+  let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(flag.read(), 10);
   assert_eq!(loader.snapshot().nonce, Some("1".to_string()));
 }
@@ -181,7 +181,7 @@ fn disk_persistence_config_corruption() {
     "runtime cache load: A protobuf error occurred: Incorrect tag".to_string(),
     unexpected_error,
   );
-  let flag: IntWatch<TestFlag> = loader.register_watch().unwrap();
+  let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(flag.read(), 1);
   assert_eq!(loader.snapshot().nonce, None);
 }
@@ -207,7 +207,7 @@ fn disk_persistence_retry_corruption() {
   let loader = setup.new_loader();
   loader.handle_cached_config();
 
-  let flag: IntWatch<TestFlag> = loader.register_watch().unwrap();
+  let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(flag.read(), 1);
   assert_eq!(loader.snapshot().nonce, None);
 }
@@ -230,14 +230,14 @@ fn disk_persistence_retry_limit() {
   for _ in 0 .. 6 {
     let loader = setup.new_loader();
     loader.handle_cached_config();
-    let flag: IntWatch<TestFlag> = loader.register_watch().unwrap();
+    let flag = TestFlag::register(&loader).unwrap();
     assert_eq!(flag.read(), 10);
   }
 
   // On the 6th go we hit the limit and will treat it as an error, wiping all state.
   let loader = setup.new_loader();
   loader.handle_cached_config();
-  let flag: IntWatch<TestFlag> = loader.register_watch().unwrap();
+  let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(flag.read(), 1);
   assert!(!loader.protobuf_file.exists());
   assert!(!loader.retry_count_file.exists());
@@ -261,7 +261,7 @@ fn disk_persistence_retry_marked_safe() {
   for _ in 0 .. 6 {
     let loader = setup.new_loader();
     loader.handle_cached_config();
-    let flag: IntWatch<TestFlag> = loader.register_watch().unwrap();
+    let flag = TestFlag::register(&loader).unwrap();
     assert_eq!(flag.read(), 10);
 
     loader.mark_safe();
@@ -270,7 +270,7 @@ fn disk_persistence_retry_marked_safe() {
   // On the 6th we would have hit the limit but we've been marking the uploads as safe.
   let loader = setup.new_loader();
   loader.handle_cached_config();
-  let flag: IntWatch<TestFlag> = loader.register_watch().unwrap();
+  let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(flag.read(), 10);
   assert_eq!(std::fs::read(&setup.retry_file).unwrap(), b"1");
 }
@@ -298,7 +298,7 @@ fn disk_persistence_missing_config_file() {
   // falling back to the default.
   let loader = setup.new_loader();
   loader.handle_cached_config();
-  let flag: IntWatch<TestFlag> = loader.register_watch().unwrap();
+  let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(flag.read(), 1);
 
   assert!(!setup.retry_file.exists());
@@ -327,7 +327,7 @@ fn disk_persistence_missing_retry_file() {
   // falling back to the default.
   let loader = setup.new_loader();
   loader.handle_cached_config();
-  let flag: IntWatch<TestFlag> = loader.register_watch().unwrap();
+  let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(flag.read(), 1);
 
   assert!(!setup.protobuf_file.exists());
@@ -361,7 +361,7 @@ fn disk_persistence_cannot_update_retry() {
     "runtime cache load: an io error occurred: Permission denied (os error 13)",
     error
   );
-  let flag: IntWatch<TestFlag> = loader.register_watch().unwrap();
+  let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(flag.read(), 1);
 
   assert!(!setup.protobuf_file.exists());

--- a/bd-runtime/src/runtime_test.rs
+++ b/bd-runtime/src/runtime_test.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::runtime::{ConfigLoader, FeatureFlag, IntWatch};
+use crate::runtime::{ConfigLoader, FeatureFlag};
 use crate::{bool_feature_flag, duration_feature_flag, int_feature_flag};
 use bd_test_helpers::runtime::{make_update, ValueKind};
 use bd_test_helpers::RecordingErrorReporter;

--- a/bd-workflows/src/engine.rs
+++ b/bd-workflows/src/engine.rs
@@ -33,7 +33,7 @@ use bd_runtime::runtime::workflows::{
   TraversalsCountLimitFlag,
   WorkflowsInsightsEnabledFlag,
 };
-use bd_runtime::runtime::{BoolWatch, ConfigLoader, DurationWatch, IntWatch};
+use bd_runtime::runtime::{BoolWatch, ConfigLoader, DurationWatch};
 use bd_stats_common::labels;
 use bd_time::TimeDurationExt as _;
 use serde::{Deserialize, Serialize};
@@ -98,10 +98,9 @@ impl WorkflowsEngine {
   ) -> (Self, Receiver<BuffersToFlush>) {
     let scope = stats.scope("workflows");
 
-    let traversals_count_limit_flag: IntWatch<TraversalsCountLimitFlag> =
-      runtime.register_watch().unwrap();
-    let state_periodic_write_interval_flag: DurationWatch<StatePeriodicWriteIntervalFlag> =
-      runtime.register_watch().unwrap();
+    let traversals_count_limit_flag = TraversalsCountLimitFlag::register(runtime).unwrap();
+    let state_periodic_write_interval_flag =
+      StatePeriodicWriteIntervalFlag::register(runtime).unwrap();
     let mut insights_enabled_flag = runtime.register_watch().unwrap();
 
     let insights_enabled = insights_enabled_flag.read_mark_update();


### PR DESCRIPTION
By having an associated function generated per flag type we are able to avoid having to rely on type inference when creating standalone watches. This avoids repetitive type declaration when the type would have to otherwise be explicitly specified

Also same a few allocations by storing &'static str in the watch map instead of String