### PR TITLE
improve ergonomics when matching against uploaded logs in test

### DIFF
--- a/bd-buffer/src/ring_buffer_test.rs
+++ b/bd-buffer/src/ring_buffer_test.rs
@@ -169,7 +169,7 @@ async fn test_ring_buffer_manager() {
 }
 
 #[tokio::test]
-async fn test_ring_buffer_stats() {
+async fn ring_buffer_stats() {
   let diretory = tempfile::TempDir::with_prefix("ringbuffer").unwrap();
 
   let collector = Collector::default();
@@ -250,7 +250,7 @@ async fn test_ring_buffer_stats() {
   );
 
   // Write a bunch of entries that will overflow the small buffers
-  for _ in 0 .. 1000 {
+  for _ in 0 .. 5000 {
     let _ignored = producer1.write(&[0; 50]);
   }
 

--- a/bd-logger/src/test/crash_handler_integration.rs
+++ b/bd-logger/src/test/crash_handler_integration.rs
@@ -6,7 +6,6 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use super::setup::Setup;
-use crate::test::setup::{expected_binary_field_value, expected_message};
 use crate::wait_for;
 use assert_matches::assert_matches;
 use bd_runtime::runtime::crash_handling::CrashDirectories;
@@ -43,9 +42,9 @@ fn crash_reports() {
   setup.upload_individual_logs();
 
   assert_matches!(setup.server.blocking_next_log_upload(), Some(upload) => {
-    assert_eq!(upload.logs.len(), 1);
-    assert_eq!(expected_message(&upload.logs[0].clone()), "App crashed");
-    assert_eq!(expected_binary_field_value(&upload.logs[0], "_crash_artifact"), b"crash1");
+    assert_eq!(upload.logs().len(), 1);
+    assert_eq!(upload.logs()[0].message(), "App crashed");
+    assert_eq!(upload.logs()[0].binary_field("_crash_artifact"), b"crash1");
   });
 }
 

--- a/bd-logger/src/test/setup.rs
+++ b/bd-logger/src/test/setup.rs
@@ -14,7 +14,6 @@ use crate::{
   LogType,
   Logger,
 };
-use bd_client_common::fb::root_as_log;
 use bd_device::Store;
 use bd_proto::protos::client::api::configuration_update::StateOfTheWorld;
 use bd_proto::protos::client::api::configuration_update_ack::Nack;
@@ -345,96 +344,4 @@ impl Drop for Setup {
     // completes.
     self.logger.shutdown(true);
   }
-}
-
-pub fn exists_field_value(log: &[u8], key: &str) -> bool {
-  let log = root_as_log(log).unwrap();
-
-  log.fields().unwrap().iter().any(|field| field.key() == key)
-}
-
-// Extracts out the value of an expected field from a flatbuffer encoded log.
-pub fn expected_field_value<'a>(log: &'a [u8], key: &str) -> &'a str {
-  let log = root_as_log(log).unwrap();
-
-  let field_entry = log
-    .fields()
-    .unwrap()
-    .iter()
-    .find(|field| field.key() == key)
-    .unwrap();
-
-  field_entry.value_as_string_data().unwrap().data()
-}
-
-pub fn expected_stream_ids(log: &[u8]) -> Vec<String> {
-  let log = root_as_log(log).unwrap();
-
-  log
-    .stream_ids()
-    .unwrap()
-    .iter()
-    .map(ToString::to_string)
-    .collect()
-}
-
-pub fn log_type(log: &[u8]) -> LogType {
-  root_as_log(log).unwrap().log_type()
-}
-
-pub fn expected_binary_field_value<'a>(log: &'a [u8], key: &str) -> &'a [u8] {
-  let log = root_as_log(log).unwrap();
-
-  let field_entry = log
-    .fields()
-    .unwrap()
-    .iter()
-    .find(|field| field.key() == key)
-    .unwrap();
-
-  field_entry.value_as_binary_data().unwrap().data().bytes()
-}
-
-// Extracts out the message from a flatbuffer encoded log.
-pub fn expected_message(log: &[u8]) -> &str {
-  let log = root_as_log(log).unwrap();
-
-  log.message_as_string_data().unwrap().data()
-}
-
-pub fn expected_binary_message(log: &[u8]) -> &[u8] {
-  let log = root_as_log(log).unwrap();
-
-  log.message_as_binary_data().unwrap().data().bytes()
-}
-
-pub fn expected_session_id(log: &[u8]) -> &str {
-  let log = root_as_log(log).unwrap();
-
-  log.session_id().unwrap()
-}
-
-pub fn expected_timestamp(log: &[u8]) -> time::OffsetDateTime {
-  let log = root_as_log(log).unwrap();
-  let timestamp = log.timestamp().unwrap();
-
-  #[allow(clippy::cast_lossless)]
-  time::OffsetDateTime::from_unix_timestamp_nanos(
-    (timestamp.seconds() as i128) * 1_000_000_000 + (timestamp.nanos() as i128),
-  )
-  .unwrap()
-}
-
-pub fn expected_workflow_action_ids(log: &[u8]) -> Vec<String> {
-  let log = root_as_log(log).unwrap();
-
-  log
-    .workflow_action_ids()
-    .map(|workflow_action_ids| {
-      workflow_action_ids
-        .iter()
-        .map(ToString::to_string)
-        .collect()
-    })
-    .unwrap_or_default()
 }

--- a/bd-test-helpers/src/test_api_server.rs
+++ b/bd-test-helpers/src/test_api_server.rs
@@ -5,6 +5,8 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
+mod log_upload;
+
 use axum::body::Body;
 use axum::extract::{Request, State};
 use axum::routing::post;
@@ -43,6 +45,7 @@ use bd_proto::protos::client::api::{
 use bd_proto::protos::logging::payload::data::Data_type;
 use bd_time::{TimeDurationExt, ToProtoDuration};
 use http_body_util::StreamBody;
+use log_upload::LogUpload;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -883,8 +886,8 @@ impl ServerHandle {
     Self::next_request_with_timeout(&mut self.log_upload_rx).await
   }
 
-  pub fn blocking_next_log_upload(&mut self) -> Option<LogUploadRequest> {
-    Self::blocking_next_request_with_timeout(&mut self.log_upload_rx)
+  pub fn blocking_next_log_upload(&mut self) -> Option<LogUpload> {
+    Self::blocking_next_request_with_timeout(&mut self.log_upload_rx).map(LogUpload)
   }
 
   pub fn next_stat_upload(&mut self) -> Option<StatsUploadRequest> {

--- a/bd-test-helpers/src/test_api_server/log_upload.rs
+++ b/bd-test-helpers/src/test_api_server/log_upload.rs
@@ -1,3 +1,10 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 use bd_log_primitives::LogType;
 use bd_proto::flatbuffers::buffer_log::bitdrift_public::fbs::logging::v_1::root_as_log;
 use bd_proto::protos::client::api::LogUploadRequest;

--- a/bd-test-helpers/src/test_api_server/log_upload.rs
+++ b/bd-test-helpers/src/test_api_server/log_upload.rs
@@ -1,0 +1,112 @@
+use bd_log_primitives::LogType;
+use bd_proto::flatbuffers::buffer_log::bitdrift_public::fbs::logging::v_1::root_as_log;
+use bd_proto::protos::client::api::LogUploadRequest;
+
+#[derive(Debug)]
+pub struct LogUpload(pub(super) LogUploadRequest);
+
+impl LogUpload {
+  pub fn logs(&self) -> Vec<Log<'_>> {
+    self
+      .0
+      .logs
+      .iter()
+      .map(|log| Log(root_as_log(log).unwrap()))
+      .collect()
+  }
+
+  pub fn upload_uuid(&self) -> &str {
+    &self.0.upload_uuid
+  }
+
+  pub fn buffer_id(&self) -> &str {
+    &self.0.buffer_uuid
+  }
+}
+
+pub struct Log<'a>(bd_proto::flatbuffers::buffer_log::bitdrift_public::fbs::logging::v_1::Log<'a>);
+
+impl Log<'_> {
+  pub fn session_id(&self) -> &str {
+    self.0.session_id().unwrap()
+  }
+
+  pub fn message(&self) -> &str {
+    self.0.message_as_string_data().unwrap().data()
+  }
+
+  pub fn binary_message(&self) -> &[u8] {
+    self.0.message_as_binary_data().unwrap().data().bytes()
+  }
+
+  pub fn field(&self, key: &str) -> &str {
+    self
+      .0
+      .fields()
+      .unwrap_or_default()
+      .iter()
+      .find_map(|field| {
+        (field.key() == key).then_some(
+          field
+            .value_as_string_data()
+            .expect("field should be string value")
+            .data(),
+        )
+      })
+      .expect("field should exist")
+  }
+
+  pub fn has_field(&self, key: &str) -> bool {
+    self
+      .0
+      .fields()
+      .unwrap_or_default()
+      .iter()
+      .any(|field| field.key() == key)
+  }
+
+  pub fn binary_field(&self, key: &str) -> &[u8] {
+    self
+      .0
+      .fields()
+      .unwrap_or_default()
+      .iter()
+      .find_map(|field| {
+        (field.key() == key).then(|| {
+          field
+            .value_as_binary_data()
+            .expect("field should be binary value")
+            .data()
+            .bytes()
+        })
+      })
+      .expect("field should exist")
+  }
+
+  pub fn timestamp(&self) -> time::OffsetDateTime {
+    let timestamp = self.0.timestamp().unwrap();
+
+    #[allow(clippy::cast_lossless)]
+    time::OffsetDateTime::from_unix_timestamp_nanos(
+      (timestamp.seconds() as i128) * 1_000_000_000 + (timestamp.nanos() as i128),
+    )
+    .unwrap()
+  }
+
+  pub fn workflow_action_ids(&self) -> Vec<&str> {
+    self
+      .0
+      .workflow_action_ids()
+      .unwrap_or_default()
+      .iter()
+      .collect()
+  }
+
+  pub fn stream_ids(&self) -> Vec<&str> {
+    self.0.stream_ids().unwrap_or_default().iter().collect()
+  }
+
+  pub fn log_type(&self) -> LogType {
+    self.0.log_type()
+  }
+}


### PR DESCRIPTION
Instead of using a number of free functions that take &[u8], instead we have the log upload test helpers return a newtype that wraps the data. This allows us to move all the helpers to take &self which makes them easier to discover via IDEs and the code a bit easier to follow