### PR TITLE
allow creating a StreamHandle from a raw stream_id and server handle

### DIFF
--- a/bd-test-helpers/src/test_api_server.rs
+++ b/bd-test-helpers/src/test_api_server.rs
@@ -929,6 +929,15 @@ pub struct StreamHandle {
 
 impl StreamHandle {
   #[must_use]
+  pub fn from_stream_id(stream_id: i32, server: &ServerHandle) -> Self {
+    Self {
+      stream_id,
+      timed_event_wait_tx: Sender::clone(&server.timed_event_wait_tx),
+      stream_action_tx: Sender::clone(&server.stream_action_tx),
+    }
+  }
+
+  #[must_use]
   pub const fn id(&self) -> i32 {
     self.stream_id
   }


### PR DESCRIPTION
In the platform tests we marshal the stream as an integer into platform code, this should allow us to convert it back to a StreamHandle