### PR TITLE
report crash reports with session of previous process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
+ "bd-log-primitives",
  "bd-runtime",
  "bd-shutdown",
  "bd-test-helpers",

--- a/bd-crash-handler/Cargo.toml
+++ b/bd-crash-handler/Cargo.toml
@@ -9,12 +9,13 @@ version      = "1.0.0"
 doctest = false
 
 [dependencies]
-anyhow.workspace      = true
-async-trait.workspace = true
-bd-runtime.path       = "../bd-runtime"
-bd-shutdown.path      = "../bd-shutdown"
-log.workspace         = true
-tokio.workspace       = true
+anyhow.workspace       = true
+async-trait.workspace  = true
+bd-log-primitives.path = "../bd-log-primitives"
+bd-runtime.path        = "../bd-runtime"
+bd-shutdown.path       = "../bd-shutdown"
+log.workspace          = true
+tokio.workspace        = true
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -5,11 +5,10 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::{MockCrashLogger, Monitor};
+use crate::Monitor;
 use bd_runtime::runtime::crash_handling::CrashDirectories;
 use bd_runtime::runtime::{ConfigLoader, FeatureFlag as _};
 use bd_shutdown::ComponentShutdownTrigger;
-use bd_test_helpers::make_mut;
 use bd_test_helpers::runtime::{ValueKind, make_simple_update};
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -19,7 +18,6 @@ struct Setup {
   monitor: Monitor,
   runtime: Arc<ConfigLoader>,
   _shutdown: ComponentShutdownTrigger,
-  crash_logger: Arc<MockCrashLogger>,
 }
 
 impl Setup {
@@ -28,26 +26,19 @@ impl Setup {
     std::fs::create_dir_all(directory.path().join("runtime")).unwrap();
     let runtime = ConfigLoader::new(&directory.path().join("runtime"));
     let shutdown = ComponentShutdownTrigger::default();
-    let crash_logger = Arc::new(MockCrashLogger::new());
 
-    let monitor = Monitor::new(
-      &runtime,
-      directory.path(),
-      crash_logger.clone(),
-      shutdown.make_shutdown(),
-    );
+    let monitor = Monitor::new(&runtime, directory.path(), shutdown.make_shutdown());
 
     Self {
       directory,
       monitor,
       runtime,
       _shutdown: shutdown,
-      crash_logger,
     }
   }
 
   fn make_crash(&self, name: &str, data: &[u8]) {
-    let crash_directory = self.directory.path().join("crashes/new");
+    let crash_directory = self.directory.path().join("reports/new");
     std::fs::create_dir_all(&crash_directory).unwrap();
     std::fs::write(crash_directory.join(name), data).unwrap();
   }
@@ -73,23 +64,37 @@ impl Setup {
 
 #[tokio::test]
 async fn crash_handling() {
-  let mut setup = Setup::new().await;
+  let setup = Setup::new().await;
 
   setup.monitor.try_ensure_directories_exist().await;
 
   setup.make_crash("crash1", b"crash1");
   setup.make_crash("crash2", b"crash2");
 
-  make_mut(&mut setup.crash_logger)
-    .expect_log_crash()
-    .withf(|data| data == b"crash1")
-    .return_const(());
-  make_mut(&mut setup.crash_logger)
-    .expect_log_crash()
-    .withf(|data| data == b"crash2")
-    .return_const(());
-
-  setup.monitor.process_new_reports().await;
+  let logs = setup.monitor.process_new_reports().await;
+  assert_eq!(2, logs.len());
+  assert_eq!(
+    b"crash1",
+    &logs[0]
+      .fields
+      .iter()
+      .find(|field| field.key == "_crash_artifact")
+      .unwrap()
+      .value
+      .as_bytes()
+      .unwrap()
+  );
+  assert_eq!(
+    b"crash2",
+    &logs[1]
+      .fields
+      .iter()
+      .find(|field| field.key == "_crash_artifact")
+      .unwrap()
+      .value
+      .as_bytes()
+      .unwrap()
+  );
 }
 
 #[tokio::test]

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -9,7 +9,6 @@ use crate::Monitor;
 use bd_runtime::runtime::crash_handling::CrashDirectories;
 use bd_runtime::runtime::{ConfigLoader, FeatureFlag as _};
 use bd_shutdown::ComponentShutdownTrigger;
-use bd_test_helpers::make_mut;
 use bd_test_helpers::runtime::{make_simple_update, ValueKind};
 use std::sync::Arc;
 use tempfile::TempDir;

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -9,7 +9,7 @@ use crate::Monitor;
 use bd_runtime::runtime::crash_handling::CrashDirectories;
 use bd_runtime::runtime::{ConfigLoader, FeatureFlag as _};
 use bd_shutdown::ComponentShutdownTrigger;
-use bd_test_helpers::runtime::{make_simple_update, ValueKind};
+use bd_test_helpers::runtime::{ValueKind, make_simple_update};
 use std::sync::Arc;
 use tempfile::TempDir;
 
@@ -71,8 +71,15 @@ async fn crash_handling() {
   setup.make_crash("crash1", b"crash1");
   setup.make_crash("crash2", b"crash2");
 
-  let logs = setup.monitor.process_new_reports().await;
+  let mut logs = setup.monitor.process_new_reports().await;
   assert_eq!(2, logs.len());
+  logs.sort_by_key(|log| {
+    log.fields[0]
+      .value
+      .clone()
+      .as_bytes()
+      .map(ToOwned::to_owned)
+  });
   assert_eq!(
     b"crash1",
     &logs[0]

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -9,7 +9,7 @@ use crate::Monitor;
 use bd_runtime::runtime::crash_handling::CrashDirectories;
 use bd_runtime::runtime::{ConfigLoader, FeatureFlag as _};
 use bd_shutdown::ComponentShutdownTrigger;
-use bd_test_helpers::runtime::{ValueKind, make_simple_update};
+use bd_test_helpers::runtime::{make_simple_update, ValueKind};
 use std::sync::Arc;
 use tempfile::TempDir;
 

--- a/bd-log-primitives/src/lib.rs
+++ b/bd-log-primitives/src/lib.rs
@@ -30,6 +30,14 @@ impl<T: AsRef<str>, B: AsRef<[u8]>> StringOrBytes<T, B> {
       Self::Bytes(_) => None,
     }
   }
+
+  /// Extracts the underlying bytes if the enum represents a Bytes, None otherwise.
+  pub fn as_bytes(&self) -> Option<&[u8]> {
+    match self {
+      Self::String(_) | Self::SharedString(_) => None,
+      Self::Bytes(b) => Some(b.as_ref()),
+    }
+  }
 }
 
 impl From<String> for StringOrBytes<String, Vec<u8>> {

--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -611,7 +611,10 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
 
           self = updated_self;
           if let Some(pre_config_log_buffer) = maybe_pre_config_buffer {
-            self.maybe_replay_pre_config_buffer_logs(pre_config_log_buffer, &mut initial_logs).await;
+            self.maybe_replay_pre_config_buffer_logs(
+                pre_config_log_buffer,
+                &mut initial_logs
+            ).await;
           }
         },
         Some(async_log_buffer_message) = self.communication_rx.recv() => {

--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -534,10 +534,25 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
   async fn maybe_replay_pre_config_buffer_logs(
     &mut self,
     pre_config_log_buffer: PreConfigBuffer<bd_log_primitives::Log>,
+    initial_logs: &mut Vec<Log>,
   ) {
     let LoggingState::Initialized(initialized_logging_context) = &mut self.logging_state else {
       return;
     };
+
+    for log_line in initial_logs.drain(..) {
+      if let Err(e) = self
+        .replayer
+        .replay_log(
+          log_line,
+          None,
+          &mut initialized_logging_context.processing_pipeline,
+        )
+        .await
+      {
+        log::debug!("failed to reply initial logs: {e}");
+      }
+    }
 
     for log_line in pre_config_log_buffer.pop_all() {
       if let Err(e) = self
@@ -554,16 +569,20 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
     }
   }
 
-  pub async fn run(self) -> Self {
+  pub async fn run(self, initial_logs: Vec<Log>) -> Self {
     let shutdown_trigger = ComponentShutdownTrigger::default();
     self
-      .run_with_shutdown(shutdown_trigger.make_shutdown())
+      .run_with_shutdown(shutdown_trigger.make_shutdown(), initial_logs)
       .await
   }
 
   // TODO(mattklein123): This seems to only be used for tests. Figure out how to clean this up
   // so we don't need this just for tests.
-  pub async fn run_with_shutdown(mut self, mut shutdown: ComponentShutdown) -> Self {
+  pub async fn run_with_shutdown(
+    mut self,
+    mut shutdown: ComponentShutdown,
+    mut initial_logs: Vec<Log>,
+  ) -> Self {
     // Processes incoming logs and reacts to workflows config updates.
     //
     // The first workflows config update makes the async log buffer disable
@@ -592,7 +611,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
 
           self = updated_self;
           if let Some(pre_config_log_buffer) = maybe_pre_config_buffer {
-            self.maybe_replay_pre_config_buffer_logs(pre_config_log_buffer).await;
+            self.maybe_replay_pre_config_buffer_logs(pre_config_log_buffer, &mut initial_logs).await;
           }
         },
         Some(async_log_buffer_message) = self.communication_rx.recv() => {

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -39,9 +39,9 @@ use bd_test_helpers::metadata_provider::LogMetadata;
 use bd_test_helpers::resource_utilization::EmptyTarget;
 use bd_test_helpers::runtime::{make_simple_update, ValueKind};
 use bd_test_helpers::session::InMemoryStorage;
-use bd_test_helpers::workflow::macros::{state, workflow};
+use bd_test_helpers::{state, workflow_proto};
 use bd_time::TimeDurationExt;
-use bd_workflows::config::WorkflowsConfiguration;
+use bd_workflows::config::{Config, WorkflowsConfiguration};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use time::ext::NumericalDuration;
@@ -782,7 +782,7 @@ async fn updates_workflow_engine_in_response_to_config_update() {
     assert_ok!(
       config_update_tx_clone.blocking_send(setup_clone.make_config_update(
         WorkflowsConfiguration::new_with_workflow_configurations_for_test(vec![
-          workflow!(exclusive with state!("a"))
+          Config::new(&workflow_proto!(exclusive with state!("a"))).unwrap()
         ])
       ))
     );

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -131,7 +131,7 @@ impl Setup {
   }
 
   fn make_real_async_log_buffer(
-    &mut self,
+    &self,
     config_update_rx: tokio::sync::mpsc::Receiver<ConfigUpdate>,
   ) -> (
     AsyncLogBuffer<LoggerReplay>,
@@ -532,7 +532,7 @@ async fn logs_are_replayed_in_order() {
 
 #[test]
 fn enqueuing_log_does_not_block() {
-  let mut setup = Setup::new();
+  let setup = Setup::new();
   setup.enable_workflows(true);
 
   let (_config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
@@ -578,7 +578,7 @@ fn take_screenshot_action() {
 
 #[test]
 fn enqueuing_log_blocks() {
-  let mut setup = Setup::new();
+  let setup = Setup::new();
   setup.enable_workflows(true);
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
@@ -622,7 +622,7 @@ fn enqueuing_log_blocks() {
 
 #[tokio::test]
 async fn creates_workflows_engine_in_response_to_config_update() {
-  let mut setup = Setup::new();
+  let setup = Setup::new();
   setup.enable_workflows(true);
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
@@ -686,7 +686,6 @@ async fn initial_logs_are_processed_first() {
   let (buffer, buffer_tx) = setup.make_test_async_log_buffer(config_update_rx);
 
   let t0 = datetime!(2021-01-01 00:00:00 UTC);
-  let t0_clone = t0.clone();
   let shutdown = setup.shutdown.as_ref().unwrap().make_shutdown();
 
   let handle = tokio::spawn(async move {
@@ -700,7 +699,7 @@ async fn initial_logs_are_processed_first() {
           fields: vec![],
           matching_fields: vec![],
           session_id: "first session".into(),
-          occurred_at: t0_clone,
+          occurred_at: t0,
         }],
       )
       .await;
@@ -739,7 +738,7 @@ async fn initial_logs_are_processed_first() {
 
 #[tokio::test]
 async fn updates_workflow_engine_in_response_to_config_update() {
-  let mut setup = Setup::new();
+  let setup = Setup::new();
   setup.enable_workflows(true);
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -374,7 +374,7 @@ async fn no_logs_are_lost() {
   }
 
   let run_buffer_task = tokio::task::spawn(async move {
-    _ = buffer.run().await;
+    _ = buffer.run(vec![]).await;
   });
 
   shutdown.store(true, Ordering::SeqCst);
@@ -479,7 +479,7 @@ async fn logs_are_replayed_in_order() {
   }
 
   let run_buffer_task = tokio::task::spawn(async move {
-    _ = buffer.run().await;
+    _ = buffer.run(vec![]).await;
   });
 
   shutdown.store(true, Ordering::SeqCst);
@@ -632,7 +632,7 @@ fn enqueuing_log_blocks() {
 
     let shutdown_trigger = ComponentShutdownTrigger::default();
     buffer
-      .run_with_shutdown(shutdown_trigger.make_shutdown())
+      .run_with_shutdown(shutdown_trigger.make_shutdown(), vec![])
       .await;
     shutdown_trigger.shutdown().await;
   });
@@ -687,7 +687,8 @@ async fn creates_workflows_engine_in_response_to_config_update() {
   );
 
   let shutdown_trigger = ComponentShutdownTrigger::default();
-  let handle = tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown()));
+  let handle =
+    tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown(), vec![]));
   1.seconds().sleep().await;
   shutdown_trigger.shutdown().await;
   buffer = handle.await.unwrap();
@@ -733,7 +734,7 @@ async fn does_not_create_workflows_engine_in_response_to_config_update_if_workfl
       .await
   );
 
-  buffer = buffer.run().await;
+  buffer = buffer.run(vec![]).await;
 
   assert_matches!(
     buffer.logging_state,
@@ -790,7 +791,8 @@ async fn updates_workflow_engine_in_response_to_config_update() {
   // Timeout as otherwise buffer's workflows engine continues to try
   // to periodically flush its state to disk which hold us stuck here.
   let shutdown_trigger = ComponentShutdownTrigger::default();
-  let handle = tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown()));
+  let handle =
+    tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown(), vec![]));
   1.seconds().sleep().await;
   shutdown_trigger.shutdown().await;
   buffer = handle.await.unwrap();
@@ -819,7 +821,8 @@ async fn updates_workflow_engine_in_response_to_config_update() {
   // Timeout as otherwise buffer's workflows engine continues to try
   // to periodically flush its state to disk which hold us stuck here.
   let shutdown_trigger = ComponentShutdownTrigger::default();
-  let handle = tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown()));
+  let handle =
+    tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown(), vec![]));
   1.seconds().sleep().await;
   shutdown_trigger.shutdown().await;
   buffer = handle.await.unwrap();
@@ -878,7 +881,8 @@ async fn stops_workflows_engine_if_workflows_runtime_flag_is_disabled() {
   // Timeout as otherwise buffer's workflows engine continues to try
   // to periodically flush its state to disk which hold us stuck here.
   let shutdown_trigger = ComponentShutdownTrigger::default();
-  let handle = tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown()));
+  let handle =
+    tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown(), vec![]));
   500.milliseconds().sleep().await;
   shutdown_trigger.shutdown().await;
   let buffer = handle.await.unwrap();
@@ -896,7 +900,8 @@ async fn stops_workflows_engine_if_workflows_runtime_flag_is_disabled() {
   // Timeout as otherwise buffer's workflows engine continues to try
   // to periodically flush its state to disk which hold us stuck here.
   let shutdown_trigger = ComponentShutdownTrigger::default();
-  let handle = tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown()));
+  let handle =
+    tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown(), vec![]));
   500.milliseconds().sleep().await;
   shutdown_trigger.shutdown().await;
   let buffer = handle.await.unwrap();
@@ -985,7 +990,8 @@ async fn logs_resource_utilization_log() {
   // Timeout as otherwise buffer's workflows engine continues to try
   // to periodically flush its state to disk which hold us stuck here.
   let shutdown_trigger = ComponentShutdownTrigger::default();
-  let handle = tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown()));
+  let handle =
+    tokio::task::spawn(buffer.run_with_shutdown(shutdown_trigger.make_shutdown(), vec![]));
   500.milliseconds().sleep().await;
 
   shutdown_trigger.shutdown().await;

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -7,7 +7,7 @@
 
 use super::AsyncLogBufferMessage;
 use crate::async_log_buffer::{AsyncLogBuffer, LogLine, LogReplay};
-use crate::bounded_buffer::MemorySized;
+use crate::bounded_buffer::{self, MemorySized};
 use crate::client_config::TailConfigurations;
 use crate::log_replay::{LoggerReplay, ProcessingPipeline};
 use crate::logging_state::{
@@ -32,7 +32,7 @@ use bd_proto::protos::filter::filter::FiltersConfiguration;
 use bd_runtime::runtime::{ConfigLoader, FeatureFlag};
 use bd_session::fixed::UUIDCallbacks;
 use bd_session::{fixed, Strategy};
-use bd_shutdown::{ComponentShutdownTrigger, ComponentShutdownTriggerHandle};
+use bd_shutdown::ComponentShutdownTrigger;
 use bd_stats_common::labels;
 use bd_test_helpers::events::NoOpListenerTarget;
 use bd_test_helpers::metadata_provider::LogMetadata;
@@ -45,17 +45,21 @@ use bd_workflows::config::{Config, WorkflowsConfiguration};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use time::ext::NumericalDuration;
-use time::Duration;
+use time::macros::datetime;
 use tokio::sync::oneshot::Sender;
 use tokio_test::assert_ok;
 
-#[derive(Clone)]
 struct Setup {
   buffer_manager: Arc<bd_buffer::Manager>,
   runtime: Arc<ConfigLoader>,
   stats: Collector,
   dynamic_counter_stats: Arc<DynamicStats>,
   tmp_dir: Arc<tempfile::TempDir>,
+
+  replayer_log_count: Arc<AtomicUsize>,
+  replayer_logs: Arc<parking_lot::Mutex<Vec<String>>>,
+  replayer_fields: Arc<parking_lot::Mutex<Vec<LogFields>>>,
+  shutdown: Option<ComponentShutdownTrigger>,
 }
 
 impl Setup {
@@ -76,7 +80,83 @@ impl Setup {
       stats: helper,
       dynamic_counter_stats,
       tmp_dir,
+      replayer_log_count: Arc::default(),
+      replayer_logs: Arc::default(),
+      replayer_fields: Arc::default(),
+      shutdown: Some(ComponentShutdownTrigger::default()),
     }
+  }
+
+  fn shutdown_in(&mut self, duration: time::Duration) {
+    let shutdown = self.shutdown.take().unwrap();
+    tokio::spawn(async move {
+      duration.sleep().await;
+      shutdown.shutdown().await;
+    });
+  }
+
+
+  fn make_test_async_log_buffer(
+    &mut self,
+    config_update_rx: tokio::sync::mpsc::Receiver<ConfigUpdate>,
+  ) -> (
+    AsyncLogBuffer<TestReplay>,
+    bounded_buffer::Sender<AsyncLogBufferMessage>,
+  ) {
+    let replayer = TestReplay::new();
+    self.replayer_log_count = replayer.logs_count.clone();
+    self.replayer_logs = replayer.logs.clone();
+    self.replayer_fields = replayer.fields.clone();
+
+    AsyncLogBuffer::new(
+      self.make_logging_context(),
+      replayer,
+      Arc::new(Strategy::Fixed(fixed::Strategy::new(
+        Arc::new(Store::new(Box::<InMemoryStorage>::default())),
+        Arc::new(UUIDCallbacks),
+      ))),
+      Arc::new(LogMetadata {
+        timestamp: time::OffsetDateTime::now_utc(),
+        fields: vec![],
+      }),
+      Box::new(EmptyTarget),
+      Box::new(bd_test_helpers::session_replay::NoOpTarget),
+      Box::new(NoOpListenerTarget),
+      config_update_rx,
+      self.shutdown.as_ref().unwrap().make_handle(),
+      &self.runtime,
+      Arc::new(SimpleNetworkQualityProvider::default()),
+      String::new(),
+    )
+  }
+
+  fn make_real_async_log_buffer(
+    &mut self,
+    config_update_rx: tokio::sync::mpsc::Receiver<ConfigUpdate>,
+  ) -> (
+    AsyncLogBuffer<LoggerReplay>,
+    bounded_buffer::Sender<AsyncLogBufferMessage>,
+  ) {
+    AsyncLogBuffer::new(
+      self.make_logging_context(),
+      LoggerReplay {},
+      Arc::new(Strategy::Fixed(fixed::Strategy::new(
+        Arc::new(Store::new(Box::<InMemoryStorage>::default())),
+        Arc::new(UUIDCallbacks),
+      ))),
+      Arc::new(LogMetadata {
+        timestamp: time::OffsetDateTime::now_utc(),
+        fields: vec![],
+      }),
+      Box::new(EmptyTarget),
+      Box::new(bd_test_helpers::session_replay::NoOpTarget),
+      Box::new(NoOpListenerTarget),
+      config_update_rx,
+      self.shutdown.as_ref().unwrap().make_handle(),
+      &self.runtime,
+      Arc::new(SimpleNetworkQualityProvider::default()),
+      String::new(),
+    )
   }
 
   fn make_logging_context(&self) -> UninitializedLoggingContext<Log> {
@@ -154,17 +234,6 @@ impl LogReplay for TestReplay {
 
     Ok(())
   }
-}
-
-fn make_shutdown(timeout: Duration) -> ComponentShutdownTriggerHandle {
-  let shutdown_trigger = ComponentShutdownTrigger::default();
-  let shutdown_trigger_handle = shutdown_trigger.make_handle();
-  std::thread::spawn(move || {
-    std::thread::sleep(timeout.unsigned_abs());
-    shutdown_trigger.shutdown_blocking();
-  });
-
-  shutdown_trigger_handle
 }
 
 #[test]
@@ -288,33 +357,10 @@ fn annotated_log_line_size_is_computed_correctly() {
 
 #[tokio::test]
 async fn no_logs_are_lost() {
-  let setup = Setup::new();
+  let mut setup = Setup::new();
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
-
-  let replayer = TestReplay::new();
-  let replayer_logs_count = replayer.logs_count.clone();
-
-  let (buffer, buffer_tx) = AsyncLogBuffer::new(
-    setup.make_logging_context(),
-    replayer,
-    Arc::new(Strategy::Fixed(fixed::Strategy::new(
-      Arc::new(Store::new(Box::<InMemoryStorage>::default())),
-      Arc::new(UUIDCallbacks),
-    ))),
-    Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: vec![],
-    }),
-    Box::new(EmptyTarget),
-    Box::new(bd_test_helpers::session_replay::NoOpTarget),
-    Box::new(NoOpListenerTarget),
-    config_update_rx,
-    make_shutdown(1.seconds()),
-    &setup.runtime,
-    Arc::new(SimpleNetworkQualityProvider::default()),
-    String::new(),
-  );
+  let (buffer, buffer_tx) = setup.make_test_async_log_buffer(config_update_rx);
 
   let written_logs_count = Arc::new(AtomicUsize::new(0));
   let shutdown = Arc::new(AtomicBool::new(false));
@@ -373,6 +419,8 @@ async fn no_logs_are_lost() {
     counted_logs += 1;
   }
 
+  setup.shutdown_in(1.seconds());
+
   let run_buffer_task = tokio::task::spawn(async move {
     _ = buffer.run(vec![]).await;
   });
@@ -388,40 +436,17 @@ async fn no_logs_are_lost() {
   assert!(written_logs_count.load(Ordering::SeqCst) > 0);
   assert_eq!(
     written_logs_count.load(Ordering::SeqCst),
-    replayer_logs_count.load(Ordering::SeqCst)
+    setup.replayer_log_count.load(Ordering::SeqCst)
   );
 }
 
 #[tokio::test]
 async fn logs_are_replayed_in_order() {
-  let setup = Setup::new();
+  let mut setup = Setup::new();
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
 
-  let replayer = TestReplay::new();
-  let replayer_logs = replayer.logs.clone();
-  let replayer_logs_count = replayer.logs_count.clone();
-
-  let (buffer, buffer_tx) = AsyncLogBuffer::new(
-    setup.make_logging_context(),
-    replayer,
-    Arc::new(Strategy::Fixed(fixed::Strategy::new(
-      Arc::new(Store::new(Box::<InMemoryStorage>::default())),
-      Arc::new(UUIDCallbacks),
-    ))),
-    Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: vec![],
-    }),
-    Box::new(EmptyTarget),
-    Box::new(bd_test_helpers::session_replay::NoOpTarget),
-    Box::new(NoOpListenerTarget),
-    config_update_rx,
-    make_shutdown(5.seconds()),
-    &setup.runtime,
-    Arc::new(SimpleNetworkQualityProvider::default()),
-    String::new(),
-  );
+  let (buffer, buffer_tx) = setup.make_test_async_log_buffer(config_update_rx);
 
   let written_logs = Arc::new(Mutex::new(vec![]));
   let shutdown = Arc::new(AtomicBool::new(false));
@@ -461,12 +486,11 @@ async fn logs_are_replayed_in_order() {
     }
   });
 
-  let setup_clone = setup.clone();
+  let config_update = setup.make_config_update(WorkflowsConfiguration::default());
   let config_update_task = std::thread::spawn(move || {
     // Send an initial workflows config update to allow
     // the async log buffer to start replaying buffered logs.
-    assert_ok!(config_update_tx
-      .blocking_send(setup_clone.make_config_update(WorkflowsConfiguration::default())));
+    assert_ok!(config_update_tx.blocking_send(config_update));
     drop(config_update_tx);
   });
 
@@ -477,6 +501,8 @@ async fn logs_are_replayed_in_order() {
     counting_logs_rx.recv().await.unwrap();
     counted_logs += 1;
   }
+
+  setup.shutdown_in(1.seconds());
 
   let run_buffer_task = tokio::task::spawn(async move {
     _ = buffer.run(vec![]).await;
@@ -494,41 +520,24 @@ async fn logs_are_replayed_in_order() {
   assert!(written_logs.len() > 0);
   assert_eq!(
     written_logs.len(),
-    replayer_logs_count.load(Ordering::SeqCst),
+    setup.replayer_log_count.load(Ordering::SeqCst),
   );
   for index in 0 .. written_logs.len() {
-    assert_eq!(written_logs[index], replayer_logs.lock()[index].as_str());
+    assert_eq!(
+      written_logs[index],
+      setup.replayer_logs.lock()[index].as_str()
+    );
   }
 }
 
 #[test]
 fn enqueuing_log_does_not_block() {
-  let setup = Setup::new();
+  let mut setup = Setup::new();
   setup.enable_workflows(true);
 
   let (_config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
 
-  let shutdown_trigger = ComponentShutdownTrigger::default();
-  let (mut _buffer, buffer_tx) = AsyncLogBuffer::new(
-    setup.make_logging_context(),
-    TestReplay::new(),
-    Arc::new(Strategy::Fixed(fixed::Strategy::new(
-      Arc::new(Store::new(Box::<InMemoryStorage>::default())),
-      Arc::new(UUIDCallbacks),
-    ))),
-    Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: vec![],
-    }),
-    Box::new(EmptyTarget),
-    Box::new(bd_test_helpers::session_replay::NoOpTarget),
-    Box::new(NoOpListenerTarget),
-    config_update_rx,
-    shutdown_trigger.make_handle(),
-    &setup.runtime,
-    Arc::new(SimpleNetworkQualityProvider::default()),
-    String::new(),
-  );
+  let (mut _buffer, buffer_tx) = setup.make_real_async_log_buffer(config_update_rx);
 
   let result = AsyncLogBuffer::<TestReplay>::enqueue_log(
     &buffer_tx,
@@ -546,32 +555,12 @@ fn enqueuing_log_does_not_block() {
 
 #[test]
 fn take_screenshot_action() {
-  let setup = Setup::new();
+  let mut setup = Setup::new();
   setup.enable_workflows(true);
 
   let (_config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
 
-  let shutdown_trigger = ComponentShutdownTrigger::default();
-  let (mut _buffer, buffer_tx) = AsyncLogBuffer::new(
-    setup.make_logging_context(),
-    TestReplay::new(),
-    Arc::new(Strategy::Fixed(fixed::Strategy::new(
-      Arc::new(Store::new(Box::<InMemoryStorage>::default())),
-      Arc::new(UUIDCallbacks),
-    ))),
-    Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: vec![],
-    }),
-    Box::new(EmptyTarget),
-    Box::new(bd_test_helpers::session_replay::NoOpTarget),
-    Box::new(NoOpListenerTarget),
-    config_update_rx,
-    shutdown_trigger.make_handle(),
-    &setup.runtime,
-    Arc::new(SimpleNetworkQualityProvider::default()),
-    String::new(),
-  );
+  let (mut _buffer, buffer_tx) = setup.make_test_async_log_buffer(config_update_rx);
 
   let result = AsyncLogBuffer::<TestReplay>::enqueue_log(
     &buffer_tx,
@@ -589,32 +578,12 @@ fn take_screenshot_action() {
 
 #[test]
 fn enqueuing_log_blocks() {
-  let setup = Setup::new();
+  let mut setup = Setup::new();
   setup.enable_workflows(true);
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
 
-  let shutdown_trigger = ComponentShutdownTrigger::default();
-  let (buffer, buffer_tx) = AsyncLogBuffer::new(
-    setup.make_logging_context(),
-    LoggerReplay {},
-    Arc::new(Strategy::Fixed(fixed::Strategy::new(
-      Arc::new(Store::new(Box::<InMemoryStorage>::default())),
-      Arc::new(UUIDCallbacks),
-    ))),
-    Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: vec![],
-    }),
-    Box::new(EmptyTarget),
-    Box::new(bd_test_helpers::session_replay::NoOpTarget),
-    Box::new(NoOpListenerTarget),
-    config_update_rx,
-    shutdown_trigger.make_handle(),
-    &setup.runtime,
-    Arc::new(SimpleNetworkQualityProvider::default()),
-    String::new(),
-  );
+  let (buffer, buffer_tx) = setup.make_real_async_log_buffer(config_update_rx);
 
   let rt = tokio::runtime::Runtime::new().unwrap();
   rt.spawn(async move {
@@ -653,31 +622,12 @@ fn enqueuing_log_blocks() {
 
 #[tokio::test]
 async fn creates_workflows_engine_in_response_to_config_update() {
-  let setup = Setup::new();
+  let mut setup = Setup::new();
   setup.enable_workflows(true);
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
 
-  let (mut buffer, _buffer_tx) = AsyncLogBuffer::new(
-    setup.make_logging_context(),
-    LoggerReplay {},
-    Arc::new(Strategy::Fixed(fixed::Strategy::new(
-      Arc::new(Store::new(Box::<InMemoryStorage>::default())),
-      Arc::new(UUIDCallbacks),
-    ))),
-    Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: vec![],
-    }),
-    Box::new(EmptyTarget),
-    Box::new(bd_test_helpers::session_replay::NoOpTarget),
-    Box::new(NoOpListenerTarget),
-    config_update_rx,
-    make_shutdown(1.seconds()),
-    &setup.runtime,
-    Arc::new(SimpleNetworkQualityProvider::default()),
-    String::new(),
-  );
+  let (mut buffer, _buffer_tx) = setup.make_real_async_log_buffer(config_update_rx);
 
   // Simulate config update.
   assert_ok!(
@@ -702,30 +652,11 @@ async fn creates_workflows_engine_in_response_to_config_update() {
 
 #[tokio::test]
 async fn does_not_create_workflows_engine_in_response_to_config_update_if_workflows_are_disabled() {
-  let setup = Setup::new();
+  let mut setup = Setup::new();
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
 
-  let (mut buffer, _buffer_tx) = AsyncLogBuffer::new(
-    setup.make_logging_context(),
-    LoggerReplay {},
-    Arc::new(Strategy::Fixed(fixed::Strategy::new(
-      Arc::new(Store::new(Box::<InMemoryStorage>::default())),
-      Arc::new(UUIDCallbacks),
-    ))),
-    Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: vec![],
-    }),
-    Box::new(EmptyTarget),
-    Box::new(bd_test_helpers::session_replay::NoOpTarget),
-    Box::new(NoOpListenerTarget),
-    config_update_rx,
-    make_shutdown(1.seconds()),
-    &setup.runtime,
-    Arc::new(SimpleNetworkQualityProvider::default()),
-    String::new(),
-  );
+  let (mut buffer, _buffer_tx) = setup.make_real_async_log_buffer(config_update_rx);
 
   // Simulate config update.
   assert_ok!(
@@ -733,6 +664,8 @@ async fn does_not_create_workflows_engine_in_response_to_config_update_if_workfl
       .send(setup.make_config_update(WorkflowsConfiguration::default()))
       .await
   );
+
+  setup.shutdown_in(1.seconds());
 
   buffer = buffer.run(vec![]).await;
 
@@ -743,49 +676,88 @@ async fn does_not_create_workflows_engine_in_response_to_config_update_if_workfl
   );
 }
 
+
+#[tokio::test]
+async fn initial_logs_are_processed_first() {
+  let mut setup = Setup::new();
+
+  let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
+
+  let (buffer, buffer_tx) = setup.make_test_async_log_buffer(config_update_rx);
+
+  let t0 = datetime!(2021-01-01 00:00:00 UTC);
+  let t0_clone = t0.clone();
+  let shutdown = setup.shutdown.as_ref().unwrap().make_shutdown();
+
+  let handle = tokio::spawn(async move {
+    buffer
+      .run_with_shutdown(
+        shutdown,
+        vec![Log {
+          log_level: log_level::ERROR,
+          log_type: LogType::Normal,
+          message: "first".into(),
+          fields: vec![],
+          matching_fields: vec![],
+          session_id: "first session".into(),
+          occurred_at: t0_clone,
+        }],
+      )
+      .await;
+  });
+
+  // One log is sent over the channel before the config update.
+
+  buffer_tx
+    .try_send(AsyncLogBufferMessage::EmitLog(LogLine {
+      log_level: log_level::INFO,
+      log_type: LogType::Normal,
+      message: "second".into(),
+      fields: vec![],
+      matching_fields: vec![],
+      attributes_overrides: None,
+      log_processing_completed_tx: None,
+    }))
+    .unwrap();
+
+  // Simulate config update.
+  assert_ok!(
+    config_update_tx
+      .send(setup.make_config_update(WorkflowsConfiguration::default()))
+      .await
+  );
+
+  setup.shutdown_in(1.seconds());
+
+  handle.await.unwrap();
+
+  let logs = setup.replayer_logs.lock().clone();
+  assert_eq!(2, logs.len());
+  assert_eq!("first", logs[0].as_str());
+  assert_eq!("second", logs[1].as_str());
+}
+
 #[tokio::test]
 async fn updates_workflow_engine_in_response_to_config_update() {
-  let setup = Setup::new();
+  let mut setup = Setup::new();
   setup.enable_workflows(true);
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
-  let shutdown_trigger = ComponentShutdownTrigger::default();
-  let (mut buffer, _) = AsyncLogBuffer::new(
-    setup.make_logging_context(),
-    LoggerReplay {},
-    Arc::new(Strategy::Fixed(fixed::Strategy::new(
-      Arc::new(Store::new(Box::<InMemoryStorage>::default())),
-      Arc::new(UUIDCallbacks),
-    ))),
-    Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: vec![],
-    }),
-    Box::new(EmptyTarget),
-    Box::new(bd_test_helpers::session_replay::NoOpTarget),
-    Box::new(NoOpListenerTarget),
-    config_update_rx,
-    shutdown_trigger.make_handle(),
-    &setup.runtime,
-    Arc::new(SimpleNetworkQualityProvider::default()),
-    String::new(),
-  );
-
-  let setup_clone = setup.clone();
+  let (mut buffer, _) = setup.make_real_async_log_buffer(config_update_rx);
   let config_update_tx_clone = config_update_tx.clone();
 
+  let config_update1 = setup.make_config_update(WorkflowsConfiguration::default());
+  let config_update2 = setup.make_config_update(
+    WorkflowsConfiguration::new_with_workflow_configurations_for_test(vec![Config::new(
+      &workflow_proto!(exclusive with state!("a")),
+    )
+    .unwrap()]),
+  );
   let task = std::thread::spawn(move || {
     // Simulate config update with no workflows.
-    assert_ok!(config_update_tx_clone
-      .blocking_send(setup_clone.make_config_update(WorkflowsConfiguration::default())));
+    assert_ok!(config_update_tx_clone.blocking_send(config_update1));
     // Simulate config update with one workflow.
-    assert_ok!(
-      config_update_tx_clone.blocking_send(setup_clone.make_config_update(
-        WorkflowsConfiguration::new_with_workflow_configurations_for_test(vec![
-          Config::new(&workflow_proto!(exclusive with state!("a"))).unwrap()
-        ])
-      ))
-    );
+    assert_ok!(config_update_tx_clone.blocking_send(config_update2));
   });
 
   // Timeout as otherwise buffer's workflows engine continues to try
@@ -811,11 +783,10 @@ async fn updates_workflow_engine_in_response_to_config_update() {
     labels! { "operation" => "start" },
   );
 
-  let setup_clone = setup.clone();
+  let config_update = setup.make_config_update(WorkflowsConfiguration::default());
   let task = std::thread::spawn(move || {
     // Config push disables workflow engine by pushing an empty workflow config.
-    assert_ok!(config_update_tx
-      .blocking_send(setup_clone.make_config_update(WorkflowsConfiguration::default())));
+    assert_ok!(config_update_tx.blocking_send(config_update));
   });
 
   // Timeout as otherwise buffer's workflows engine continues to try
@@ -871,11 +842,10 @@ async fn stops_workflows_engine_if_workflows_runtime_flag_is_disabled() {
     String::new(),
   );
 
-  let setup_clone = setup.clone();
+  let config_update = setup.make_config_update(WorkflowsConfiguration::default());
   let task = std::thread::spawn(move || {
     // Config push disables workflow engine by pushing an empty workflow config.
-    assert_ok!(config_update_tx
-      .blocking_send(setup_clone.make_config_update(WorkflowsConfiguration::default())));
+    assert_ok!(config_update_tx.blocking_send(config_update));
   });
 
   // Timeout as otherwise buffer's workflows engine continues to try
@@ -915,37 +885,12 @@ async fn stops_workflows_engine_if_workflows_runtime_flag_is_disabled() {
 
 #[tokio::test]
 async fn logs_resource_utilization_log() {
-  let setup = Setup::new();
+  let mut setup = Setup::new();
   setup.enable_workflows(true);
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
 
-  let replayer = TestReplay::new();
-  let replayer_logs_count = replayer.logs_count.clone();
-  let replayer_logs = replayer.logs.clone();
-  let replayer_fields = replayer.fields.clone();
-
-  let shutdown_trigger = ComponentShutdownTrigger::default();
-  let (buffer, sender) = AsyncLogBuffer::new(
-    setup.make_logging_context(),
-    replayer,
-    Arc::new(Strategy::Fixed(fixed::Strategy::new(
-      Arc::new(Store::new(Box::<InMemoryStorage>::default())),
-      Arc::new(UUIDCallbacks),
-    ))),
-    Arc::new(LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: vec![],
-    }),
-    Box::new(EmptyTarget),
-    Box::new(bd_test_helpers::session_replay::NoOpTarget),
-    Box::new(NoOpListenerTarget),
-    config_update_rx,
-    shutdown_trigger.make_handle(),
-    &setup.runtime,
-    Arc::new(SimpleNetworkQualityProvider::default()),
-    String::new(),
-  );
+  let (buffer, sender) = setup.make_test_async_log_buffer(config_update_rx);
 
   setup
     .runtime
@@ -968,11 +913,10 @@ async fn logs_resource_utilization_log() {
       ),
     ]));
 
-  let setup_clone = setup.clone();
+  let config_update = setup.make_config_update(WorkflowsConfiguration::default());
   let task = std::thread::spawn(move || {
     // Config push disables workflow engine by pushing an empty workflow config.
-    assert_ok!(config_update_tx
-      .blocking_send(setup_clone.make_config_update(WorkflowsConfiguration::default())));
+    assert_ok!(config_update_tx.blocking_send(config_update));
   });
 
   let message = AsyncLogBufferMessage::EmitLog(LogLine {
@@ -1001,12 +945,12 @@ async fn logs_resource_utilization_log() {
 
   // There should be at least one periodic internal log reported by using >= to avoid flakes as
   // there are many time dependant things happening in this test.
-  assert!(replayer_logs_count.load(Ordering::SeqCst) >= 1);
-  assert_eq!("", replayer_logs.lock()[0]);
+  assert!(setup.replayer_log_count.load(Ordering::SeqCst) >= 1);
+  assert_eq!("", setup.replayer_logs.lock()[0]);
 
   // Confirm that internal fields are added if enabled.
-  assert!(replayer_fields.lock().len() > 0);
-  assert!(replayer_fields.lock()[0]
+  assert!(setup.replayer_fields.lock().len() > 0);
+  assert!(setup.replayer_fields.lock()[0]
     .iter()
     .any(|f| f.key == "_logs_count"));
 }

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -255,7 +255,11 @@ impl LoggerBuilder {
     let session_strategy = self.params.session_strategy;
 
     let logger_future = async move {
-      // This is guaranteed to run before the initial configuration load, which means that
+      // By running it before we start all the other components, we ensure that the crash is
+      // processed before cached configuration is loaded, allowing us to pass a fixed set of logs
+      // to the async buffer that it can emit once it transitions into the configured mode,
+      // emitting these logs before any logs emitted by the application while we were starting
+      // up.
       let crash_logs = crash_monitor
         .process_new_reports()
         .await

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -252,7 +252,7 @@ impl LoggerBuilder {
 
     bd_client_common::error::UnexpectedErrorHandler::register_stats(&scope);
 
-    let session_strategy = self.params.session_strategy.clone();
+    let session_strategy = self.params.session_strategy;
 
     let logger_future = async move {
       // This is guaranteed to run before the initial configuration load, which means that

--- a/bd-logger/src/test/crash_handler_integration.rs
+++ b/bd-logger/src/test/crash_handler_integration.rs
@@ -6,18 +6,21 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use super::setup::Setup;
+use crate::test::setup::SetupOptions;
 use crate::wait_for;
 use assert_matches::assert_matches;
 use bd_runtime::runtime::crash_handling::CrashDirectories;
 use bd_runtime::runtime::FeatureFlag;
-use bd_test_helpers::metadata_provider::LogMetadata;
 use bd_test_helpers::runtime::{make_simple_update, ValueKind};
 use time::ext::{NumericalDuration, NumericalStdDuration};
 
 #[test]
 fn crash_reports() {
   let (directory, initial_session_id) = {
-    let setup = Setup::new();
+    let setup = Setup::new_with_options(SetupOptions {
+      disk_storage: true,
+      ..Default::default()
+    });
 
     std::fs::create_dir_all(setup.sdk_directory.path().join("reports/new")).unwrap();
 
@@ -33,13 +36,11 @@ fn crash_reports() {
     )
   };
 
-  let mut setup = Setup::new_with_directory(
-    directory,
-    LogMetadata {
-      timestamp: time::OffsetDateTime::now_utc(),
-      fields: Vec::new(),
-    },
-  );
+  let mut setup = Setup::new_with_options(SetupOptions {
+    sdk_directory: directory,
+    disk_storage: true,
+    ..Default::default()
+  });
 
   assert_ne!(
     initial_session_id,

--- a/bd-test-helpers/src/session.rs
+++ b/bd-test-helpers/src/session.rs
@@ -19,6 +19,7 @@ pub struct DiskStorage {
 }
 
 impl DiskStorage {
+  #[must_use]
   pub fn new(root: PathBuf) -> Self {
     std::fs::create_dir_all(&root).unwrap();
 

--- a/bd-test-helpers/src/session.rs
+++ b/bd-test-helpers/src/session.rs
@@ -13,6 +13,8 @@ use std::path::PathBuf;
 // DiskStorage
 //
 
+// A simple disk-based key-value store to be used to simulate a real-world persisted storage
+// solution, allowing it to be scoped within the SDK directory.
 #[derive(Default)]
 pub struct DiskStorage {
   root: parking_lot::Mutex<PathBuf>,

--- a/bd-test-helpers/src/workflow.rs
+++ b/bd-test-helpers/src/workflow.rs
@@ -52,8 +52,6 @@ use protos::workflow::workflow::workflow::{
 };
 use std::collections::BTreeMap;
 
-
-
 #[allow(clippy::module_inception)]
 pub mod macros {
   #[macro_export]

--- a/bd-test-helpers/src/workflow.rs
+++ b/bd-test-helpers/src/workflow.rs
@@ -54,18 +54,6 @@ use std::collections::BTreeMap;
 
 #[allow(clippy::module_inception)]
 pub mod macros {
-  #[macro_export]
-  #[allow(clippy::module_name_repetitions)]
-  /// A macro that creates a workflow config using provided states.
-  /// See `workflow_proto` macro for more details.
-  macro_rules! workflow {
-    ($($x:tt)*) => {
-      bd_workflows::config::Config::new(
-        &$crate::workflow::macros::workflow_proto!($($x)*)
-      ).unwrap()
-    }
-  }
-
   /// A macro that creates a workflow config proto using provided states.
   #[macro_export]
   #[allow(clippy::module_name_repetitions)]
@@ -418,7 +406,6 @@ pub mod macros {
     rule,
     sankey_value,
     state,
-    workflow,
     workflow_proto,
   };
 }


### PR DESCRIPTION
For crash handling we'll assume that any of the newly reported crashes are associated with the previous process run. This seems sane since we clean up all the crash reports on each start immediately, thus we'd have previously cleaned up any older reports. Since we only check for reports on startup this also means that the current session cannot have emitted this. 

To achieve the correct ordering, we introduce the idea of "initial logs" that are passed to the pre-config buffer that will be replayed after the initial config log but before any of the otherwise queued up logs. This ensures that the crash logs are the first logs processed during app start if they exist, allowing them to be associated with the correct session/workflow engine instance. 

Fixes BIT-4827