### PR TITLE
persist pending sankey path uploads to workflow state file

### DIFF
--- a/bd-logger/tests/logger_integration.rs
+++ b/bd-logger/tests/logger_integration.rs
@@ -345,7 +345,7 @@ mod tests {
       self
         .sdk_directory
         .path()
-        .join("workflows_state_snapshot.4.bin")
+        .join("workflows_state_snapshot.5.bin")
     }
   }
 

--- a/bd-workflows/src/engine.rs
+++ b/bd-workflows/src/engine.rs
@@ -753,9 +753,14 @@ impl WorkflowsEngine {
       .emit_sankeys(&emit_sankey_diagrams_actions, log);
 
     for action in emit_sankey_diagrams_actions {
+        self.state.pending_sankey_actions.insert(PendingSankeyPathUpload {
+          sankey_path: action.path.clone(),
+        });
       if let Err(e) = self.sankey_processor_input_tx.try_send(action.path) {
         log::debug!("failed to process sankey: {e}");
       }
+
+      self.needs_state_persistence = true;
     }
 
     for action in flush_buffers_actions_processing_result.new_pending_actions_to_add {

--- a/bd-workflows/src/engine.rs
+++ b/bd-workflows/src/engine.rs
@@ -486,7 +486,9 @@ impl WorkflowsEngine {
       Some(processed_sankey_path) = self.sankey_processor_output_rx.recv() => {
         log::debug!("received processed sankey path: \"{:?}\"", processed_sankey_path);
 
-        self.state.pending_sankey_actions.remove(&PendingSankeyPathUpload { sankey_path: processed_sankey_path });
+        self.state.pending_sankey_actions.remove(&PendingSankeyPathUpload {
+            sankey_path: processed_sankey_path
+        });
         self.needs_state_persistence = true;
       },
     }
@@ -753,7 +755,10 @@ impl WorkflowsEngine {
       .emit_sankeys(&emit_sankey_diagrams_actions, log);
 
     for action in emit_sankey_diagrams_actions {
-        self.state.pending_sankey_actions.insert(PendingSankeyPathUpload {
+      self
+        .state
+        .pending_sankey_actions
+        .insert(PendingSankeyPathUpload {
           sankey_path: action.path.clone(),
         });
       if let Err(e) = self.sankey_processor_input_tx.try_send(action.path) {

--- a/bd-workflows/src/engine.rs
+++ b/bd-workflows/src/engine.rs
@@ -26,7 +26,7 @@ use crate::config::{
   WorkflowsConfiguration,
 };
 use crate::metrics::MetricsCollector;
-use crate::sankey_diagram;
+use crate::sankey_diagram::{self, PendingSankeyPathUpload};
 use crate::workflow::{SankeyPath, TriggeredAction, TriggeredActionEmitSankey, Workflow};
 use anyhow::anyhow;
 use bd_api::DataUpload;
@@ -90,6 +90,8 @@ pub struct WorkflowsEngine {
   flush_buffers_negotiator_join_handle: JoinHandle<()>,
 
   sankey_processor_input_tx: Sender<SankeyPath>,
+  sankey_processor_output_rx: Receiver<SankeyPath>,
+
   sankey_processor_join_handle: JoinHandle<()>,
 
   metrics_collector: MetricsCollector,
@@ -125,8 +127,13 @@ impl WorkflowsEngine {
     let flush_buffers_actions_resolver = Resolver::new(&actions_scope);
 
     let (sankey_input_tx, sankey_input_rx) = tokio::sync::mpsc::channel(10);
-    let sankey_diagram_processor =
-      sankey_diagram::Processor::new(sankey_input_rx, data_upload_tx, &actions_scope);
+    let (sankey_output_tx, sankey_output_rx) = tokio::sync::mpsc::channel(10);
+    let sankey_diagram_processor = sankey_diagram::Processor::new(
+      sankey_input_rx,
+      data_upload_tx,
+      sankey_output_tx,
+      &actions_scope,
+    );
     let sankey_processor_join_handle = sankey_diagram_processor.run();
 
     let workflows_engine = Self {
@@ -143,6 +150,7 @@ impl WorkflowsEngine {
       flush_buffers_negotiator_input_tx: input_tx,
       flush_buffers_negotiator_output_rx: output_rx,
       sankey_processor_input_tx: sankey_input_tx,
+      sankey_processor_output_rx: sankey_output_rx,
       sankey_processor_join_handle,
       metrics_collector: MetricsCollector::new(dynamic_stats),
       buffers_to_flush_tx,
@@ -163,9 +171,9 @@ impl WorkflowsEngine {
     let workflows_state = self.state_store.load();
 
     if let Some(state) = workflows_state {
-      self.state.pending_actions = self
+      self.state.pending_flush_actions = self
         .flush_buffers_actions_resolver
-        .standardize_pending_actions(state.pending_actions);
+        .standardize_pending_actions(state.pending_flush_actions);
       self.state.streaming_actions = self
         .flush_buffers_actions_resolver
         .standardize_streaming_buffers(state.streaming_actions);
@@ -179,7 +187,7 @@ impl WorkflowsEngine {
       self.add_workflows(config.workflows_configuration.workflows, None);
     }
 
-    for action in &self.state.pending_actions {
+    for action in &self.state.pending_flush_actions {
       if let Err(e) = self
         .flush_buffers_negotiator_input_tx
         .try_send(action.clone())
@@ -189,11 +197,21 @@ impl WorkflowsEngine {
       }
     }
 
+    for sankey_path in &self.state.pending_sankey_actions {
+      if let Err(e) = self
+        .sankey_processor_input_tx
+        .try_send(sankey_path.sankey_path.clone())
+      {
+        log::debug!("failed to process sankey: {e}");
+      }
+    }
+
     log::debug!(
-      "started workflows engine with {} workflow(s); {} pending processing action(s); {} \
-       streaming action(s); session ID: \"{}\"; traversals count limit: {}",
+      "started workflows engine with {} workflow(s); {} pending processing action(s); {} pending \
+       sankey path uploads; {} streaming action(s); session ID: \"{}\"; traversals count limit: {}",
       self.state.workflows.len(),
-      self.state.pending_actions.len(),
+      self.state.pending_flush_actions.len(),
+      self.state.pending_sankey_actions.len(),
       self.state.streaming_actions.len(),
       self.state.session_id,
       self.traversals_count_limit,
@@ -279,9 +297,9 @@ impl WorkflowsEngine {
         config.continuous_buffer_ids,
       ));
 
-    self.state.pending_actions = self
+    self.state.pending_flush_actions = self
       .flush_buffers_actions_resolver
-      .standardize_pending_actions(self.state.pending_actions.clone());
+      .standardize_pending_actions(self.state.pending_flush_actions.clone());
     self.state.streaming_actions = self
       .flush_buffers_actions_resolver
       .standardize_streaming_buffers(self.state.streaming_actions.clone());
@@ -460,16 +478,22 @@ impl WorkflowsEngine {
               self.on_log_upload_approved(action).await;
           },
           NegotiatorOutput::UploadRejected(action) => {
-            self.state.pending_actions.remove(&action);
+            self.state.pending_flush_actions.remove(&action);
             self.needs_state_persistence = true;
           }
         }
+      },
+      Some(processed_sankey_path) = self.sankey_processor_output_rx.recv() => {
+        log::debug!("received processed sankey path: \"{:?}\"", processed_sankey_path);
+
+        self.state.pending_sankey_actions.remove(&PendingSankeyPathUpload { sankey_path: processed_sankey_path });
+        self.needs_state_persistence = true;
       },
     }
   }
 
   async fn on_log_upload_approved(&mut self, action: PendingFlushBuffersAction) {
-    self.state.pending_actions.remove(&action);
+    self.state.pending_flush_actions.remove(&action);
 
     // If there is already a pending buffer flush we don't want to signal another one, as
     // this would do nothing but mess up our tracking of the in-flight flush.
@@ -716,7 +740,7 @@ impl WorkflowsEngine {
       .process_flush_buffer_actions(
         flush_buffers_actions,
         &self.state.session_id,
-        &self.state.pending_actions,
+        &self.state.pending_flush_actions,
         &self.state.streaming_actions,
       );
 
@@ -735,7 +759,7 @@ impl WorkflowsEngine {
     }
 
     for action in flush_buffers_actions_processing_result.new_pending_actions_to_add {
-      self.state.pending_actions.insert(action.clone());
+      self.state.pending_flush_actions.insert(action.clone());
       if let Err(e) = self.flush_buffers_negotiator_input_tx.try_send(action) {
         log::debug!("failed to send flush buffers action intent for intent negotiation: {e}");
         self.stats.intent_negotiation_channel_send_failures.inc();
@@ -934,7 +958,7 @@ impl StateStore {
     );
 
     Self {
-      state_path: sdk_directory.join("workflows_state_snapshot.4.bin"),
+      state_path: sdk_directory.join("workflows_state_snapshot.5.bin"),
       last_persisted: None,
       stats,
       persistence_write_interval_flag: runtime.register_watch().unwrap(),
@@ -1059,7 +1083,8 @@ pub(crate) struct WorkflowsState {
   session_id: String,
   workflows: Vec<Workflow>,
 
-  pending_actions: BTreeSet<PendingFlushBuffersAction>,
+  pending_flush_actions: BTreeSet<PendingFlushBuffersAction>,
+  pending_sankey_actions: BTreeSet<PendingSankeyPathUpload>,
   streaming_actions: Vec<StreamingBuffersAction>,
 }
 
@@ -1086,7 +1111,8 @@ impl WorkflowsState {
           }
         })
         .collect(),
-      pending_actions: self.pending_actions.clone(),
+      pending_flush_actions: self.pending_flush_actions.clone(),
+      pending_sankey_actions: self.pending_sankey_actions.clone(),
       streaming_actions: self.streaming_actions.clone(),
     }
   }

--- a/bd-workflows/src/engine_test.rs
+++ b/bd-workflows/src/engine_test.rs
@@ -224,7 +224,7 @@ struct Hooks {
 
   sankey_uploads: Vec<SankeyPathUploadRequest>,
   received_sankey_upload_intents: Vec<SankeyIntentRequest>,
-  awaiting_sankey_upload_intent_decisions: Vec<IntentDecision>,
+  awaiting_sankey_upload_intent_decisions: Vec<Option<IntentDecision>>,
 }
 
 struct AnnotatedWorkflowsEngine {
@@ -316,7 +316,12 @@ impl AnnotatedWorkflowsEngine {
 
                   let sankey_upload_intent_payload = sankey_upload_intent.payload.clone();
 
-                  let decision = hooks.lock().awaiting_sankey_upload_intent_decisions.remove(0);
+                  let Some(decision) = hooks.lock().awaiting_sankey_upload_intent_decisions.remove(0) else {
+                    log::debug!("no decision available for sankey upload intent, not responding");
+                      continue;
+                  };
+                      
+
                   log::debug!("responding \"{:?}\" to sankey upload intent \"{}\" intent", decision, sankey_upload_intent.uuid);
 
                   hooks.lock().received_sankey_upload_intents
@@ -3013,8 +3018,7 @@ async fn test_exclusive_workflow_potential_fork() {
   );
 }
 
-#[tokio::test]
-async fn sankey_action() {
+fn sankey_workflow() -> crate::config::Config {
   let mut a = state!("A");
   let mut b = state!("B");
   let mut c = state!("C");
@@ -3050,9 +3054,14 @@ async fn sankey_action() {
     )
   );
 
-  let workflow = workflow!(exclusive with a, b, c, d);
+  workflow!(exclusive with a, b, c, d)
+}
+
+#[tokio::test]
+async fn sankey_action() {
   let setup = Setup::new();
 
+  let workflow = sankey_workflow();
   let mut engine = setup.make_workflows_engine(
     WorkflowsEngineConfig::new_with_workflow_configurations(vec![workflow]),
   );
@@ -3063,7 +3072,7 @@ async fn sankey_action() {
     .hooks
     .lock()
     .awaiting_sankey_upload_intent_decisions
-    .push(IntentDecision::Drop);
+    .push(Some(IntentDecision::Drop));
 
   engine_process_log!(engine; "foo");
   engine_process_log!(engine; "bar");
@@ -3090,7 +3099,7 @@ async fn sankey_action() {
     .hooks
     .lock()
     .awaiting_sankey_upload_intent_decisions
-    .push(IntentDecision::UploadImmediately);
+    .push(Some(IntentDecision::UploadImmediately));
 
   engine_process_log!(engine; "foo");
   engine_process_log!(engine; "bar_loop");
@@ -3173,6 +3182,103 @@ async fn sankey_action() {
       "extracted_field" => "extracted_value",
     },
   );
+}
+
+#[tokio::test]
+async fn sankey_action_persistence() {
+  let setup = Setup::new();
+
+  let workflow = sankey_workflow();
+
+  {
+    let mut engine = setup.make_workflows_engine(
+      WorkflowsEngineConfig::new_with_workflow_configurations(vec![workflow.clone()]),
+    );
+
+    // Emit a Sankey path but don't accept it.
+
+  engine
+    .hooks
+    .lock()
+    .awaiting_sankey_upload_intent_decisions
+    .push(None);
+
+    engine_process_log!(engine; "foo");
+    engine_process_log!(engine; "bar");
+    engine_process_log!(engine; "dar");
+
+    1.milliseconds().sleep().await;
+
+    engine.maybe_persist(false).await;
+  }
+
+  // After shutting down the engine, we only expect to see a response from the server if the Sankey
+  // path upload was persisted to disk.
+
+  let engine = setup.make_workflows_engine(
+    WorkflowsEngineConfig::new_with_workflow_configurations(vec![workflow]),
+  );
+
+  engine
+    .hooks
+    .lock()
+    .awaiting_sankey_upload_intent_decisions
+    .push(Some(IntentDecision::UploadImmediately));
+
+  10.milliseconds().sleep().await;
+
+  assert_eq!(1, engine.hooks.lock().sankey_uploads.len());
+  assert_eq!(1, engine.hooks.lock().received_sankey_upload_intents.len());
+}
+
+#[tokio::test]
+async fn sankey_action_persistence_limit() {
+  let setup = Setup::new();
+
+  let workflow = sankey_workflow();
+
+  {
+    let mut engine = setup.make_workflows_engine(
+      WorkflowsEngineConfig::new_with_workflow_configurations(vec![workflow.clone()]),
+    );
+
+    // Emit 20 Sankey paths that we don't immediately accept.
+    for i in 0..20 {
+      engine
+        .hooks
+        .lock()
+        .awaiting_sankey_upload_intent_decisions
+        .push(None);
+
+      engine_process_log!(engine; "foo");
+      engine_process_log!(engine; "bar"; with labels!{ "field_to_extract_key" => format!("value_{}", i) });
+      engine_process_log!(engine; "dar");
+    }
+
+    1.milliseconds().sleep().await;
+
+    engine.maybe_persist(false).await;
+  }
+
+  // After shutting down the engine, we only expect to see a response from the server if the Sankey
+  // path upload was persisted to disk.
+
+  let engine = setup.make_workflows_engine(
+    WorkflowsEngineConfig::new_with_workflow_configurations(vec![workflow]),
+  );
+
+  for _ in 0..10 {
+  engine
+    .hooks
+    .lock()
+    .awaiting_sankey_upload_intent_decisions
+    .push(Some(IntentDecision::UploadImmediately));
+  }
+
+  10.milliseconds().sleep().await;
+
+  assert_eq!(10, engine.hooks.lock().sankey_uploads.len());
+  assert_eq!(10, engine.hooks.lock().received_sankey_upload_intents.len());
 }
 
 #[tokio::test]

--- a/bd-workflows/src/engine_test.rs
+++ b/bd-workflows/src/engine_test.rs
@@ -477,7 +477,7 @@ impl Setup {
     self
       .sdk_directory
       .path()
-      .join("workflows_state_snapshot.4.bin")
+      .join("workflows_state_snapshot.5.bin")
   }
 }
 
@@ -2150,7 +2150,7 @@ async fn logs_streaming() {
 
   // Two of the triggered flush buffers actions are awaiting corresponding logs upload intents to be
   // processed.
-  assert_eq!(workflows_engine.state.pending_actions.len(), 2);
+  assert_eq!(workflows_engine.state.pending_flush_actions.len(), 2);
 
   // One logs streaming action is active.
   assert_eq!(workflows_engine.state.streaming_actions.len(), 1);
@@ -2286,7 +2286,7 @@ async fn logs_streaming() {
     Cow::Owned(BTreeSet::from(["trigger_buffer_id".into()]))
   );
 
-  assert!(workflows_engine.state.pending_actions.is_empty());
+  assert!(workflows_engine.state.pending_flush_actions.is_empty());
   assert!(workflows_engine.state.streaming_actions.is_empty());
 
   // Make sure that workflows state was persisted to disk.
@@ -2351,7 +2351,7 @@ async fn engine_does_not_purge_pending_actions_on_session_id_change() {
   );
 
   // Confirm that the pending action was not cleaned up.
-  assert_eq!(1, workflows_engine.state.pending_actions.len());
+  assert_eq!(1, workflows_engine.state.pending_flush_actions.len());
 
   // Make sure that the engine's state is persisted to disk.
   assert!(workflows_engine.needs_state_persistence);
@@ -2680,7 +2680,7 @@ async fn workflows_state_is_purged_when_session_id_changes() {
   // State was updated.
   assert_eq!(workflows_engine.state.session_id, "bar_session",);
   assert_eq!(1, workflows_engine.state.workflows.len());
-  assert!(workflows_engine.state.pending_actions.is_empty());
+  assert!(workflows_engine.state.pending_flush_actions.is_empty());
   assert!(workflows_engine.state.streaming_actions.is_empty());
   // No need to persist state as state file was removed already. The
   // only thing that needs storing is `session_ID` but having no session ID

--- a/bd-workflows/src/sankey_diagram.rs
+++ b/bd-workflows/src/sankey_diagram.rs
@@ -23,6 +23,10 @@ use tokio::sync::mpsc::{Receiver, Sender};
 
 const PROCESSED_INTENTS_LRU_CACHE_SIZE: usize = 100;
 
+/// The number of pending Sankey path uploads that that should be allowed to accumulate before we
+/// start dropping them.
+pub const MAX_PENDING_SANKEY_PATH_UPLOADS: usize = 10;
+
 //
 // ProcessedIntents
 //


### PR DESCRIPTION
This persists the pending Sankey path upload in the workflow state, allowing the SDK to attempt uploading the Sankey path after coming back after shutting down while there were pending uploads. This should let us handle cases where we shut down soon after the Sankey path is completed

Fixes BIT-4463