### PR TITLE
move device_id to top level metadata values

### DIFF
--- a/bd-api/src/api_test.rs
+++ b/bd-api/src/api_test.rs
@@ -54,6 +54,10 @@ impl Metadata for EmptyMetadata {
     "ios".to_string()
   }
 
+  fn device_id(&self) -> String {
+    String::new()
+  }
+
   fn collect_inner(&self) -> HashMap<String, String> {
     HashMap::new()
   }

--- a/bd-client-common/src/error_test.rs
+++ b/bd-client-common/src/error_test.rs
@@ -33,6 +33,10 @@ impl Metadata for EmptyMetadata {
   fn collect_inner(&self) -> HashMap<String, String> {
     HashMap::new()
   }
+
+  fn device_id(&self) -> String {
+    "device_id".to_string()
+  }
 }
 
 #[derive(Default)]
@@ -108,6 +112,7 @@ fn attach_error_handler() {
       ("x-sdk-version".to_string(), "1.2.3".to_string()),
       ("x-platform".to_string(), "apple".to_string()),
       ("x-os".to_string(), "ios".to_string()),
+      ("x-device-id".to_string(), "device_id".to_string()),
     ]),
     fields
   );

--- a/bd-logger/tests/logger_integration.rs
+++ b/bd-logger/tests/logger_integration.rs
@@ -533,7 +533,7 @@ mod tests {
         // If these numbers end up being too variable we do something more generic.
         let bandwidth_tx = upload.get_counter("api:bandwidth_tx", labels! {}).unwrap();
         let bandwidth_rx = upload.get_counter("api:bandwidth_rx", labels! {}).unwrap();
-        assert_eq!(upload.get_counter("api:bandwidth_tx_uncompressed", labels! {}), Some(118));
+        assert_eq!(upload.get_counter("api:bandwidth_tx_uncompressed", labels! {}), Some(135));
         assert!(bandwidth_tx > 100, "bandwidth_tx = {bandwidth_tx}");
         assert!(bandwidth_rx < 400, "bandwidth_rx = {bandwidth_rx}");
         assert_eq!(upload.get_counter("api:bandwidth_rx_decompressed", labels! {}), Some(406));

--- a/bd-metadata/src/lib.rs
+++ b/bd-metadata/src/lib.rs
@@ -40,6 +40,8 @@ pub trait Metadata: Send {
 
   fn os(&self) -> String;
 
+  fn device_id(&self) -> String;
+
   fn collect_inner(&self) -> HashMap<String, String>;
 
   fn collect(&self) -> HashMap<String, String> {
@@ -53,6 +55,7 @@ pub trait Metadata: Send {
     inner.insert("os".to_string(), self.os());
     inner.insert("platform".to_string(), self.platform().as_str().to_string());
     inner.insert("sdk_version".to_string(), self.sdk_version().to_string());
+    inner.insert("device_id".to_string(), self.device_id());
 
     inner
   }

--- a/bd-test-helpers/src/metadata.rs
+++ b/bd-test-helpers/src/metadata.rs
@@ -28,6 +28,10 @@ impl Metadata for EmptyMetadata {
     "ios".to_string()
   }
 
+  fn device_id(&self) -> String {
+    String::new()
+  }
+
   #[must_use]
   fn collect_inner(&self) -> HashMap<String, String> {
     HashMap::new()


### PR DESCRIPTION
This should make it less likely that we forget to include it in the future