### PR TITLE
further gRPC memory refinement

### DIFF
--- a/bd-api/src/api.rs
+++ b/bd-api/src/api.rs
@@ -31,6 +31,7 @@ use bd_client_stats_store::{Counter, CounterWrapper, Scope};
 use bd_grpc_codec::{
   Compression,
   Encoder,
+  OptimizeFor,
   DEFAULT_MOBILE_ZLIB_COMPRESSION_LEVEL,
   GRPC_ACCEPT_ENCODING_HEADER,
   GRPC_ENCODING_DEFLATE,
@@ -147,8 +148,10 @@ impl StreamState {
     // currently we are not passing the response headers back to Rust. Given that we currently
     // have prior knowledge of what the server will do this is OK but we should fix this in the
     // future.
-    let mut decoder =
-      bd_grpc_codec::Decoder::new(Some(bd_grpc_codec::Decompression::StatelessZlib));
+    let mut decoder = bd_grpc_codec::Decoder::new(
+      Some(bd_grpc_codec::Decompression::StatelessZlib),
+      OptimizeFor::Cpu,
+    );
     decoder.initialize_stats(
       CounterWrapper::make_dyn(stats.rx_bytes.clone()),
       CounterWrapper::make_dyn(stats.rx_bytes_decompressed.clone()),

--- a/bd-api/src/api_test.rs
+++ b/bd-api/src/api_test.rs
@@ -13,7 +13,7 @@ use anyhow::anyhow;
 use assert_matches::assert_matches;
 use bd_client_stats_store::test::StatsHelper;
 use bd_client_stats_store::Collector;
-use bd_grpc_codec::Encoder;
+use bd_grpc_codec::{Encoder, OptimizeFor};
 use bd_internal_logging::{LogFields, LogLevel, LogType};
 use bd_metadata::{Metadata, Platform};
 use bd_proto::protos::client::api::api_request::Request_type;
@@ -180,7 +180,7 @@ impl Setup {
       shutdown_trigger,
       collector,
       time_provider,
-      requests_decoder: bd_grpc_codec::Decoder::new(None),
+      requests_decoder: bd_grpc_codec::Decoder::new(None, OptimizeFor::Memory),
     }
   }
 

--- a/bd-grpc/src/grpc_test.rs
+++ b/bd-grpc/src/grpc_test.rs
@@ -24,6 +24,7 @@ use crate::{
 use assert_matches::assert_matches;
 use async_trait::async_trait;
 use bd_grpc_codec::stats::DeferredCounter;
+use bd_grpc_codec::OptimizeFor;
 use bd_server_stats::stats::CounterWrapper;
 use bd_server_stats::test::util::stats::{self, Helper};
 use bd_time::TimeDurationExt;
@@ -248,6 +249,7 @@ async fn server_streaming() {
       None,
       EchoRequest::default(),
       false,
+      OptimizeFor::Memory,
     )
     .await
     .unwrap();
@@ -300,6 +302,7 @@ async fn server_streaming_error_handler() {
       None,
       EchoRequest::default(),
       false,
+      OptimizeFor::Cpu,
     )
     .await
     .unwrap();

--- a/bd-test-helpers/src/test_api_server.rs
+++ b/bd-test-helpers/src/test_api_server.rs
@@ -11,7 +11,7 @@ use axum::routing::post;
 use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
 use bd_grpc::finalize_response_compression;
-use bd_grpc_codec::Compression;
+use bd_grpc_codec::{Compression, OptimizeFor};
 use bd_proto::protos::client::api::api_request::Request_type;
 use bd_proto::protos::client::api::api_response::Response_type;
 use bd_proto::protos::client::api::configuration_update::{StateOfTheWorld, Update_type};
@@ -302,8 +302,14 @@ async fn mux(
     Some(Compression::StatelessZlib { level: 3 }),
     &request_parts.headers,
   );
-  let mut api =
-    bd_grpc::StreamingApi::new(tx, request_parts.headers, request_body, true, compression);
+  let mut api = bd_grpc::StreamingApi::new(
+    tx,
+    request_parts.headers,
+    request_body,
+    true,
+    compression,
+    OptimizeFor::Memory,
+  );
 
   // Allocate a new id for the new stream + notify consumers about the creation.
   let stream_id = stream_state


### PR DESCRIPTION
BytesMut will hold onto capacity when split() which is not what we want for long lived streams. Use Vec to avoid this. Additionally switch the stateless codecs to use Vec as the capacity will almost always have to get reallocated anyway. Finally, optionally allow the decoding buffer to be fully released if empty.