### PR TITLE
grpc: reliability functionality

### DIFF
--- a/bd-grpc/src/grpc_test.rs
+++ b/bd-grpc/src/grpc_test.rs
@@ -9,6 +9,7 @@ use crate::generated::proto::test::{EchoRequest, EchoResponse};
 use crate::{
   make_server_streaming_router,
   make_unary_router,
+  new_grpc_response,
   Client,
   Code,
   Compression,
@@ -19,21 +20,30 @@ use crate::{
   ServiceMethod,
   Status,
   StreamStats,
+  StreamingApi,
   StreamingApiSender,
 };
 use assert_matches::assert_matches;
 use async_trait::async_trait;
+use axum::body::Body;
+use axum::extract::Request;
+use axum::routing::post;
+use axum::Router;
 use bd_grpc_codec::stats::DeferredCounter;
 use bd_grpc_codec::OptimizeFor;
 use bd_server_stats::stats::CounterWrapper;
 use bd_server_stats::test::util::stats::{self, Helper};
 use bd_time::TimeDurationExt;
+use futures::poll;
 use http::{Extensions, HeaderMap};
+use http_body_util::StreamBody;
 use prometheus::labels;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use time::ext::NumericalDuration;
 use tokio::net::TcpListener;
+use tokio::sync::{mpsc, watch};
+use tokio_stream::wrappers::ReceiverStream;
 
 #[ctor::ctor]
 fn test_global_init() {
@@ -223,6 +233,82 @@ async fn unary_error_handler() {
     Err(Error::Grpc(_))
   );
   assert!(called.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn read_stop() {
+  let (read_stop_tx, read_stop_rx) = watch::channel(false);
+  let (api_tx, mut api_rx) = mpsc::channel(1);
+
+  let router = Router::new().route(
+    &ServiceMethod::<EchoRequest, EchoResponse>::new("Test", "Echo").full_path,
+    post(move |request: Request| async move {
+      let (parts, body) = request.into_parts();
+      let (response_sender, response_body) = mpsc::channel(1);
+      let response = new_grpc_response(
+        Body::new(StreamBody::new(ReceiverStream::new(response_body))),
+        None,
+      );
+      let api = StreamingApi::<EchoResponse, EchoRequest>::new(
+        response_sender,
+        parts.headers,
+        body,
+        false,
+        None,
+        OptimizeFor::Memory,
+        Some(read_stop_rx),
+      );
+      api_tx.send(api).await.unwrap();
+      response
+    }),
+  );
+  let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+  let local_address = listener.local_addr().unwrap();
+  let server = axum::serve(listener, router.into_make_service());
+  tokio::spawn(async { server.await.unwrap() });
+  let client = Client::new_http(local_address.to_string().as_str(), 1.minutes(), 1024).unwrap();
+  let mut stream = client
+    .streaming(
+      &ServiceMethod::<EchoRequest, EchoResponse>::new("Test", "Echo"),
+      None,
+      true,
+      None,
+      OptimizeFor::Memory,
+    )
+    .await
+    .unwrap();
+  stream.send(EchoRequest::default()).await.unwrap();
+  let mut api = api_rx.recv().await.unwrap();
+  assert_eq!(
+    EchoRequest::default(),
+    api.next().await.unwrap().unwrap()[0]
+  );
+
+  {
+    // Start the next future and poll it once. It should be waiting for a frame.
+    let next_future = api.next();
+    tokio::pin!(next_future);
+    assert!(poll!(&mut next_future).is_pending());
+    // Set to read stop and then poll again. It should now be waiting for the read stop to release.
+    read_stop_tx.send(true).unwrap();
+    assert!(poll!(&mut next_future).is_pending());
+    // Send a new message. We should not get anything back.
+    stream.send(EchoRequest::default()).await.unwrap();
+    assert!(poll!(&mut next_future).is_pending());
+    // Clear the read stop and poll again. We should now get the new message.
+    read_stop_tx.send(false).unwrap();
+    assert_eq!(
+      EchoRequest::default(),
+      next_future.await.unwrap().unwrap()[0]
+    );
+  }
+
+  // Write a message and set read stop and make sure that we go into immediate read stop.
+  stream.send(EchoRequest::default()).await.unwrap();
+  read_stop_tx.send(true).unwrap();
+  let next_future = api.next();
+  tokio::pin!(next_future);
+  assert!(poll!(&mut next_future).is_pending());
 }
 
 #[tokio::test]

--- a/bd-grpc/src/lib.rs
+++ b/bd-grpc/src/lib.rs
@@ -52,7 +52,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use time::ext::NumericalDuration;
 use time::Duration;
-use tokio::sync::{mpsc, Semaphore};
+use tokio::sync::{mpsc, watch, Semaphore};
 use tokio_stream::wrappers::ReceiverStream;
 
 const GRPC_STATUS: &str = "grpc-status";
@@ -501,9 +501,11 @@ impl<C: Connect + Clone + Send + Sync + 'static> Client<C> {
       },
     }
 
+    log::debug!("sending streaming request");
     let response = self
       .common_request(service_method, extra_headers, Body::new(body))
       .await?;
+    log::debug!("received streaming response");
     let (parts, body) = response.into_parts();
 
     Ok(StreamingApi::new(
@@ -513,6 +515,7 @@ impl<C: Connect + Clone + Send + Sync + 'static> Client<C> {
       validate,
       compression,
       optimize_for,
+      None,
     ))
   }
 
@@ -540,6 +543,7 @@ impl<C: Connect + Clone + Send + Sync + 'static> Client<C> {
       Body::new(body),
       validate,
       optimize_for,
+      None,
     ))
   }
 }
@@ -578,11 +582,12 @@ impl<OutgoingType: Message, IncomingType: MessageFull> StreamingApi<OutgoingType
     validate: bool,
     compression: Option<bd_grpc_codec::Compression>,
     optimize_for: OptimizeFor,
+    read_stop: Option<watch::Receiver<bool>>,
   ) -> Self {
     let sender = StreamingApiSender::new(tx, compression);
     Self {
       sender,
-      streaming_api: ServerStreamingApi::new(headers, body, validate, optimize_for),
+      streaming_api: ServerStreamingApi::new(headers, body, validate, optimize_for, read_stop),
     }
   }
 
@@ -644,6 +649,7 @@ pub struct ServerStreamingApi<OutgoingType: Message, IncomingType: Message> {
   body: Body,
   decoder: Decoder<IncomingType>,
   validate: bool,
+  read_stop: Option<watch::Receiver<bool>>,
   _type: PhantomData<(OutgoingType, IncomingType)>,
 }
 
@@ -652,7 +658,13 @@ impl<OutgoingType: Message, IncomingType: MessageFull>
 {
   // Create a new streaming API handler.
   #[must_use]
-  pub fn new(headers: HeaderMap, body: Body, validate: bool, optimize_for: OptimizeFor) -> Self {
+  pub fn new(
+    headers: HeaderMap,
+    body: Body,
+    validate: bool,
+    optimize_for: OptimizeFor,
+    read_stop: Option<watch::Receiver<bool>>,
+  ) -> Self {
     let decompression = if headers
       .get(GRPC_ENCODING_HEADER)
       .filter(|v| *v == GRPC_ENCODING_DEFLATE)
@@ -676,6 +688,7 @@ impl<OutgoingType: Message, IncomingType: MessageFull>
       body,
       decoder: Decoder::new(decompression, optimize_for),
       validate,
+      read_stop,
       _type: PhantomData,
     }
   }
@@ -683,7 +696,30 @@ impl<OutgoingType: Message, IncomingType: MessageFull>
   // indicates the stream is complete.
   pub async fn next(&mut self) -> Result<Option<Vec<IncomingType>>> {
     loop {
-      if let Some(frame) = self.body.frame().await {
+      if let Some(read_stop) = &mut self.read_stop {
+        if *read_stop.borrow_and_update() {
+          log::trace!("read stop triggered");
+          if let Err(e) = read_stop.changed().await {
+            // This is a programming error and reasonably might only happen during shutdown.
+            // Issue a debug assert and end the stream.
+            debug_assert!(false, "read stop watch error: {e}");
+            return Ok(None);
+          }
+          log::trace!("read stop cleared");
+          continue;
+        }
+      }
+
+      let frame = tokio::select! {
+        frame = self.body.frame() => frame,
+        _ = async {
+              self.read_stop.as_mut().unwrap().changed().await
+            }, if self.read_stop.is_some() => {
+          continue;
+        },
+      };
+
+      if let Some(frame) = frame {
         let frame = frame.map_err(|e| Error::BodyStream(e.into()))?;
         if frame.is_data() {
           let messages = self.decoder.decode_data(frame.data_ref().unwrap())?;

--- a/bd-grpc/src/lib.rs
+++ b/bd-grpc/src/lib.rs
@@ -501,11 +501,9 @@ impl<C: Connect + Clone + Send + Sync + 'static> Client<C> {
       },
     }
 
-    log::debug!("sending streaming request");
     let response = self
       .common_request(service_method, extra_headers, Body::new(body))
       .await?;
-    log::debug!("received streaming response");
     let (parts, body) = response.into_parts();
 
     Ok(StreamingApi::new(

--- a/bd-test-helpers/src/test_api_server.rs
+++ b/bd-test-helpers/src/test_api_server.rs
@@ -309,6 +309,7 @@ async fn mux(
     true,
     compression,
     OptimizeFor::Memory,
+    None,
   );
 
   // Allocate a new id for the new stream + notify consumers about the creation.


### PR DESCRIPTION
1) Allow HTTP/2 stream settings to be configured.
2) Add generic read stop functionality to streaming APIs. This allows
   callers to use a watch to stop reading from streams and apply back
   pressure.