### PR TITLE
extract timestamp from start of crash artifact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,7 @@ dependencies = [
  "log",
  "mockall",
  "tempfile",
+ "time",
  "tokio",
 ]
 

--- a/bd-crash-handler/Cargo.toml
+++ b/bd-crash-handler/Cargo.toml
@@ -15,6 +15,7 @@ bd-log-primitives.path = "../bd-log-primitives"
 bd-runtime.path        = "../bd-runtime"
 bd-shutdown.path       = "../bd-shutdown"
 log.workspace          = true
+time.workspace         = true
 tokio.workspace        = true
 
 [dev-dependencies]

--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -37,7 +37,7 @@ const DETAILS_INFERENCE_CONFIG_FILE: &str = "details_inference";
 /// A single crash log to be emitted by the crash logger.
 pub struct CrashLog {
   pub fields: LogFields,
-  pub timestamp: Option<OffsetDateTime>,
+  pub timestamp: OffsetDateTime,
 }
 
 //
@@ -280,7 +280,9 @@ impl Monitor {
 
               OffsetDateTime::from_unix_timestamp(timestamp).ok()
             })
-          });
+          })
+          .unwrap_or_else(OffsetDateTime::now_utc);
+
         let (crash_reason, crash_details) =
           Self::guess_crash_details(&contents, &crash_reason_paths, &crash_details_paths);
 

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -315,7 +315,9 @@ impl LoggerBuilder {
           session_id: session_strategy
             .previous_process_session_id()
             .unwrap_or_else(|| session_strategy.session_id()),
-          occurred_at: OffsetDateTime::now_utc(),
+          occurred_at: crash_log
+            .timestamp
+            .unwrap_or_else(|| OffsetDateTime::now_utc()),
         })
         .collect();
 

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -317,7 +317,7 @@ impl LoggerBuilder {
             .unwrap_or_else(|| session_strategy.session_id()),
           occurred_at: crash_log
             .timestamp
-            .unwrap_or_else(|| OffsetDateTime::now_utc()),
+            .unwrap_or_else(OffsetDateTime::now_utc),
         })
         .collect();
 

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -28,7 +28,7 @@ use bd_time::SystemTimeProvider;
 use futures_util::{try_join, Future};
 use std::pin::Pin;
 use std::sync::Arc;
-use time::{Duration, OffsetDateTime};
+use time::Duration;
 
 pub fn default_stats_flush_triggers(
   runtime_loader: &ConfigLoader,

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -315,9 +315,7 @@ impl LoggerBuilder {
           session_id: session_strategy
             .previous_process_session_id()
             .unwrap_or_else(|| session_strategy.session_id()),
-          occurred_at: crash_log
-            .timestamp
-            .unwrap_or_else(OffsetDateTime::now_utc),
+          occurred_at: crash_log.timestamp.unwrap_or_else(OffsetDateTime::now_utc),
         })
         .collect();
 

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -315,7 +315,7 @@ impl LoggerBuilder {
           session_id: session_strategy
             .previous_process_session_id()
             .unwrap_or_else(|| session_strategy.session_id()),
-          occurred_at: crash_log.timestamp.unwrap_or_else(OffsetDateTime::now_utc),
+          occurred_at: crash_log.timestamp,
         })
         .collect();
 

--- a/bd-logger/src/test/crash_handler_integration.rs
+++ b/bd-logger/src/test/crash_handler_integration.rs
@@ -66,15 +66,18 @@ fn crash_reports() {
   assert_matches!(setup.server.blocking_next_log_upload(), Some(upload) => {
     assert_eq!(upload.logs().len(), 2);
 
-    assert_eq!(upload.logs()[0].message(), "App crashed");
-    assert_eq!(upload.logs()[0].binary_field("_crash_artifact"), b"crash2");
-    assert_eq!(upload.logs()[0].session_id(), initial_session_id);
-    assert_eq!(upload.logs()[0].timestamp(), timestamp);
+    let logs = upload.logs();
+    let crash1 = logs.iter().find(|log| log.binary_field("_crash_artifact") == b"crash1").unwrap();
+    assert_eq!(crash1.message(), "App crashed");
+    assert_eq!(crash1.binary_field("_crash_artifact"), b"crash2");
+    assert_eq!(crash1.session_id(), initial_session_id);
+    assert_eq!(crash1.timestamp(), timestamp);
 
-    assert_eq!(upload.logs()[1].message(), "App crashed");
-    assert_eq!(upload.logs()[1].binary_field("_crash_artifact"), b"crash1");
-    assert_eq!(upload.logs()[1].session_id(), initial_session_id);
-    assert_ne!(upload.logs()[1].timestamp(), timestamp);
+    let crash2 = logs.iter().find(|log| log.binary_field("_crash_artifact") == b"crash2").unwrap();
+    assert_eq!(crash2.message(), "App crashed");
+    assert_eq!(crash2.binary_field("_crash_artifact"), b"crash1");
+    assert_eq!(crash2.session_id(), initial_session_id);
+    assert_ne!(crash2.timestamp(), timestamp);
   });
 }
 

--- a/bd-logger/src/test/crash_handler_integration.rs
+++ b/bd-logger/src/test/crash_handler_integration.rs
@@ -69,15 +69,13 @@ fn crash_reports() {
     let logs = upload.logs();
     let crash1 = logs.iter().find(|log| log.binary_field("_crash_artifact") == b"crash1").unwrap();
     assert_eq!(crash1.message(), "App crashed");
-    assert_eq!(crash1.binary_field("_crash_artifact"), b"crash2");
     assert_eq!(crash1.session_id(), initial_session_id);
-    assert_eq!(crash1.timestamp(), timestamp);
+    assert_ne!(crash1.timestamp(), timestamp);
 
     let crash2 = logs.iter().find(|log| log.binary_field("_crash_artifact") == b"crash2").unwrap();
     assert_eq!(crash2.message(), "App crashed");
-    assert_eq!(crash2.binary_field("_crash_artifact"), b"crash1");
     assert_eq!(crash2.session_id(), initial_session_id);
-    assert_ne!(crash2.timestamp(), timestamp);
+    assert_eq!(crash2.timestamp(), timestamp);
   });
 }
 


### PR DESCRIPTION
Attempts to look for {timestamp}_ at the start of the crash file,
emitting this as the timestamp if parsing succeeded