### PR TITLE
add device_id as a matching field

### DIFF
--- a/bd-client-common/src/fb.rs
+++ b/bd-client-common/src/fb.rs
@@ -131,6 +131,13 @@ fn string_or_bytes_union<T: AsRef<str>, B: AsRef<[u8]>>(
         Data::string_data,
       )
     },
+    StringOrBytes::SharedString(s) => {
+      let value = builder.create_string(s.as_ref());
+      (
+        StringData::create(builder, &StringDataArgs { data: Some(value) }).as_union_value(),
+        Data::string_data,
+      )
+    },
     StringOrBytes::Bytes(b) => {
       let value = builder.create_vector(b.as_ref());
       (

--- a/bd-log-primitives/src/lib.rs
+++ b/bd-log-primitives/src/lib.rs
@@ -244,5 +244,6 @@ pub trait LogInterceptor: Send + Sync {
     log_type: LogType,
     msg: &LogMessage,
     fields: &mut AnnotatedLogFields,
+    matching_fields: &mut AnnotatedLogFields,
   );
 }

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -313,6 +313,7 @@ async fn no_logs_are_lost() {
     make_shutdown(1.seconds()),
     &setup.runtime,
     Arc::new(SimpleNetworkQualityProvider::default()),
+    String::new(),
   );
 
   let written_logs_count = Arc::new(AtomicUsize::new(0));
@@ -419,6 +420,7 @@ async fn logs_are_replayed_in_order() {
     make_shutdown(5.seconds()),
     &setup.runtime,
     Arc::new(SimpleNetworkQualityProvider::default()),
+    String::new(),
   );
 
   let written_logs = Arc::new(Mutex::new(vec![]));
@@ -525,6 +527,7 @@ fn enqueuing_log_does_not_block() {
     shutdown_trigger.make_handle(),
     &setup.runtime,
     Arc::new(SimpleNetworkQualityProvider::default()),
+    String::new(),
   );
 
   let result = AsyncLogBuffer::<TestReplay>::enqueue_log(
@@ -567,6 +570,7 @@ fn take_screenshot_action() {
     shutdown_trigger.make_handle(),
     &setup.runtime,
     Arc::new(SimpleNetworkQualityProvider::default()),
+    String::new(),
   );
 
   let result = AsyncLogBuffer::<TestReplay>::enqueue_log(
@@ -609,6 +613,7 @@ fn enqueuing_log_blocks() {
     shutdown_trigger.make_handle(),
     &setup.runtime,
     Arc::new(SimpleNetworkQualityProvider::default()),
+    String::new(),
   );
 
   let rt = tokio::runtime::Runtime::new().unwrap();
@@ -671,6 +676,7 @@ async fn creates_workflows_engine_in_response_to_config_update() {
     make_shutdown(1.seconds()),
     &setup.runtime,
     Arc::new(SimpleNetworkQualityProvider::default()),
+    String::new(),
   );
 
   // Simulate config update.
@@ -717,6 +723,7 @@ async fn does_not_create_workflows_engine_in_response_to_config_update_if_workfl
     make_shutdown(1.seconds()),
     &setup.runtime,
     Arc::new(SimpleNetworkQualityProvider::default()),
+    String::new(),
   );
 
   // Simulate config update.
@@ -760,6 +767,7 @@ async fn updates_workflow_engine_in_response_to_config_update() {
     shutdown_trigger.make_handle(),
     &setup.runtime,
     Arc::new(SimpleNetworkQualityProvider::default()),
+    String::new(),
   );
 
   let setup_clone = setup.clone();
@@ -857,6 +865,7 @@ async fn stops_workflows_engine_if_workflows_runtime_flag_is_disabled() {
     shutdown_trigger.make_handle(),
     &setup.runtime,
     Arc::new(SimpleNetworkQualityProvider::default()),
+    String::new(),
   );
 
   let setup_clone = setup.clone();
@@ -930,6 +939,7 @@ async fn logs_resource_utilization_log() {
     shutdown_trigger.make_handle(),
     &setup.runtime,
     Arc::new(SimpleNetworkQualityProvider::default()),
+    String::new(),
   );
 
   setup

--- a/bd-logger/src/bounded_buffer/size.rs
+++ b/bd-logger/src/bounded_buffer/size.rs
@@ -54,6 +54,8 @@ impl MemorySized for LogFieldValue {
     size_of_val(self)
       + match self {
         Self::String(s) => s.len(),
+        // TODO(snowp): Can we avoid counting the size of the string if we know that it's "shared"?
+        Self::SharedString(s) => s.len(),
         Self::Bytes(b) => b.capacity(),
       }
   }

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -174,6 +174,7 @@ impl LoggerBuilder {
       shutdown_handle.clone(),
       &runtime_loader,
       network_quality_provider.clone(),
+      String::new(),
     );
 
     let logger = Logger::new(

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -174,7 +174,7 @@ impl LoggerBuilder {
       shutdown_handle.clone(),
       &runtime_loader,
       network_quality_provider.clone(),
-      String::new(),
+      self.params.device.id(),
     );
 
     let logger = Logger::new(

--- a/bd-logger/src/device_id.rs
+++ b/bd-logger/src/device_id.rs
@@ -1,3 +1,10 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 use bd_log_metadata::AnnotatedLogFields;
 use bd_log_primitives::{AnnotatedLogField, LogInterceptor, LogLevel, LogMessage, LogType};
 

--- a/bd-logger/src/device_id.rs
+++ b/bd-logger/src/device_id.rs
@@ -29,7 +29,7 @@ impl LogInterceptor for DeviceIdInterceptor {
     // it in the matching fields it will be matchable and also present on all logs without us
     // having to add an explicit field that eats up buffer capacity.
     matching_fields.push(AnnotatedLogField::new_ootb(
-      "device_id".to_string(),
+      "_device_id".to_string(),
       self.device_id.clone().into(),
     ));
   }

--- a/bd-logger/src/device_id.rs
+++ b/bd-logger/src/device_id.rs
@@ -7,18 +7,21 @@
 
 use bd_log_metadata::AnnotatedLogFields;
 use bd_log_primitives::{AnnotatedLogField, LogInterceptor, LogLevel, LogMessage, LogType};
+use std::sync::Arc;
 
 //
 // DeviceIdInterceptor
 //
 
 pub struct DeviceIdInterceptor {
-  device_id: String,
+  device_id: Arc<String>,
 }
 
 impl DeviceIdInterceptor {
-  pub const fn new(device_id: String) -> Self {
-    Self { device_id }
+  pub fn new(device_id: String) -> Self {
+    Self {
+      device_id: device_id.into(),
+    }
   }
 }
 

--- a/bd-logger/src/device_id.rs
+++ b/bd-logger/src/device_id.rs
@@ -1,0 +1,36 @@
+use bd_log_metadata::AnnotatedLogFields;
+use bd_log_primitives::{AnnotatedLogField, LogInterceptor, LogLevel, LogMessage, LogType};
+
+//
+// DeviceIdInterceptor
+//
+
+pub struct DeviceIdInterceptor {
+  device_id: String,
+}
+
+impl DeviceIdInterceptor {
+  pub fn new(device_id: String) -> Self {
+    Self { device_id }
+  }
+}
+
+
+impl LogInterceptor for DeviceIdInterceptor {
+  fn process(
+    &self,
+    _log_level: LogLevel,
+    _log_type: LogType,
+    _msg: &LogMessage,
+    _fields: &mut AnnotatedLogFields,
+    matching_fields: &mut AnnotatedLogFields,
+  ) {
+    // The device_id field is populated by lapi on upload based on the handshake, so by putting
+    // it in the matching fields it will be matchable and also present on all logs without us
+    // having to add an explicit field that eats up buffer capacity.
+    matching_fields.push(AnnotatedLogField::new_ootb(
+      "device_id".to_string(),
+      self.device_id.clone().into(),
+    ));
+  }
+}

--- a/bd-logger/src/device_id.rs
+++ b/bd-logger/src/device_id.rs
@@ -10,7 +10,7 @@ pub struct DeviceIdInterceptor {
 }
 
 impl DeviceIdInterceptor {
-  pub fn new(device_id: String) -> Self {
+  pub const fn new(device_id: String) -> Self {
     Self { device_id }
   }
 }

--- a/bd-logger/src/internal_report.rs
+++ b/bd-logger/src/internal_report.rs
@@ -43,6 +43,7 @@ impl LogInterceptor for Reporter {
     log_type: LogType,
     msg: &LogMessage,
     fields: &mut AnnotatedLogFields,
+    _matching_fields: &mut AnnotatedLogFields,
   ) {
     let mut guard = self.state.lock();
 

--- a/bd-logger/src/lib.rs
+++ b/bd-logger/src/lib.rs
@@ -11,6 +11,7 @@ mod bounded_buffer;
 mod builder;
 mod client_config;
 mod consumer;
+mod device_id;
 pub mod internal;
 mod internal_report;
 mod log_replay;

--- a/bd-logger/src/network.rs
+++ b/bd-logger/src/network.rs
@@ -152,7 +152,6 @@ impl HTTPTrafficDataUsageTracker {
   }
 }
 
-#[allow(clippy::cognitive_complexity)]
 impl LogInterceptor for HTTPTrafficDataUsageTracker {
   fn process(
     &self,
@@ -160,6 +159,7 @@ impl LogInterceptor for HTTPTrafficDataUsageTracker {
     log_type: LogType,
     msg: &LogMessage,
     fields: &mut AnnotatedLogFields,
+    _matching_fields: &mut AnnotatedLogFields,
   ) {
     let LogMessage::String(msg) = msg else { return };
 
@@ -361,6 +361,7 @@ impl LogInterceptor for NetworkQualityInterceptor {
     log_type: LogType,
     _msg: &LogMessage,
     fields: &mut AnnotatedLogFields,
+    _matching_fields: &mut AnnotatedLogFields,
   ) {
     if log_type == LogType::Resource
       || log_type == LogType::Replay

--- a/bd-logger/src/network.rs
+++ b/bd-logger/src/network.rs
@@ -295,6 +295,7 @@ fn get_int_field_value(fields: &[AnnotatedLogField], field_key: &str) -> Option<
 
     let string_value = match &field.field.value {
       StringOrBytes::String(value) => value,
+      StringOrBytes::SharedString(value) => value,
       StringOrBytes::Bytes(_) => break,
     };
 

--- a/bd-logger/src/network_test.rs
+++ b/bd-logger/src/network_test.rs
@@ -235,6 +235,7 @@ fn get_int_field_value(fields: &AnnotatedLogFields, field_key: &str) -> Option<u
     }
 
     let string_value = match &field.field.value {
+      StringOrBytes::SharedString(value) => value,
       StringOrBytes::String(value) => value,
       StringOrBytes::Bytes(_) => break,
     };

--- a/bd-logger/src/network_test.rs
+++ b/bd-logger/src/network_test.rs
@@ -56,13 +56,31 @@ fn network_quality() {
   let interceptor = NetworkQualityInterceptor::new(network_quality_provider.clone());
   {
     let mut fields = vec![];
-    interceptor.process(log_level::DEBUG, LogType::Normal, &"".into(), &mut fields);
+    interceptor.process(
+      log_level::DEBUG,
+      LogType::Normal,
+      &"".into(),
+      &mut fields,
+      &mut vec![],
+    );
     assert!(fields.is_empty());
     network_quality_provider.set_network_quality(NetworkQuality::Online);
-    interceptor.process(log_level::DEBUG, LogType::Normal, &"".into(), &mut fields);
+    interceptor.process(
+      log_level::DEBUG,
+      LogType::Normal,
+      &"".into(),
+      &mut fields,
+      &mut vec![],
+    );
     assert!(fields.is_empty());
     network_quality_provider.set_network_quality(NetworkQuality::Offline);
-    interceptor.process(log_level::DEBUG, LogType::Normal, &"".into(), &mut fields);
+    interceptor.process(
+      log_level::DEBUG,
+      LogType::Normal,
+      &"".into(),
+      &mut fields,
+      &mut vec![],
+    );
     assert_eq!(
       fields[0],
       AnnotatedLogField::new_ootb("_network_quality".to_string(), "offline".into(),)
@@ -70,7 +88,13 @@ fn network_quality() {
   }
   {
     let mut fields = vec![];
-    interceptor.process(log_level::DEBUG, LogType::Replay, &"".into(), &mut fields);
+    interceptor.process(
+      log_level::DEBUG,
+      LogType::Replay,
+      &"".into(),
+      &mut fields,
+      &mut vec![],
+    );
     assert!(fields.is_empty());
   }
 }
@@ -90,7 +114,13 @@ async fn collects_bandwidth_sample() {
     time_provider.advance_by(std::time::Duration::from_secs(3));
 
     let mut fields = vec![];
-    tracker.process(log_level::DEBUG, LogType::Resource, &"".into(), &mut fields);
+    tracker.process(
+      log_level::DEBUG,
+      LogType::Resource,
+      &"".into(),
+      &mut fields,
+      &mut vec![],
+    );
     assert!(fields.is_empty());
   }
 
@@ -105,6 +135,7 @@ async fn collects_bandwidth_sample() {
       create_int_field("_response_body_bytes_received_count", 300),
       create_int_field("_response_headers_bytes_count", 400),
     ],
+    &mut vec![],
   );
 
   assert_eq!(
@@ -116,7 +147,13 @@ async fn collects_bandwidth_sample() {
     time_provider.advance_by(std::time::Duration::from_secs(3));
 
     let mut fields = vec![];
-    tracker.process(log_level::DEBUG, LogType::Resource, &"".into(), &mut fields);
+    tracker.process(
+      log_level::DEBUG,
+      LogType::Resource,
+      &"".into(),
+      &mut fields,
+      &mut vec![],
+    );
     assert!(!fields.is_empty());
 
     assert_eq!(
@@ -152,7 +189,13 @@ async fn collects_bandwidth_sample() {
   time_provider.advance_by(std::time::Duration::from_secs(3));
 
   let mut fields = vec![];
-  tracker.process(log_level::DEBUG, LogType::Resource, &"".into(), &mut fields);
+  tracker.process(
+    log_level::DEBUG,
+    LogType::Resource,
+    &"".into(),
+    &mut fields,
+    &mut vec![],
+  );
 
   assert_eq!(
     Some(0),

--- a/bd-session-replay/src/lib.rs
+++ b/bd-session-replay/src/lib.rs
@@ -294,6 +294,7 @@ impl bd_log_primitives::LogInterceptor for ScreenshotLogInterceptor {
     log_type: bd_log_primitives::LogType,
     msg: &bd_log_primitives::LogMessage,
     _fields: &mut bd_log_primitives::AnnotatedLogFields,
+    _matching_fields: &mut bd_log_primitives::AnnotatedLogFields,
   ) {
     if !(log_type == LogType::Replay && msg.as_str() == Some(SESSION_REPLAY_SCREENSHOT_LOG_MESSAGE))
     {

--- a/bd-session-replay/src/recorder_test.rs
+++ b/bd-session-replay/src/recorder_test.rs
@@ -249,6 +249,7 @@ async fn limits_the_number_of_concurrent_screenshots_to_one() {
     LogType::Replay,
     &SESSION_REPLAY_SCREENSHOT_LOG_MESSAGE.into(),
     &mut vec![],
+    &mut vec![],
   );
 
   // Request taking a screenshot goes through successfully as the previous screenshot log was
@@ -281,6 +282,7 @@ async fn limits_the_number_of_concurrent_screenshots_to_one() {
     log_level::INFO,
     LogType::Replay,
     &SESSION_REPLAY_SCREENSHOT_LOG_MESSAGE.into(),
+    &mut vec![],
     &mut vec![],
   );
 


### PR DESCRIPTION
Adds _device_id as a matching field on all logs. This should make it possible to write a matcher against device IDs without us having to upload the ID for each log

BIT-4565