### PR TITLE
use two distinct maps for custom and ootb logs 

### DIFF
--- a/bd-log-metadata/src/lib.rs
+++ b/bd-log-metadata/src/lib.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-pub use bd_log_primitives::{AnnotatedLogFields, LogFieldKind};
+pub use bd_log_primitives::LogFields;
 
 //
 // MetadataProvider
@@ -16,6 +16,6 @@ pub trait MetadataProvider {
   /// Returns the timestamp to associate with the log message.
   fn timestamp(&self) -> anyhow::Result<time::OffsetDateTime>;
 
-  /// Returns fields to include with each log message.
-  fn fields(&self) -> anyhow::Result<AnnotatedLogFields>;
+  /// Returns custom and ootb fields to include with each log message.
+  fn fields(&self) -> anyhow::Result<(LogFields, LogFields)>;
 }

--- a/bd-log-primitives/src/lib.rs
+++ b/bd-log-primitives/src/lib.rs
@@ -9,7 +9,6 @@ use ahash::AHashMap;
 pub use bd_proto::flatbuffers::buffer_log::bitdrift_public::fbs::logging::v_1::LogType;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 pub const LOG_FIELD_NAME_TYPE: &str = "log_type";
@@ -118,7 +117,7 @@ pub type LogFieldValue = StringOrBytes<String, Vec<u8>>;
 //
 
 /// The list of log fields annotated with extra information.
-pub type AnnotatedLogFields = HashMap<LogFieldKey, AnnotatedLogField>;
+pub type AnnotatedLogFields = AHashMap<LogFieldKey, AnnotatedLogField>;
 
 //
 // LogFields

--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -23,10 +23,11 @@ use anyhow::anyhow;
 use bd_buffer::BuffersWithAck;
 use bd_client_common::error::{handle_unexpected, handle_unexpected_error_with_details};
 use bd_device::Store;
-use bd_log_metadata::{AnnotatedLogFields, MetadataProvider};
+use bd_log_metadata::MetadataProvider;
 use bd_log_primitives::{
   log_level,
   AnnotatedLogField,
+  AnnotatedLogFields,
   Log,
   LogFieldValue,
   LogFields,
@@ -137,6 +138,12 @@ impl MemorySized for bd_log_primitives::Log {
       + self.fields.size()
       + self.matching_fields.size()
       + self.session_id.len()
+  }
+}
+
+impl MemorySized for AnnotatedLogFields {
+  fn size(&self) -> usize {
+    self.iter().map(|(k, v)| k.len() + v.size()).sum::<usize>()
   }
 }
 

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -17,8 +17,14 @@ use bd_client_stats_store::test::StatsHelper;
 use bd_client_stats_store::Collector;
 use bd_key_value::Store;
 use bd_log_filter::FilterChain;
-use bd_log_metadata::AnnotatedLogFields;
-use bd_log_primitives::{log_level, AnnotatedLogField, Log, LogFields, StringOrBytes};
+use bd_log_primitives::{
+  log_level,
+  AnnotatedLogField,
+  AnnotatedLogFields,
+  Log,
+  LogFields,
+  StringOrBytes,
+};
 use bd_matcher::buffer_selector::BufferSelector;
 use bd_proto::flatbuffers::buffer_log::bitdrift_public::fbs::logging::v_1::LogType;
 use bd_proto::protos::config::v1::config::BufferConfigList;
@@ -233,7 +239,7 @@ fn log_line_size_is_computed_correctly() {
     }
   }
 
-  let baseline_log_expected_size = 463;
+  let baseline_log_expected_size = 234;
   let baseline_log = create_baseline_log();
   assert_eq!(baseline_log_expected_size, baseline_log.size());
 

--- a/bd-logger/src/bounded_buffer/size.rs
+++ b/bd-logger/src/bounded_buffer/size.rs
@@ -5,7 +5,6 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use bd_log_metadata::AnnotatedLogFields;
 use bd_log_primitives::{AnnotatedLogField, LogFieldKey, LogFieldValue, LogFields, StringOrBytes};
 use std::borrow::Cow;
 use std::mem::{size_of, size_of_val};
@@ -39,16 +38,6 @@ impl MemorySized for LogFieldKey {
 }
 
 impl MemorySized for LogFields {
-  fn size(&self) -> usize {
-    let empty_reserved_mem =
-      (self.capacity() - self.len()) * size_of::<(String, StringOrBytes<String, Vec<u8>>)>();
-    size_of_val(self)
-      + self.iter().map(|(k, v)| k.size() + v.size()).sum::<usize>()
-      + empty_reserved_mem
-  }
-}
-
-impl MemorySized for AnnotatedLogFields {
   fn size(&self) -> usize {
     let empty_reserved_mem =
       (self.capacity() - self.len()) * size_of::<(String, StringOrBytes<String, Vec<u8>>)>();

--- a/bd-logger/src/device_id.rs
+++ b/bd-logger/src/device_id.rs
@@ -5,8 +5,14 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use bd_log_metadata::AnnotatedLogFields;
-use bd_log_primitives::{AnnotatedLogField, LogInterceptor, LogLevel, LogMessage, LogType};
+use bd_log_primitives::{
+  AnnotatedLogField,
+  AnnotatedLogFields,
+  LogInterceptor,
+  LogLevel,
+  LogMessage,
+  LogType,
+};
 use std::sync::Arc;
 
 //

--- a/bd-logger/src/internal_report.rs
+++ b/bd-logger/src/internal_report.rs
@@ -5,8 +5,14 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use bd_log_metadata::AnnotatedLogFields;
-use bd_log_primitives::{AnnotatedLogField, LogInterceptor, LogLevel, LogMessage, LogType};
+use bd_log_primitives::{
+  AnnotatedLogField,
+  AnnotatedLogFields,
+  LogInterceptor,
+  LogLevel,
+  LogMessage,
+  LogType,
+};
 use bd_runtime::runtime::{debugging, BoolWatch, ConfigLoader};
 
 //

--- a/bd-logger/src/lib.rs
+++ b/bd-logger/src/lib.rs
@@ -32,10 +32,11 @@ pub use async_log_buffer::LogAttributesOverridesPreviousRunSessionID;
 pub use bd_api::{PlatformNetworkManager, PlatformNetworkStream};
 pub use bd_device::Device;
 pub use bd_events::ListenerTarget as EventsListenerTarget;
-pub use bd_log_metadata::{AnnotatedLogFields, MetadataProvider};
+pub use bd_log_metadata::MetadataProvider;
 pub use bd_log_primitives::{
   log_level,
   AnnotatedLogField,
+  AnnotatedLogFields,
   FieldsRef,
   LogFieldKind,
   LogFieldValue,

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -21,8 +21,14 @@ use crate::{app_version, MetadataProvider};
 use bd_api::Metadata;
 use bd_client_stats_store::Scope;
 use bd_log::warn_every;
-use bd_log_metadata::AnnotatedLogFields;
-use bd_log_primitives::{log_level, AnnotatedLogField, LogFieldValue, LogLevel, LogMessage};
+use bd_log_primitives::{
+  log_level,
+  AnnotatedLogField,
+  AnnotatedLogFields,
+  LogFieldValue,
+  LogLevel,
+  LogMessage,
+};
 use bd_proto::flatbuffers::buffer_log::bitdrift_public::fbs::logging::v_1::LogType;
 use bd_runtime::runtime::Snapshot;
 use bd_session_replay::SESSION_REPLAY_SCREENSHOT_LOG_MESSAGE;

--- a/bd-logger/src/metadata.rs
+++ b/bd-logger/src/metadata.rs
@@ -11,8 +11,8 @@ mod metadata_test;
 
 use crate::global_state::Tracker;
 use bd_log::warn_every;
-use bd_log_metadata::{AnnotatedLogFields, LogFieldKind, MetadataProvider};
-use bd_log_primitives::{LogFieldKey, LogFieldValue, LogFields};
+use bd_log_metadata::MetadataProvider;
+use bd_log_primitives::{AnnotatedLogFields, LogFieldKey, LogFieldKind, LogFieldValue, LogFields};
 use bd_proto::flatbuffers::buffer_log::bitdrift_public::fbs::logging::v_1::LogType;
 use itertools::Itertools;
 use std::collections::BTreeSet;
@@ -79,10 +79,22 @@ impl MetadataCollector {
   ) -> anyhow::Result<LogMetadata> {
     let timestamp = self.metadata_provider.timestamp()?;
 
-    let provider_fields = self.metadata_provider.fields()?;
-    let provider_fields = partition_fields(provider_fields);
-    global_state_tracker.maybe_update_global_state(&provider_fields.ootb);
+    let (custom_fields, ootb_fields) = self.metadata_provider.fields()?;
+    global_state_tracker.maybe_update_global_state(&ootb_fields);
 
+    let provider_fields = PartitionedFields {
+      ootb: ootb_fields,
+      custom: custom_fields
+        .into_iter()
+        .filter(|field| match verify_custom_field_name(&field.0) {
+          Ok(_) => true,
+          Err(e) => {
+            warn_every!(15.seconds(), "failed to process field: {:?}", e);
+            false
+          },
+        })
+        .collect(),
+    };
     // Attach field provider's fields to session replay, resource logs, and internal SDK logs
     // as matching fields as opposed to 'normal' fields to save on bandwidth usage while still
     // allowing matching on them.

--- a/bd-logger/src/metadata.rs
+++ b/bd-logger/src/metadata.rs
@@ -87,7 +87,7 @@ impl MetadataCollector {
       custom: custom_fields
         .into_iter()
         .filter(|field| match verify_custom_field_name(&field.0) {
-          Ok(_) => true,
+          Ok(()) => true,
           Err(e) => {
             warn_every!(15.seconds(), "failed to process field: {:?}", e);
             false

--- a/bd-logger/src/metadata_test.rs
+++ b/bd-logger/src/metadata_test.rs
@@ -21,7 +21,8 @@ use std::sync::Arc;
 fn collector_attaches_provider_fields_as_matching_fields() {
   let metadata = LogMetadata {
     timestamp: Mutex::new(time::OffsetDateTime::now_utc()),
-    fields: [("key".into(), AnnotatedLogField::new_ootb("provider_value"))].into(),
+    ootb_fields: [("key".into(), "provider_value".into())].into(),
+    ..Default::default()
   };
 
   let collector = MetadataCollector::new(Arc::new(metadata));
@@ -65,31 +66,16 @@ fn collector_attaches_provider_fields_as_matching_fields() {
 fn collector_fields_hierarchy() {
   let metadata = LogMetadata {
     timestamp: Mutex::new(time::OffsetDateTime::now_utc()),
-    fields: [
-      (
-        "custom_provider_key".into(),
-        AnnotatedLogField::new_custom(StringOrBytes::String("custom_provider_value".into())),
-      ),
-      (
-        "ootb_provider_key_1".into(),
-        AnnotatedLogField::new_ootb(StringOrBytes::String("ootb_provider_value_1".into())),
-      ),
-      (
-        "ootb_provider_key_2".into(),
-        AnnotatedLogField::new_ootb(StringOrBytes::String("ootb_provider_value_2".into())),
-      ),
-      (
-        "provider_key".into(),
-        AnnotatedLogField::new_custom(StringOrBytes::String("custom_provider_value".into())),
-      ),
-      (
-        "provider_key".into(),
-        AnnotatedLogField::new_ootb(StringOrBytes::String("ootb_provider_value".into())),
-      ),
-      (
-        "collector_key".into(),
-        AnnotatedLogField::new_custom(StringOrBytes::String("custom_provider_value".into())),
-      ),
+    custom_fields: [
+      ("custom_provider_key".into(), "custom_provider_value".into()),
+      ("provider_key".into(), "custom_provider_value".into()),
+      ("collector_key".into(), "custom_provider_value".into()),
+    ]
+    .into(),
+    ootb_fields: [
+      ("ootb_provider_key_1".into(), "ootb_provider_value_1".into()),
+      ("ootb_provider_key_2".into(), "ootb_provider_value_2".into()),
+      ("provider_key".into(), "ootb_provider_value".into()),
     ]
     .into(),
   };
@@ -170,17 +156,12 @@ fn collector_fields_hierarchy() {
 fn collector_does_not_accept_reserved_fields() {
   let metadata = LogMetadata {
     timestamp: Mutex::new(time::OffsetDateTime::now_utc()),
-    fields: [
-      (
-        "_custom_provider_key".into(),
-        AnnotatedLogField::new_custom("custom_provider_value"),
-      ),
-      (
-        "_ootb_provider_key".into(),
-        AnnotatedLogField::new_ootb("ootb_provider_value"),
-      ),
-    ]
+    custom_fields: [(
+      "_custom_provider_key".into(),
+      "custom_provider_value".into(),
+    )]
     .into(),
+    ootb_fields: [("_ootb_provider_key".into(), "ootb_provider_value".into())].into(),
   };
 
   let mut collector = MetadataCollector::new(Arc::new(metadata));
@@ -215,7 +196,7 @@ fn collector_does_not_accept_reserved_fields() {
 fn collector_fields_management() {
   let metadata = LogMetadata {
     timestamp: Mutex::new(time::OffsetDateTime::now_utc()),
-    fields: [].into(),
+    ..Default::default()
   };
 
   let mut collector = MetadataCollector::new(Arc::new(metadata));

--- a/bd-logger/src/network.rs
+++ b/bd-logger/src/network.rs
@@ -8,9 +8,9 @@
 #[cfg(test)]
 #[path = "./network_test.rs"]
 mod network_test;
-use bd_log_metadata::AnnotatedLogFields;
 use bd_log_primitives::{
   AnnotatedLogField,
+  AnnotatedLogFields,
   LogFieldKey,
   LogInterceptor,
   LogLevel,

--- a/bd-logger/src/network_test.rs
+++ b/bd-logger/src/network_test.rs
@@ -8,10 +8,10 @@
 use super::{NetworkQualityInterceptor, TimeProvider};
 use crate::network::HTTPTrafficDataUsageTracker;
 use bd_api::api::SimpleNetworkQualityProvider;
-use bd_log_metadata::AnnotatedLogFields;
 use bd_log_primitives::{
   log_level,
   AnnotatedLogField,
+  AnnotatedLogFields,
   LogInterceptor,
   LogMessage,
   LogType,

--- a/bd-logger/src/test/crash_handler_integration.rs
+++ b/bd-logger/src/test/crash_handler_integration.rs
@@ -9,7 +9,6 @@ use super::setup::Setup;
 use crate::test::setup::SetupOptions;
 use crate::wait_for;
 use assert_matches::assert_matches;
-use bd_log_primitives::AnnotatedLogField;
 use bd_runtime::runtime::crash_handling::CrashDirectories;
 use bd_runtime::runtime::FeatureFlag;
 use bd_test_helpers::metadata_provider::LogMetadata;
@@ -27,11 +26,8 @@ fn crash_reports() {
       disk_storage: true,
       metadata_provider: Arc::new(LogMetadata {
         timestamp: time::OffsetDateTime::now_utc().into(),
-        fields: [
-          ("_ootb_field".into(), AnnotatedLogField::new_ootb("ootb")),
-          ("custom".into(), AnnotatedLogField::new_custom("custom")),
-        ]
-        .into(),
+        ootb_fields: [("_ootb_field".into(), "ootb".into())].into(),
+        custom_fields: [("custom".into(), "custom".into())].into(),
       }),
       ..Default::default()
     });

--- a/bd-logger/src/test/embedded_logger_integration.rs
+++ b/bd-logger/src/test/embedded_logger_integration.rs
@@ -8,7 +8,7 @@
 use crate::{log_level, InitParams, LogType, Logger, MetadataProvider};
 use assert_matches::assert_matches;
 use bd_key_value::Store;
-use bd_log_metadata::AnnotatedLogFields;
+use bd_log_metadata::LogFields;
 use bd_proto::protos::client::api::RuntimeUpdate;
 use bd_proto::protos::client::runtime::runtime::{value, Value};
 use bd_proto::protos::client::runtime::Runtime;
@@ -38,8 +38,8 @@ impl MetadataProvider for TestMetadataProvider {
     Ok(time::OffsetDateTime::now_utc())
   }
 
-  fn fields(&self) -> anyhow::Result<AnnotatedLogFields> {
-    Ok(AnnotatedLogFields::default())
+  fn fields(&self) -> anyhow::Result<(LogFields, LogFields)> {
+    Ok((LogFields::default(), LogFields::default()))
   }
 }
 

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -139,7 +139,7 @@ fn log_upload_attributes_override() {
   let time_first = time::OffsetDateTime::now_utc();
   let mut setup = Setup::new_with_metadata(Arc::new(LogMetadata {
     timestamp: Mutex::new(time_first),
-    fields: [].into(),
+    ..Default::default()
   }));
 
   setup.send_configuration_update(
@@ -783,14 +783,8 @@ fn workflow_flush_buffers_action_emits_synthetic_log_and_uploads_buffer_and_star
 
   let mut setup = Setup::new_with_metadata(Arc::new(LogMetadata {
     timestamp: Mutex::new(time::OffsetDateTime::now_utc()),
-    fields: [
-      (
-        "k1".into(),
-        AnnotatedLogField::new_custom("provider_value_1"),
-      ),
-      ("k2".into(), AnnotatedLogField::new_ootb("provider_value_2")),
-    ]
-    .into(),
+    custom_fields: [("k1".into(), "provider_value_1".into())].into(),
+    ootb_fields: [("k2".into(), "provider_value_2".into())].into(),
   }));
 
   // Send down a configuration with a single buffer ('default')
@@ -921,7 +915,7 @@ fn workflow_flush_buffers_action_emits_synthetic_log_and_uploads_buffer_and_star
 fn workflow_generate_log_to_histogram() {
   let metadata = Arc::new(LogMetadata {
     timestamp: Mutex::new(datetime!(2023-10-01 00:00:00 UTC)),
-    fields: [].into(),
+    ..Default::default()
   });
   let mut setup = Setup::new_with_metadata(metadata.clone());
   setup.send_runtime_update();

--- a/bd-test-helpers/src/metadata_provider.rs
+++ b/bd-test-helpers/src/metadata_provider.rs
@@ -5,12 +5,13 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use bd_log_metadata::{AnnotatedLogFields, MetadataProvider};
+use bd_log_metadata::{LogFields, MetadataProvider};
 use parking_lot::Mutex;
 
 pub struct LogMetadata {
   pub timestamp: Mutex<time::OffsetDateTime>,
-  pub fields: AnnotatedLogFields,
+  pub custom_fields: LogFields,
+  pub ootb_fields: LogFields,
 }
 
 impl MetadataProvider for LogMetadata {
@@ -18,8 +19,8 @@ impl MetadataProvider for LogMetadata {
     Ok(*self.timestamp.lock())
   }
 
-  fn fields(&self) -> anyhow::Result<AnnotatedLogFields> {
-    Ok(self.fields.clone())
+  fn fields(&self) -> anyhow::Result<(LogFields, LogFields)> {
+    Ok((self.custom_fields.clone(), self.ootb_fields.clone()))
   }
 }
 
@@ -27,7 +28,8 @@ impl Default for LogMetadata {
   fn default() -> Self {
     Self {
       timestamp: Mutex::new(time::OffsetDateTime::now_utc()),
-      fields: AnnotatedLogFields::default(),
+      custom_fields: LogFields::default(),
+      ootb_fields: LogFields::default(),
     }
   }
 }


### PR DESCRIPTION
This fixes a regression from the change to use a map where custom fields
could now override ootb fields