### PR TITLE
workflow: remove sankey debug assert

### DIFF
--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -281,10 +281,7 @@ impl Monitor {
           Self::guess_crash_details(&contents, &crash_reason_paths, &crash_details_paths);
 
         if crash_reason.is_none() {
-          log::warn!(
-            "Failed to infer crash reason from report {:?}, dropping.",
-            path
-          );
+          log::warn!("Failed to infer crash reason from report {path:?}, dropping.");
           continue;
         }
 

--- a/bd-workflows/src/workflow.rs
+++ b/bd-workflows/src/workflow.rs
@@ -990,10 +990,6 @@ impl Traversal {
           triggered_actions.push(TriggeredAction::EmitMetric(action));
         },
         Action::EmitSankey(action) => {
-          debug_assert!(
-            extractions.sankey_states.is_some(),
-            "sankey_states should be present"
-          );
           let Some(sankey_states) = &mut extractions.sankey_states else {
             continue;
           };


### PR DESCRIPTION
This can happen if a field extraction does not
extract anything.