### PR TITLE
simplify stats tracking with macro

### DIFF
--- a/bd-workflows/src/engine.rs
+++ b/bd-workflows/src/engine.rs
@@ -619,15 +619,9 @@ impl WorkflowsEngine {
         reset_exclusive_workflows_count
       );
       inc_by!(
-        exclusive_workflow_resets_total,
-        reset_exclusive_workflows_count
-      );
-
-      inc_by!(
         exclusive_workflow_potential_forks_total,
         potential_fork_exclusive_workflows_count
       );
-
       inc_by!(run_starts_total, created_runs_count);
       inc_by!(run_advances_total, advanced_runs_count);
       inc_by!(run_stops_total, stopped_runs_count);


### PR DESCRIPTION
This uses a simple macro to reduce some of the boilerplate required to track all of the workflow stats after each run.

Also implements Default for WorkflowState instead of an explicit new function