### PR TITLE
transition "kind" to "platform"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1149,9 +1149,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "jobserver",
  "libc",
@@ -2652,18 +2652,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2672,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2769,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -3409,9 +3409,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.94"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3461,12 +3461,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -4211,9 +4212,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
+checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ anyhow          = "1.0.95"
 arbitrary       = { version = "1.4.1", features = ["derive"] }
 arc-swap        = "1.7.1"
 assert_matches  = "1.5.0"
-async-trait     = "0.1.83"
+async-trait     = "0.1.84"
 axum            = { version = "0.8.1", features = ["http2"] }
 axum-server     = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
 backoff         = "0.4.0"
@@ -56,7 +56,7 @@ base64-url      = "3.0.0"
 base64ct        = { version = "1.6.0", features = ["alloc", "std"] }
 bincode         = "1.3.3"
 bytes           = "1.9.0"
-cc              = "1.2.6"
+cc              = "1.2.7"
 clap            = { version = "4.5.23", features = ["derive", "env"] }
 color-backtrace = "0.6.1"
 concat-string   = "1.0.1"
@@ -120,7 +120,7 @@ sketches-rust = { git = "https://github.com/mattklein123/sketches-rust.git", bra
 
 snap              = "1.1.1"
 static_assertions = "1.1.0"
-tempfile          = "3.14.0"
+tempfile          = "3.15.0"
 thiserror         = "2.0.9"
 tikv-jemalloc-ctl = "0.6.0"
 time              = { version = "0.3.37", features = ["serde-well-known", "macros"] }

--- a/bd-api/src/api_test.rs
+++ b/bd-api/src/api_test.rs
@@ -47,7 +47,11 @@ impl Metadata for EmptyMetadata {
   }
 
   fn platform(&self) -> &Platform {
-    &Platform::Other("unknown", "unknown")
+    &Platform::Apple
+  }
+
+  fn os(&self) -> String {
+    "ios".to_string()
   }
 
   fn collect_inner(&self) -> HashMap<String, String> {

--- a/bd-client-common/src/error_test.rs
+++ b/bd-client-common/src/error_test.rs
@@ -23,7 +23,11 @@ impl Metadata for EmptyMetadata {
   }
 
   fn platform(&self) -> &bd_metadata::Platform {
-    &bd_metadata::Platform::Ios
+    &bd_metadata::Platform::Apple
+  }
+
+  fn os(&self) -> String {
+    "ios".to_string()
   }
 
   fn collect_inner(&self) -> HashMap<String, String> {
@@ -102,7 +106,7 @@ fn attach_error_handler() {
     HashMap::from([
       ("x-session-id".to_string(), session_strategy.session_id()),
       ("x-sdk-version".to_string(), "1.2.3".to_string()),
-      ("x-kind".to_string(), "mobile".to_string()),
+      ("x-platform".to_string(), "apple".to_string()),
       ("x-os".to_string(), "ios".to_string()),
     ]),
     fields

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -18,7 +18,7 @@ use crate::async_log_buffer::{
 use crate::log_replay::LoggerReplay;
 use crate::memory_bound::{self, Sender as MemoryBoundSender};
 use crate::{app_version, MetadataProvider};
-use bd_api::{Metadata, Platform};
+use bd_api::Metadata;
 use bd_client_stats_store::Scope;
 use bd_log::warn_every;
 use bd_log_metadata::{AnnotatedLogFields, LogFieldKind};
@@ -417,7 +417,7 @@ pub struct InitParams {
   /// The platform network implementation to use. This provides the implementation of the transport
   /// used to talk to the backend.
   pub network: Box<dyn bd_api::PlatformNetworkManager<bd_runtime::runtime::ConfigLoader>>,
-  pub platform: Platform,
+
   // Static metadata used to identify the client when communicating with the backend.
   pub static_metadata: Arc<dyn Metadata + Send + Sync>,
 }

--- a/bd-logger/tests/embedded_logger_integration.rs
+++ b/bd-logger/tests/embedded_logger_integration.rs
@@ -77,7 +77,6 @@ impl Setup {
     let (logger, upload_tx, future) = bd_logger::LoggerBuilder::new(InitParams {
       sdk_directory: sdk_directory.path().to_owned(),
       network: Box::new(handle),
-      platform: bd_api::Platform::Other("test", "test_os"),
       session_strategy: Arc::new(Strategy::Fixed(fixed::Strategy::new(
         store.clone(),
         Arc::new(UUIDCallbacks),

--- a/bd-logger/tests/logger_integration.rs
+++ b/bd-logger/tests/logger_integration.rs
@@ -8,7 +8,6 @@
 #[cfg(test)]
 mod tests {
   use assert_matches::assert_matches;
-  use bd_api::Platform;
   use bd_client_common::error::UnexpectedErrorHandler;
   use bd_key_value::Store;
   use bd_log_metadata::LogFieldKind;
@@ -172,7 +171,6 @@ mod tests {
         device,
         store: store.clone(),
         network: Box::new(Self::run_network(server.port, shutdown.make_shutdown())),
-        platform: Platform::Other("integration-test", "test"),
         static_metadata: Arc::new(EmptyMetadata),
       })
       .with_mobile_features(true)
@@ -535,7 +533,7 @@ mod tests {
         // If these numbers end up being too variable we do something more generic.
         let bandwidth_tx = upload.get_counter("api:bandwidth_tx", labels! {}).unwrap();
         let bandwidth_rx = upload.get_counter("api:bandwidth_rx", labels! {}).unwrap();
-        assert_eq!(upload.get_counter("api:bandwidth_tx_uncompressed", labels! {}), Some(120));
+        assert_eq!(upload.get_counter("api:bandwidth_tx_uncompressed", labels! {}), Some(118));
         assert!(bandwidth_tx > 100, "bandwidth_tx = {bandwidth_tx}");
         assert!(bandwidth_rx < 400, "bandwidth_rx = {bandwidth_rx}");
         assert_eq!(upload.get_counter("api:bandwidth_rx_decompressed", labels! {}), Some(406));
@@ -2142,7 +2140,6 @@ mod tests {
       events_listener_target: Box::new(bd_test_helpers::events::NoOpListenerTarget),
       device,
       network,
-      platform: Platform::Other("integration-test", "test"),
       static_metadata: Arc::new(EmptyMetadata),
     })
     .with_mobile_features(true)
@@ -2277,7 +2274,6 @@ mod tests {
       let logger = bd_logger::LoggerBuilder::new(InitParams {
         api_key: "foo-api-key".to_string(),
         network,
-        platform: Platform::Other("integration-test", "test"),
         session_strategy: Arc::new(Strategy::Fixed(fixed::Strategy::new(
           store.clone(),
           Arc::new(UUIDCallbacks),

--- a/bd-metadata/src/lib.rs
+++ b/bd-metadata/src/lib.rs
@@ -16,6 +16,7 @@ use std::fmt::Display;
 const CONFIGURATION_VERSION: &str = "27";
 
 /// The platform we're currently running as.
+#[derive(Clone, Copy)]
 pub enum Platform {
   Android,
   Apple,

--- a/bd-test-helpers/src/metadata.rs
+++ b/bd-test-helpers/src/metadata.rs
@@ -21,7 +21,11 @@ impl Metadata for EmptyMetadata {
   }
 
   fn platform(&self) -> &Platform {
-    &Platform::Other("unknown", "unknown")
+    &Platform::Apple
+  }
+
+  fn os(&self) -> String {
+    "ios".to_string()
   }
 
   #[must_use]


### PR DESCRIPTION
We never used "kind" for anything real and this is the first part of officially supporting Electron and also making "apple" and "android" first class platforms.