### PR TITLE
use rust edition 2021 for bd-crash-handler

### DIFF
--- a/bd-crash-handler/Cargo.toml
+++ b/bd-crash-handler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition      = "2024"
+edition      = "2021"
 license-file = "../LICENSE"
 name         = "bd-crash-handler"
 publish      = false

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -10,7 +10,7 @@ use bd_runtime::runtime::crash_handling::CrashDirectories;
 use bd_runtime::runtime::{ConfigLoader, FeatureFlag as _};
 use bd_shutdown::ComponentShutdownTrigger;
 use bd_test_helpers::make_mut;
-use bd_test_helpers::runtime::{ValueKind, make_simple_update};
+use bd_test_helpers::runtime::{make_simple_update, ValueKind};
 use std::sync::Arc;
 use tempfile::TempDir;
 


### PR DESCRIPTION
2024 forces updates to the rust version in capture-sdk, downgrade for now