### PR TITLE
api: add the ability to remotely shutoff clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -149,9 +149,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f43644eed690f5374f1af436ecd6aea01cd201f6fbdf0178adaf6907afb2cec"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6b8ba012a258d63c9adfa28b9ddcf66149da6f986c5b5452e629d5ee64bf00"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1098,9 +1098,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
 dependencies = [
  "jobserver",
  "libc",
@@ -1469,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
@@ -1823,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1836,7 +1836,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -2001,9 +2000,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2607,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2770,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -3014,9 +3013,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3037,9 +3036,9 @@ checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -3240,9 +3239,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.5.0",
  "toml_datetime",
@@ -3259,7 +3258,6 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
- "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3732,9 +3730,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "bd-metadata",
  "bd-proto",
  "flatbuffers",
+ "flate2",
  "log",
  "parking_lot",
  "protobuf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ anyhow          = "1.0.89"
 arbitrary       = { version = "1.3.2", features = ["derive"] }
 arc-swap        = "1.7.1"
 assert_matches  = "1.5.0"
-async-trait     = "0.1.82"
-axum            = { version = "0.7.6", features = ["http2"] }
+async-trait     = "0.1.83"
+axum            = { version = "0.7.7", features = ["http2"] }
 axum-server     = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
 backoff         = "0.4.0"
 base64          = "0.22.1"
@@ -62,7 +62,7 @@ ctor            = "0.2.8"
 dashmap         = "6.1.0"
 flatbuffers     = "24.3.25"
 flatc-rust      = "0.2.0"
-flate2          = { version = "1.0.33", default-features = false }
+flate2          = { version = "1.0.34", default-features = false }
 fs2             = "0.4.3"
 futures         = "0.3.30"
 futures-core    = "0.3.30"
@@ -78,7 +78,7 @@ hyper-rustls = { version = "0.27.3", default-features = false, features = [
   "webpki-tokio",
 ] }
 
-hyper-util            = { version = "0.1.8", features = ["client", "client-legacy"] }
+hyper-util            = { version = "0.1.9", features = ["client", "client-legacy"] }
 intrusive-collections = "0.9.7"
 itertools             = "0.13.0"
 jni                   = "0.21.1"
@@ -115,7 +115,7 @@ sketches-rust = { git = "https://github.com/mattklein123/sketches-rust.git", bra
 
 snap              = "1.1.1"
 static_assertions = "1.1.0"
-tempfile          = "3.12.0"
+tempfile          = "3.13.0"
 thiserror         = "1.0.64"
 tikv-jemalloc-ctl = "0.6.0"
 time              = { version = "0.3.36", features = ["serde-well-known", "macros"] }

--- a/bd-api/Cargo.toml
+++ b/bd-api/Cargo.toml
@@ -29,7 +29,9 @@ uuid.workspace             = true
 
 [dev-dependencies]
 assert_matches.workspace = true
-bd-stats-common.path     = "../bd-stats-common"
-bd-test-helpers          = { path = "../bd-test-helpers", default-features = false }
-ctor.workspace           = true
-tempfile.workspace       = true
+bd-stats-common.path = "../bd-stats-common"
+bd-test-helpers = { path = "../bd-test-helpers", default-features = false, features = [
+  "test_logger",
+] }
+ctor.workspace = true
+tempfile.workspace = true

--- a/bd-api/src/api.rs
+++ b/bd-api/src/api.rs
@@ -450,15 +450,16 @@ impl Api {
           kill_until_time - self.time_provider.now()
         );
         log::warn!(
-          "Attention: The SDK has been force disabled due to either a previous authentication \
-           failure or a remote server configuration. Double check your API key or contact support."
+          "Attention: The Capture SDK has been force disabled due to either a previous \
+           authentication failure or a remote server configuration. Double check your API key or \
+           contact support."
         );
         self.client_killed = true;
       } else {
-        // Delete the kill file if the kill duration has passed. This will allow the client to
-        // come up and contact the server again to see if anything has changed. It will likely get
-        // killed again on the next startup.
-        log::debug!("kill file has expired, removing");
+        // Delete the kill file if the kill duration has passed or the API key has changed. This
+        // will allow the client to come up and contact the server again to see if anything
+        // has changed. It will likely get killed again on the next startup.
+        log::debug!("kill file has expired or the API key has changed, removing");
         if let Err(e) = tokio::fs::remove_file(self.kill_file_path()).await {
           log::warn!("failed to remove kill file: {}", e);
         }

--- a/bd-client-common/Cargo.toml
+++ b/bd-client-common/Cargo.toml
@@ -13,6 +13,7 @@ bd-matcher.path            = "../bd-matcher"
 bd-metadata.path           = "../bd-metadata"
 bd-proto.path              = "../bd-proto"
 flatbuffers.workspace      = true
+flate2                     = { workspace = true, default-features = false, features = ["zlib"] }
 log.workspace              = true
 parking_lot.workspace      = true
 protobuf.workspace         = true

--- a/bd-client-common/src/file.rs
+++ b/bd-client-common/src/file.rs
@@ -1,0 +1,41 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use crate::zlib::DEFAULT_MOBILE_ZLIB_COMPRESSION_LEVEL;
+use flate2::read::{ZlibDecoder, ZlibEncoder};
+use flate2::Compression;
+use std::io::Read;
+
+pub fn write_compressed_protobuf<T: protobuf::Message>(message: &T) -> Vec<u8> {
+  let bytes = message.write_to_bytes().unwrap();
+  let mut encoder = ZlibEncoder::new(
+    &bytes[..],
+    Compression::new(DEFAULT_MOBILE_ZLIB_COMPRESSION_LEVEL),
+  );
+  let mut compressed_bytes = Vec::new();
+  encoder.read_to_end(&mut compressed_bytes).unwrap();
+  compressed_bytes
+}
+
+pub fn read_compressed_protobuf<T: protobuf::Message>(
+  compressed_bytes: &[u8],
+) -> anyhow::Result<T> {
+  // We should never write empty files. If there is no data this was a partial write, full disk
+  // issue, or some other problem. We use zlib for compression which includes a CRC at the end
+  // so as long as the file is not empty we can be sure that the data is not corrupted.
+  if compressed_bytes.is_empty() {
+    anyhow::bail!("unexpected empty file");
+  }
+
+  // The files are likely not large enough to deal with streaming decompression on top of flate2.
+  // For now we just read the entire thing and then decompress it in memory. We can consider
+  // streaming later.
+  let mut decoder = ZlibDecoder::new(compressed_bytes);
+  // In the future if/when we switch to using Bytes/Chars in the compiled proto it may be more
+  // efficient to read out the uncompressed into Bytes and then parse from that.
+  Ok(T::parse_from_reader(&mut decoder)?)
+}

--- a/bd-client-common/src/lib.rs
+++ b/bd-client-common/src/lib.rs
@@ -10,6 +10,8 @@ use std::future::Future;
 
 pub mod error;
 pub mod fb;
+pub mod file;
+pub mod zlib;
 
 pub fn spawn_error_handling_task<E: std::error::Error + Sync + Send + 'static>(
   f: impl Future<Output = std::result::Result<(), E>> + Send + 'static,

--- a/bd-client-common/src/zlib.rs
+++ b/bd-client-common/src/zlib.rs
@@ -1,0 +1,12 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+// zlib has 10 compression levels (0-9). We use level 5 as this is what Apple says about
+// this particular compression level: "This compression level provides a good balance
+// between compression speed and compression ratio.".
+// Source: https://developer.apple.com/documentation/compression/algorithm/zlib
+pub const DEFAULT_MOBILE_ZLIB_COMPRESSION_LEVEL: u32 = 5;

--- a/bd-client-stats/Cargo.toml
+++ b/bd-client-stats/Cargo.toml
@@ -18,7 +18,6 @@ bd-runtime.path            = "../bd-runtime"
 bd-shutdown.path           = "../bd-shutdown"
 bd-stats-common.path       = "../bd-stats-common"
 bd-time.path               = "../bd-time"
-flate2                     = { workspace = true, default-features = false, features = ["zlib"] }
 log.workspace              = true
 parking_lot.workspace      = true
 protobuf.workspace         = true
@@ -31,5 +30,6 @@ bd-log.path              = "../bd-log"
 bd-stats-common.path     = "../bd-stats-common"
 bd-test-helpers.path     = "../bd-test-helpers"
 ctor.workspace           = true
+flate2                   = { workspace = true, default-features = false, features = ["zlib"] }
 futures-util.workspace   = true
 tempfile.workspace       = true

--- a/bd-grpc-codec/src/coding_test.rs
+++ b/bd-grpc-codec/src/coding_test.rs
@@ -5,14 +5,8 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::{
-  Compression,
-  Decoder,
-  Decompression,
-  Encoder,
-  OptimizeFor,
-  DEFAULT_MOBILE_ZLIB_COMPRESSION_LEVEL,
-};
+use crate::{Compression, Decoder, Decompression, Encoder, OptimizeFor};
+use bd_client_common::zlib::DEFAULT_MOBILE_ZLIB_COMPRESSION_LEVEL;
 use protobuf::well_known_types::any::Any;
 use protobuf::well_known_types::struct_::{Struct, Value};
 use rstest::rstest;

--- a/bd-grpc-codec/src/lib.rs
+++ b/bd-grpc-codec/src/lib.rs
@@ -59,11 +59,6 @@ const GRPC_MESSAGE_PREFIX_LEN: usize = 5;
 // compressable. Used to avoid compression of small messages whose compressed
 // version is often greater in size than orginal.
 const GRPC_MIN_MESSAGE_SIZE_COMPRESSION_THRESHOLD: usize = 100;
-// zlib has 10 compression levels (0-9). We use level 5 as this is what Apple says about
-// this particular compression level: "This compression level provides a good balance
-// between compression speed and compression ratio.".
-// Source: https://developer.apple.com/documentation/compression/algorithm/zlib
-pub const DEFAULT_MOBILE_ZLIB_COMPRESSION_LEVEL: u32 = 5;
 
 pub const LEGACY_GRPC_ENCODING_HEADER: &str = "x-grpc-encoding";
 pub const GRPC_ENCODING_HEADER: &str = "grpc-encoding";

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -215,6 +215,7 @@ impl LoggerBuilder {
     )?);
 
     let api = bd_api::api::Api::new(
+      self.params.sdk_directory,
       self.params.api_key,
       self.params.network,
       shutdown_handle.make_shutdown(),

--- a/bd-proto/src/protos/client/api.rs
+++ b/bd-proto/src/protos/client/api.rs
@@ -31,6 +31,147 @@
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_4_0_0_ALPHA_0;
 
+// @@protoc_insertion_point(message:bitdrift_public.protobuf.client.v1.ClientKillFile)
+#[derive(PartialEq,Clone,Default,Debug)]
+pub struct ClientKillFile {
+    // message fields
+    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.ClientKillFile.api_key_hash)
+    pub api_key_hash: ::std::vec::Vec<u8>,
+    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.ClientKillFile.kill_until)
+    pub kill_until: ::protobuf::MessageField<::protobuf::well_known_types::timestamp::Timestamp>,
+    // special fields
+    // @@protoc_insertion_point(special_field:bitdrift_public.protobuf.client.v1.ClientKillFile.special_fields)
+    pub special_fields: ::protobuf::SpecialFields,
+}
+
+impl<'a> ::std::default::Default for &'a ClientKillFile {
+    fn default() -> &'a ClientKillFile {
+        <ClientKillFile as ::protobuf::Message>::default_instance()
+    }
+}
+
+impl ClientKillFile {
+    pub fn new() -> ClientKillFile {
+        ::std::default::Default::default()
+    }
+
+    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
+        let mut fields = ::std::vec::Vec::with_capacity(2);
+        let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "api_key_hash",
+            |m: &ClientKillFile| { &m.api_key_hash },
+            |m: &mut ClientKillFile| { &mut m.api_key_hash },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, ::protobuf::well_known_types::timestamp::Timestamp>(
+            "kill_until",
+            |m: &ClientKillFile| { &m.kill_until },
+            |m: &mut ClientKillFile| { &mut m.kill_until },
+        ));
+        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<ClientKillFile>(
+            "ClientKillFile",
+            fields,
+            oneofs,
+        )
+    }
+}
+
+impl ::protobuf::Message for ClientKillFile {
+    const NAME: &'static str = "ClientKillFile";
+
+    fn is_initialized(&self) -> bool {
+        true
+    }
+
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
+        while let Some(tag) = is.read_raw_tag_or_eof()? {
+            match tag {
+                10 => {
+                    self.api_key_hash = is.read_bytes()?;
+                },
+                18 => {
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.kill_until)?;
+                },
+                tag => {
+                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
+                },
+            };
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    // Compute sizes of nested messages
+    #[allow(unused_variables)]
+    fn compute_size(&self) -> u64 {
+        let mut my_size = 0;
+        if !self.api_key_hash.is_empty() {
+            my_size += ::protobuf::rt::bytes_size(1, &self.api_key_hash);
+        }
+        if let Some(v) = self.kill_until.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+        }
+        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
+        self.special_fields.cached_size().set(my_size as u32);
+        my_size
+    }
+
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if !self.api_key_hash.is_empty() {
+            os.write_bytes(1, &self.api_key_hash)?;
+        }
+        if let Some(v) = self.kill_until.as_ref() {
+            ::protobuf::rt::write_message_field_with_cached_size(2, v, os)?;
+        }
+        os.write_unknown_fields(self.special_fields.unknown_fields())?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn special_fields(&self) -> &::protobuf::SpecialFields {
+        &self.special_fields
+    }
+
+    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
+        &mut self.special_fields
+    }
+
+    fn new() -> ClientKillFile {
+        ClientKillFile::new()
+    }
+
+    fn clear(&mut self) {
+        self.api_key_hash.clear();
+        self.kill_until.clear();
+        self.special_fields.clear();
+    }
+
+    fn default_instance() -> &'static ClientKillFile {
+        static instance: ClientKillFile = ClientKillFile {
+            api_key_hash: ::std::vec::Vec::new(),
+            kill_until: ::protobuf::MessageField::none(),
+            special_fields: ::protobuf::SpecialFields::new(),
+        };
+        &instance
+    }
+}
+
+impl ::protobuf::MessageFull for ClientKillFile {
+    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
+        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
+        descriptor.get(|| file_descriptor().message_by_package_relative_name("ClientKillFile").unwrap()).clone()
+    }
+}
+
+impl ::std::fmt::Display for ClientKillFile {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        ::protobuf::text_format::fmt(self, f)
+    }
+}
+
+impl ::protobuf::reflect::ProtobufValue for ClientKillFile {
+    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
+}
+
 // @@protoc_insertion_point(message:bitdrift_public.protobuf.client.v1.HandshakeRequest)
 #[derive(PartialEq,Clone,Default,Debug)]
 pub struct HandshakeRequest {
@@ -6142,134 +6283,136 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     tobuf/workflow/v1/workflow.proto\x1a6bitdrift_public/protobuf/bdtail/v1/\
     bdtail_config.proto\x1a/bitdrift_public/protobuf/config/v1/config.proto\
     \x1a1bitdrift_public/protobuf/logging/v1/payload.proto\x1a\x17validate/v\
-    alidate.proto\"\xe8\x04\n\x10HandshakeRequest\x12\x84\x01\n\x16static_de\
-    vice_metadata\x18\x01\x20\x03(\x0b2N.bitdrift_public.protobuf.client.v1.\
-    HandshakeRequest.StaticDeviceMetadataEntryR\x14staticDeviceMetadata\x12>\
-    \n\x1bconfiguration_version_nonce\x18\x03\x20\x01(\tR\x19configurationVe\
-    rsionNonce\x122\n\x15runtime_version_nonce\x18\x04\x20\x01(\tR\x13runtim\
-    eVersionNonce\x12\x81\x01\n\x15opqaue_version_nonces\x18\x05\x20\x03(\
-    \x0b2M.bitdrift_public.protobuf.client.v1.HandshakeRequest.OpqaueVersion\
-    NoncesEntryR\x13opqaueVersionNonces\x1ar\n\x19StaticDeviceMetadataEntry\
-    \x12\x10\n\x03key\x18\x01\x20\x01(\tR\x03key\x12?\n\x05value\x18\x02\x20\
-    \x01(\x0b2).bitdrift_public.protobuf.logging.v1.DataR\x05value:\x028\x01\
-    \x1aF\n\x18OpqaueVersionNoncesEntry\x12\x10\n\x03key\x18\x01\x20\x01(\tR\
-    \x03key\x12\x14\n\x05value\x18\x02\x20\x01(\tR\x05value:\x028\x01J\x04\
-    \x08\x02\x10\x03R\x13fields_for_all_logs\"|\n\x19OpaqueConfigurationUpda\
-    te\x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNonce\x12:\n\rcon\
-    figuration\x18\x02\x20\x01(\x0b2\x14.google.protobuf.AnyR\rconfiguration\
-    \"\x87\x01\n\x1cOpaqueConfigurationUpdateAck\x12\x19\n\x08type_url\x18\
-    \x01\x20\x01(\tR\x07typeUrl\x12L\n\x03ack\x18\x02\x20\x01(\x0b2:.bitdrif\
-    t_public.protobuf.client.v1.ConfigurationUpdateAckR\x03ack\"\xf3\x02\n\
-    \x16LogUploadIntentRequest\x12\x1b\n\tlog_count\x18\x01\x20\x01(\rR\x08l\
-    ogCount\x12\x1d\n\nbyte_count\x18\x02\x20\x01(\rR\tbyteCount\x12\x1b\n\t\
-    buffer_id\x18\x03\x20\x01(\tR\x08bufferId\x12\x1f\n\x0bintent_uuid\x18\
-    \x04\x20\x01(\tR\nintentUuid\x12\x87\x01\n\x16workflow_action_upload\x18\
-    \x05\x20\x01(\x0b2O.bitdrift_public.protobuf.client.v1.LogUploadIntentRe\
-    quest.WorkflowActionUploadH\0R\x14workflowActionUpload\x1aF\n\x14Workflo\
-    wActionUpload\x12.\n\x13workflow_action_ids\x18\x01\x20\x03(\tR\x11workf\
-    lowActionIdsB\r\n\x0bintent_type\"\xbb\x02\n\x17LogUploadIntentResponse\
-    \x12\x1f\n\x0bintent_uuid\x18\x01\x20\x01(\tR\nintentUuid\x12~\n\x12uplo\
-    ad_immediately\x18\x02\x20\x01(\x0b2M.bitdrift_public.protobuf.client.v1\
-    .LogUploadIntentResponse.UploadImmediatelyH\0R\x11uploadImmediately\x12V\
-    \n\x04drop\x18\x03\x20\x01(\x0b2@.bitdrift_public.protobuf.client.v1.Log\
-    UploadIntentResponse.DropH\0R\x04drop\x1a\x13\n\x11UploadImmediately\x1a\
-    \x06\n\x04DropB\n\n\x08decision\"\x84\x01\n\x10LogUploadRequest\x12(\n\
-    \x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\
-    \x01\x12\x1c\n\x04logs\x18\x02\x20\x03(\x0cR\x04logsB\x08\xfaB\x05\x92\
-    \x01\x02\x08\x01\x12(\n\x0bbuffer_uuid\x18\x03\x20\x01(\tR\nbufferUuidB\
-    \x07\xfaB\x04r\x02\x10\x01\"\r\n\x0bPingRequest\"\xfc\x01\n\x16Configura\
-    tionUpdateAck\x12;\n\x1alast_applied_version_nonce\x18\x01\x20\x01(\tR\
-    \x17lastAppliedVersionNonce\x12S\n\x04nack\x18\x02\x20\x01(\x0b2?.bitdri\
-    ft_public.protobuf.client.v1.ConfigurationUpdateAck.NackR\x04nack\x1aP\n\
-    \x04Nack\x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNonce\x12#\
-    \n\rerror_details\x18\x02\x20\x01(\tR\x0cerrorDetails\"\xa6\x07\n\nApiRe\
-    quest\x12T\n\thandshake\x18\x01\x20\x01(\x0b24.bitdrift_public.protobuf.\
-    client.v1.HandshakeRequestH\0R\thandshake\x12h\n\x11log_upload_intent\
-    \x18\x07\x20\x01(\x0b2:.bitdrift_public.protobuf.client.v1.LogUploadInte\
-    ntRequestH\0R\x0flogUploadIntent\x12U\n\nlog_upload\x18\x02\x20\x01(\x0b\
-    24.bitdrift_public.protobuf.client.v1.LogUploadRequestH\0R\tlogUpload\
-    \x12[\n\x0cstats_upload\x18\x06\x20\x01(\x0b26.bitdrift_public.protobuf.\
-    client.v1.StatsUploadRequestH\0R\x0bstatsUpload\x12E\n\x04ping\x18\x03\
-    \x20\x01(\x0b2/.bitdrift_public.protobuf.client.v1.PingRequestH\0R\x04pi\
-    ng\x12v\n\x18configuration_update_ack\x18\x04\x20\x01(\x0b2:.bitdrift_pu\
-    blic.protobuf.client.v1.ConfigurationUpdateAckH\0R\x16configurationUpdat\
-    eAck\x12j\n\x12runtime_update_ack\x18\x05\x20\x01(\x0b2:.bitdrift_public\
-    .protobuf.client.v1.ConfigurationUpdateAckH\0R\x10runtimeUpdateAck\x12\
-    \x89\x01\n\x1fopaque_configuration_update_ack\x18\x08\x20\x01(\x0b2@.bit\
-    drift_public.protobuf.client.v1.OpaqueConfigurationUpdateAckH\0R\x1copaq\
-    ueConfigurationUpdateAck\x12X\n\ropaque_upload\x18\t\x20\x01(\x0b21.bitd\
-    rift_public.protobuf.client.v1.OpaqueRequestH\0R\x0copaqueUploadB\x13\n\
-    \x0crequest_type\x12\x03\xf8B\x01\"\xd4\x01\n\x11HandshakeResponse\x12m\
-    \n\x0fstream_settings\x18\x01\x20\x01(\x0b2D.bitdrift_public.protobuf.cl\
-    ient.v1.HandshakeResponse.StreamSettingsR\x0estreamSettings\x1aP\n\x0eSt\
-    reamSettings\x12>\n\rping_interval\x18\x01\x20\x01(\x0b2\x19.google.prot\
-    obuf.DurationR\x0cpingInterval\"\r\n\x0bRateLimited\"\xca\x01\n\x11LogUp\
-    loadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\
-    \xfaB\x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05error\
-    \x12!\n\x0clogs_dropped\x18\x03\x20\x01(\rR\x0blogsDropped\x12R\n\x0crat\
-    e_limited\x18\x04\x20\x01(\x0b2/.bitdrift_public.protobuf.client.v1.Rate\
-    LimitedR\x0brateLimited\"\xa3\x04\n\x12StatsUploadRequest\x12(\n\x0buplo\
-    ad_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12e\
-    \n\x08snapshot\x18\x02\x20\x03(\x0b2?.bitdrift_public.protobuf.client.v1\
-    .StatsUploadRequest.SnapshotR\x08snapshotB\x08\xfaB\x05\x92\x01\x02\x08\
-    \x01\x123\n\x07sent_at\x18\x03\x20\x01(\x0b2\x1a.google.protobuf.Timesta\
-    mpR\x06sentAt\x1a\xc6\x02\n\x08Snapshot\x12K\n\x07metrics\x18\x01\x20\
-    \x01(\x0b2/.bitdrift_public.protobuf.client.v1.MetricsListH\0R\x07metric\
-    s\x12l\n\naggregated\x18\x02\x20\x01(\x0b2J.bitdrift_public.protobuf.cli\
-    ent.v1.StatsUploadRequest.Snapshot.AggregatedH\x01R\naggregated\x1aU\n\n\
-    Aggregated\x12G\n\x0cperiod_start\x18\x04\x20\x01(\x0b2\x1a.google.proto\
-    buf.TimestampR\x0bperiodStartB\x08\xfaB\x05\x8a\x01\x02\x10\x01B\x14\n\r\
-    snapshot_type\x12\x03\xf8B\x01B\x12\n\x0boccurred_at\x12\x03\xf8B\x01\"~\
-    \n\x13StatsUploadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nupl\
-    oadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\t\
-    R\x05error\x12'\n\x0fmetrics_dropped\x18\x03\x20\x01(\rR\x0emetricsDropp\
-    ed\"]\n\rOpaqueRequest\x12\x12\n\x04uuid\x18\x01\x20\x01(\tR\x04uuid\x12\
-    8\n\x07request\x18\x02\x20\x01(\x0b2\x14.google.protobuf.AnyR\x07request\
-    B\x08\xfaB\x05\x8a\x01\x02\x10\x01\"R\n\x0eOpaqueResponse\x12\x1b\n\x04u\
-    uid\x18\x01\x20\x01(\tR\x04uuidB\x07\xfaB\x04r\x02\x10\x01\x12\x19\n\x05\
-    error\x18\x02\x20\x01(\tH\0R\x05error\x88\x01\x01B\x08\n\x06_error\"\x0e\
-    \n\x0cPongResponse\"\x8f\x06\n\x13ConfigurationUpdate\x12#\n\rversion_no\
-    nce\x18\x01\x20\x01(\tR\x0cversionNonce\x12v\n\x12state_of_the_world\x18\
-    \x02\x20\x01(\x0b2G.bitdrift_public.protobuf.client.v1.ConfigurationUpda\
-    te.StateOfTheWorldH\0R\x0fstateOfTheWorld\x1a\xcb\x04\n\x0fStateOfTheWor\
-    ld\x12b\n\x12buffer_config_list\x18\x03\x20\x01(\x0b24.bitdrift_public.p\
-    rotobuf.config.v1.BufferConfigListR\x10bufferConfigList\x12u\n\x17workfl\
-    ows_configuration\x18\x04\x20\x01(\x0b2<.bitdrift_public.protobuf.workfl\
-    ow.v1.WorkflowsConfigurationR\x16workflowsConfiguration\x12k\n\x14bdtail\
-    _configuration\x18\x06\x20\x01(\x0b28.bitdrift_public.protobuf.bdtail.v1\
-    .BdTailConfigurationsR\x13bdtailConfiguration\x12q\n\x16insights_configu\
-    ration\x18\x07\x20\x01(\x0b2:.bitdrift_public.protobuf.insight.v1.Insigh\
-    tsConfigurationR\x15insightsConfiguration\x12m\n\x15filters_configuratio\
-    n\x18\x08\x20\x01(\x0b28.bitdrift_public.protobuf.filter.v1.FiltersConfi\
-    gurationR\x14filtersConfigurationJ\x04\x08\x02\x10\x03R\x08mll_listB\r\n\
-    \x0bupdate_type\"{\n\rRuntimeUpdate\x12#\n\rversion_nonce\x18\x01\x20\
-    \x01(\tR\x0cversionNonce\x12E\n\x07runtime\x18\x02\x20\x01(\x0b2+.bitdri\
-    ft_public.protobuf.client.v1.RuntimeR\x07runtime\"S\n\rErrorShutdown\x12\
-    \x1f\n\x0bgrpc_status\x18\x01\x20\x01(\x05R\ngrpcStatus\x12!\n\x0cgrpc_m\
-    essage\x18\x02\x20\x01(\tR\x0bgrpcMessage\"4\n\x0cFlushBuffers\x12$\n\
-    \x0ebuffer_id_list\x18\x01\x20\x03(\tR\x0cbufferIdList\"\xbe\x08\n\x0bAp\
-    iResponse\x12U\n\thandshake\x18\x01\x20\x01(\x0b25.bitdrift_public.proto\
-    buf.client.v1.HandshakeResponseH\0R\thandshake\x12V\n\nlog_upload\x18\
-    \x02\x20\x01(\x0b25.bitdrift_public.protobuf.client.v1.LogUploadResponse\
-    H\0R\tlogUpload\x12i\n\x11log_upload_intent\x18\x08\x20\x01(\x0b2;.bitdr\
-    ift_public.protobuf.client.v1.LogUploadIntentResponseH\0R\x0flogUploadIn\
-    tent\x12\\\n\x0cstats_upload\x18\x07\x20\x01(\x0b27.bitdrift_public.prot\
-    obuf.client.v1.StatsUploadResponseH\0R\x0bstatsUpload\x12F\n\x04pong\x18\
-    \x03\x20\x01(\x0b20.bitdrift_public.protobuf.client.v1.PongResponseH\0R\
-    \x04pong\x12l\n\x14configuration_update\x18\x04\x20\x01(\x0b27.bitdrift_\
-    public.protobuf.client.v1.ConfigurationUpdateH\0R\x13configurationUpdate\
-    \x12Z\n\x0eruntime_update\x18\x05\x20\x01(\x0b21.bitdrift_public.protobu\
-    f.client.v1.RuntimeUpdateH\0R\rruntimeUpdate\x12Z\n\x0eerror_shutdown\
-    \x18\x06\x20\x01(\x0b21.bitdrift_public.protobuf.client.v1.ErrorShutdown\
-    H\0R\rerrorShutdown\x12W\n\rflush_buffers\x18\t\x20\x01(\x0b20.bitdrift_\
-    public.protobuf.client.v1.FlushBuffersH\0R\x0cflushBuffers\x12\x7f\n\x1b\
-    opaque_configuration_update\x18\n\x20\x01(\x0b2=.bitdrift_public.protobu\
-    f.client.v1.OpaqueConfigurationUpdateH\0R\x19opaqueConfigurationUpdate\
-    \x12Y\n\ropaque_upload\x18\x0b\x20\x01(\x0b22.bitdrift_public.protobuf.c\
-    lient.v1.OpaqueResponseH\0R\x0copaqueUploadB\x14\n\rresponse_type\x12\
-    \x03\xf8B\x012x\n\nApiService\x12j\n\x03Mux\x12..bitdrift_public.protobu\
-    f.client.v1.ApiRequest\x1a/.bitdrift_public.protobuf.client.v1.ApiRespon\
-    se(\x010\x01b\x06proto3\
+    alidate.proto\"m\n\x0eClientKillFile\x12\x20\n\x0capi_key_hash\x18\x01\
+    \x20\x01(\x0cR\napiKeyHash\x129\n\nkill_until\x18\x02\x20\x01(\x0b2\x1a.\
+    google.protobuf.TimestampR\tkillUntil\"\xe8\x04\n\x10HandshakeRequest\
+    \x12\x84\x01\n\x16static_device_metadata\x18\x01\x20\x03(\x0b2N.bitdrift\
+    _public.protobuf.client.v1.HandshakeRequest.StaticDeviceMetadataEntryR\
+    \x14staticDeviceMetadata\x12>\n\x1bconfiguration_version_nonce\x18\x03\
+    \x20\x01(\tR\x19configurationVersionNonce\x122\n\x15runtime_version_nonc\
+    e\x18\x04\x20\x01(\tR\x13runtimeVersionNonce\x12\x81\x01\n\x15opqaue_ver\
+    sion_nonces\x18\x05\x20\x03(\x0b2M.bitdrift_public.protobuf.client.v1.Ha\
+    ndshakeRequest.OpqaueVersionNoncesEntryR\x13opqaueVersionNonces\x1ar\n\
+    \x19StaticDeviceMetadataEntry\x12\x10\n\x03key\x18\x01\x20\x01(\tR\x03ke\
+    y\x12?\n\x05value\x18\x02\x20\x01(\x0b2).bitdrift_public.protobuf.loggin\
+    g.v1.DataR\x05value:\x028\x01\x1aF\n\x18OpqaueVersionNoncesEntry\x12\x10\
+    \n\x03key\x18\x01\x20\x01(\tR\x03key\x12\x14\n\x05value\x18\x02\x20\x01(\
+    \tR\x05value:\x028\x01J\x04\x08\x02\x10\x03R\x13fields_for_all_logs\"|\n\
+    \x19OpaqueConfigurationUpdate\x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\
+    \x0cversionNonce\x12:\n\rconfiguration\x18\x02\x20\x01(\x0b2\x14.google.\
+    protobuf.AnyR\rconfiguration\"\x87\x01\n\x1cOpaqueConfigurationUpdateAck\
+    \x12\x19\n\x08type_url\x18\x01\x20\x01(\tR\x07typeUrl\x12L\n\x03ack\x18\
+    \x02\x20\x01(\x0b2:.bitdrift_public.protobuf.client.v1.ConfigurationUpda\
+    teAckR\x03ack\"\xf3\x02\n\x16LogUploadIntentRequest\x12\x1b\n\tlog_count\
+    \x18\x01\x20\x01(\rR\x08logCount\x12\x1d\n\nbyte_count\x18\x02\x20\x01(\
+    \rR\tbyteCount\x12\x1b\n\tbuffer_id\x18\x03\x20\x01(\tR\x08bufferId\x12\
+    \x1f\n\x0bintent_uuid\x18\x04\x20\x01(\tR\nintentUuid\x12\x87\x01\n\x16w\
+    orkflow_action_upload\x18\x05\x20\x01(\x0b2O.bitdrift_public.protobuf.cl\
+    ient.v1.LogUploadIntentRequest.WorkflowActionUploadH\0R\x14workflowActio\
+    nUpload\x1aF\n\x14WorkflowActionUpload\x12.\n\x13workflow_action_ids\x18\
+    \x01\x20\x03(\tR\x11workflowActionIdsB\r\n\x0bintent_type\"\xbb\x02\n\
+    \x17LogUploadIntentResponse\x12\x1f\n\x0bintent_uuid\x18\x01\x20\x01(\tR\
+    \nintentUuid\x12~\n\x12upload_immediately\x18\x02\x20\x01(\x0b2M.bitdrif\
+    t_public.protobuf.client.v1.LogUploadIntentResponse.UploadImmediatelyH\0\
+    R\x11uploadImmediately\x12V\n\x04drop\x18\x03\x20\x01(\x0b2@.bitdrift_pu\
+    blic.protobuf.client.v1.LogUploadIntentResponse.DropH\0R\x04drop\x1a\x13\
+    \n\x11UploadImmediately\x1a\x06\n\x04DropB\n\n\x08decision\"\x84\x01\n\
+    \x10LogUploadRequest\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUu\
+    idB\x07\xfaB\x04r\x02\x10\x01\x12\x1c\n\x04logs\x18\x02\x20\x03(\x0cR\
+    \x04logsB\x08\xfaB\x05\x92\x01\x02\x08\x01\x12(\n\x0bbuffer_uuid\x18\x03\
+    \x20\x01(\tR\nbufferUuidB\x07\xfaB\x04r\x02\x10\x01\"\r\n\x0bPingRequest\
+    \"\xfc\x01\n\x16ConfigurationUpdateAck\x12;\n\x1alast_applied_version_no\
+    nce\x18\x01\x20\x01(\tR\x17lastAppliedVersionNonce\x12S\n\x04nack\x18\
+    \x02\x20\x01(\x0b2?.bitdrift_public.protobuf.client.v1.ConfigurationUpda\
+    teAck.NackR\x04nack\x1aP\n\x04Nack\x12#\n\rversion_nonce\x18\x01\x20\x01\
+    (\tR\x0cversionNonce\x12#\n\rerror_details\x18\x02\x20\x01(\tR\x0cerrorD\
+    etails\"\xa6\x07\n\nApiRequest\x12T\n\thandshake\x18\x01\x20\x01(\x0b24.\
+    bitdrift_public.protobuf.client.v1.HandshakeRequestH\0R\thandshake\x12h\
+    \n\x11log_upload_intent\x18\x07\x20\x01(\x0b2:.bitdrift_public.protobuf.\
+    client.v1.LogUploadIntentRequestH\0R\x0flogUploadIntent\x12U\n\nlog_uplo\
+    ad\x18\x02\x20\x01(\x0b24.bitdrift_public.protobuf.client.v1.LogUploadRe\
+    questH\0R\tlogUpload\x12[\n\x0cstats_upload\x18\x06\x20\x01(\x0b26.bitdr\
+    ift_public.protobuf.client.v1.StatsUploadRequestH\0R\x0bstatsUpload\x12E\
+    \n\x04ping\x18\x03\x20\x01(\x0b2/.bitdrift_public.protobuf.client.v1.Pin\
+    gRequestH\0R\x04ping\x12v\n\x18configuration_update_ack\x18\x04\x20\x01(\
+    \x0b2:.bitdrift_public.protobuf.client.v1.ConfigurationUpdateAckH\0R\x16\
+    configurationUpdateAck\x12j\n\x12runtime_update_ack\x18\x05\x20\x01(\x0b\
+    2:.bitdrift_public.protobuf.client.v1.ConfigurationUpdateAckH\0R\x10runt\
+    imeUpdateAck\x12\x89\x01\n\x1fopaque_configuration_update_ack\x18\x08\
+    \x20\x01(\x0b2@.bitdrift_public.protobuf.client.v1.OpaqueConfigurationUp\
+    dateAckH\0R\x1copaqueConfigurationUpdateAck\x12X\n\ropaque_upload\x18\t\
+    \x20\x01(\x0b21.bitdrift_public.protobuf.client.v1.OpaqueRequestH\0R\x0c\
+    opaqueUploadB\x13\n\x0crequest_type\x12\x03\xf8B\x01\"\xd4\x01\n\x11Hand\
+    shakeResponse\x12m\n\x0fstream_settings\x18\x01\x20\x01(\x0b2D.bitdrift_\
+    public.protobuf.client.v1.HandshakeResponse.StreamSettingsR\x0estreamSet\
+    tings\x1aP\n\x0eStreamSettings\x12>\n\rping_interval\x18\x01\x20\x01(\
+    \x0b2\x19.google.protobuf.DurationR\x0cpingInterval\"\r\n\x0bRateLimited\
+    \"\xca\x01\n\x11LogUploadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\
+    \tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\
+    \x20\x01(\tR\x05error\x12!\n\x0clogs_dropped\x18\x03\x20\x01(\rR\x0blogs\
+    Dropped\x12R\n\x0crate_limited\x18\x04\x20\x01(\x0b2/.bitdrift_public.pr\
+    otobuf.client.v1.RateLimitedR\x0brateLimited\"\xa3\x04\n\x12StatsUploadR\
+    equest\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\
+    \x04r\x02\x10\x01\x12e\n\x08snapshot\x18\x02\x20\x03(\x0b2?.bitdrift_pub\
+    lic.protobuf.client.v1.StatsUploadRequest.SnapshotR\x08snapshotB\x08\xfa\
+    B\x05\x92\x01\x02\x08\x01\x123\n\x07sent_at\x18\x03\x20\x01(\x0b2\x1a.go\
+    ogle.protobuf.TimestampR\x06sentAt\x1a\xc6\x02\n\x08Snapshot\x12K\n\x07m\
+    etrics\x18\x01\x20\x01(\x0b2/.bitdrift_public.protobuf.client.v1.Metrics\
+    ListH\0R\x07metrics\x12l\n\naggregated\x18\x02\x20\x01(\x0b2J.bitdrift_p\
+    ublic.protobuf.client.v1.StatsUploadRequest.Snapshot.AggregatedH\x01R\na\
+    ggregated\x1aU\n\nAggregated\x12G\n\x0cperiod_start\x18\x04\x20\x01(\x0b\
+    2\x1a.google.protobuf.TimestampR\x0bperiodStartB\x08\xfaB\x05\x8a\x01\
+    \x02\x10\x01B\x14\n\rsnapshot_type\x12\x03\xf8B\x01B\x12\n\x0boccurred_a\
+    t\x12\x03\xf8B\x01\"~\n\x13StatsUploadResponse\x12(\n\x0bupload_uuid\x18\
+    \x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\x05err\
+    or\x18\x02\x20\x01(\tR\x05error\x12'\n\x0fmetrics_dropped\x18\x03\x20\
+    \x01(\rR\x0emetricsDropped\"]\n\rOpaqueRequest\x12\x12\n\x04uuid\x18\x01\
+    \x20\x01(\tR\x04uuid\x128\n\x07request\x18\x02\x20\x01(\x0b2\x14.google.\
+    protobuf.AnyR\x07requestB\x08\xfaB\x05\x8a\x01\x02\x10\x01\"R\n\x0eOpaqu\
+    eResponse\x12\x1b\n\x04uuid\x18\x01\x20\x01(\tR\x04uuidB\x07\xfaB\x04r\
+    \x02\x10\x01\x12\x19\n\x05error\x18\x02\x20\x01(\tH\0R\x05error\x88\x01\
+    \x01B\x08\n\x06_error\"\x0e\n\x0cPongResponse\"\x8f\x06\n\x13Configurati\
+    onUpdate\x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNonce\x12v\
+    \n\x12state_of_the_world\x18\x02\x20\x01(\x0b2G.bitdrift_public.protobuf\
+    .client.v1.ConfigurationUpdate.StateOfTheWorldH\0R\x0fstateOfTheWorld\
+    \x1a\xcb\x04\n\x0fStateOfTheWorld\x12b\n\x12buffer_config_list\x18\x03\
+    \x20\x01(\x0b24.bitdrift_public.protobuf.config.v1.BufferConfigListR\x10\
+    bufferConfigList\x12u\n\x17workflows_configuration\x18\x04\x20\x01(\x0b2\
+    <.bitdrift_public.protobuf.workflow.v1.WorkflowsConfigurationR\x16workfl\
+    owsConfiguration\x12k\n\x14bdtail_configuration\x18\x06\x20\x01(\x0b28.b\
+    itdrift_public.protobuf.bdtail.v1.BdTailConfigurationsR\x13bdtailConfigu\
+    ration\x12q\n\x16insights_configuration\x18\x07\x20\x01(\x0b2:.bitdrift_\
+    public.protobuf.insight.v1.InsightsConfigurationR\x15insightsConfigurati\
+    on\x12m\n\x15filters_configuration\x18\x08\x20\x01(\x0b28.bitdrift_publi\
+    c.protobuf.filter.v1.FiltersConfigurationR\x14filtersConfigurationJ\x04\
+    \x08\x02\x10\x03R\x08mll_listB\r\n\x0bupdate_type\"{\n\rRuntimeUpdate\
+    \x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNonce\x12E\n\x07run\
+    time\x18\x02\x20\x01(\x0b2+.bitdrift_public.protobuf.client.v1.RuntimeR\
+    \x07runtime\"S\n\rErrorShutdown\x12\x1f\n\x0bgrpc_status\x18\x01\x20\x01\
+    (\x05R\ngrpcStatus\x12!\n\x0cgrpc_message\x18\x02\x20\x01(\tR\x0bgrpcMes\
+    sage\"4\n\x0cFlushBuffers\x12$\n\x0ebuffer_id_list\x18\x01\x20\x03(\tR\
+    \x0cbufferIdList\"\xbe\x08\n\x0bApiResponse\x12U\n\thandshake\x18\x01\
+    \x20\x01(\x0b25.bitdrift_public.protobuf.client.v1.HandshakeResponseH\0R\
+    \thandshake\x12V\n\nlog_upload\x18\x02\x20\x01(\x0b25.bitdrift_public.pr\
+    otobuf.client.v1.LogUploadResponseH\0R\tlogUpload\x12i\n\x11log_upload_i\
+    ntent\x18\x08\x20\x01(\x0b2;.bitdrift_public.protobuf.client.v1.LogUploa\
+    dIntentResponseH\0R\x0flogUploadIntent\x12\\\n\x0cstats_upload\x18\x07\
+    \x20\x01(\x0b27.bitdrift_public.protobuf.client.v1.StatsUploadResponseH\
+    \0R\x0bstatsUpload\x12F\n\x04pong\x18\x03\x20\x01(\x0b20.bitdrift_public\
+    .protobuf.client.v1.PongResponseH\0R\x04pong\x12l\n\x14configuration_upd\
+    ate\x18\x04\x20\x01(\x0b27.bitdrift_public.protobuf.client.v1.Configurat\
+    ionUpdateH\0R\x13configurationUpdate\x12Z\n\x0eruntime_update\x18\x05\
+    \x20\x01(\x0b21.bitdrift_public.protobuf.client.v1.RuntimeUpdateH\0R\rru\
+    ntimeUpdate\x12Z\n\x0eerror_shutdown\x18\x06\x20\x01(\x0b21.bitdrift_pub\
+    lic.protobuf.client.v1.ErrorShutdownH\0R\rerrorShutdown\x12W\n\rflush_bu\
+    ffers\x18\t\x20\x01(\x0b20.bitdrift_public.protobuf.client.v1.FlushBuffe\
+    rsH\0R\x0cflushBuffers\x12\x7f\n\x1bopaque_configuration_update\x18\n\
+    \x20\x01(\x0b2=.bitdrift_public.protobuf.client.v1.OpaqueConfigurationUp\
+    dateH\0R\x19opaqueConfigurationUpdate\x12Y\n\ropaque_upload\x18\x0b\x20\
+    \x01(\x0b22.bitdrift_public.protobuf.client.v1.OpaqueResponseH\0R\x0copa\
+    queUploadB\x14\n\rresponse_type\x12\x03\xf8B\x012x\n\nApiService\x12j\n\
+    \x03Mux\x12..bitdrift_public.protobuf.client.v1.ApiRequest\x1a/.bitdrift\
+    _public.protobuf.client.v1.ApiResponse(\x010\x01b\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -6299,7 +6442,8 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             deps.push(super::config::file_descriptor().clone());
             deps.push(super::payload::file_descriptor().clone());
             deps.push(super::validate::file_descriptor().clone());
-            let mut messages = ::std::vec::Vec::with_capacity(30);
+            let mut messages = ::std::vec::Vec::with_capacity(31);
+            messages.push(ClientKillFile::generated_message_descriptor_data());
             messages.push(HandshakeRequest::generated_message_descriptor_data());
             messages.push(OpaqueConfigurationUpdate::generated_message_descriptor_data());
             messages.push(OpaqueConfigurationUpdateAck::generated_message_descriptor_data());

--- a/bd-runtime/src/runtime_test.rs
+++ b/bd-runtime/src/runtime_test.rs
@@ -178,7 +178,7 @@ fn disk_persistence_config_corruption() {
     RecordingErrorReporter::record_error(|| loader.handle_cached_config());
 
   assert_eq!(
-    "runtime cache load: A protobuf error occurred: Incorrect tag".to_string(),
+    "runtime cache load: Incorrect tag".to_string(),
     unexpected_error,
   );
   let flag = TestFlag::register(&loader).unwrap();

--- a/ci/check_license.sh
+++ b/ci/check_license.sh
@@ -6,6 +6,6 @@ python3 ./ci/license_header.py
 
 # Check if git repository is dirty
 if [[ -n $(git status --porcelain) ]]; then
-  echo "Error: Git repository is dirty. Run ci/license_headers.py to update license headers."
+  echo "Error: Git repository is dirty. Run ci/check_license.sh to update license headers."
   exit 1
 fi


### PR DESCRIPTION
This is known as the "client kill" mechanism. There are two different paths, both leading to the client being disabled with no network connection to the SaaS for some period of time:
1. The client receives an unauthenticated response.
2. The client receives a specific runtime generic kill update which can be more targeted.

The client will persist a file with a wakeup time after which the client will come back online and attempt to contact the server again.

Fixes BIT-3577