### PR TITLE
harden more client files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ clap            = { version = "4.5.35", features = ["derive", "env"] }
 color-backtrace = "0.7.0"
 concat-string   = "1.0.1"
 crc32fast       = "1.4.2"
+criterion       = "0.5.1"
 ctor            = "0.4.1"
 dashmap         = "6.1.0"
 flatbuffers     = "25.2.10"

--- a/bd-client-common/src/file.rs
+++ b/bd-client-common/src/file.rs
@@ -12,8 +12,13 @@ use std::io::Read;
 
 pub fn write_compressed_protobuf<T: protobuf::Message>(message: &T) -> Vec<u8> {
   let bytes = message.write_to_bytes().unwrap();
+  write_compressed(&bytes)
+}
+
+#[must_use]
+pub fn write_compressed(bytes: &[u8]) -> Vec<u8> {
   let mut encoder = ZlibEncoder::new(
-    &bytes[..],
+    bytes,
     Compression::new(DEFAULT_MOBILE_ZLIB_COMPRESSION_LEVEL),
   );
   let mut compressed_bytes = Vec::new();
@@ -21,13 +26,11 @@ pub fn write_compressed_protobuf<T: protobuf::Message>(message: &T) -> Vec<u8> {
   compressed_bytes
 }
 
-pub fn read_compressed_protobuf<T: protobuf::Message>(
-  compressed_bytes: &[u8],
-) -> anyhow::Result<T> {
+pub fn read_compressed(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
   // We should never write empty files. If there is no data this was a partial write, full disk
   // issue, or some other problem. We use zlib for compression which includes a CRC at the end
   // so as long as the file is not empty we can be sure that the data is not corrupted.
-  if compressed_bytes.is_empty() {
+  if bytes.is_empty() {
     anyhow::bail!("unexpected empty file");
   }
 
@@ -36,8 +39,15 @@ pub fn read_compressed_protobuf<T: protobuf::Message>(
   // streaming later. Generally these are small files so we use a small buffer to avoid needless
   // allocation.
   // TODO(mattklein123): Zero-initializing is not necessary here but we will defer this for now.
-  let mut decoder = ZlibDecoder::new_with_buf(compressed_bytes, vec![0; 1024]);
-  // In the future if/when we switch to using Bytes/Chars in the compiled proto it may be more
-  // efficient to read out the uncompressed into Bytes and then parse from that.
-  Ok(T::parse_from_reader(&mut decoder)?)
+  let mut decoder = ZlibDecoder::new_with_buf(bytes, vec![0; 1024]);
+  let mut decompressed_bytes = Vec::new();
+  decoder.read_to_end(&mut decompressed_bytes)?;
+  Ok(decompressed_bytes)
+}
+
+pub fn read_compressed_protobuf<T: protobuf::Message>(
+  compressed_bytes: &[u8],
+) -> anyhow::Result<T> {
+  let decompressed_bytes = read_compressed(compressed_bytes)?;
+  Ok(T::parse_from_tokio_bytes(&decompressed_bytes.into())?)
 }

--- a/bd-logger/src/client_config_test.rs
+++ b/bd-logger/src/client_config_test.rs
@@ -120,7 +120,10 @@ async fn load_malformed_file() {
   std::fs::write(config_file, "not a proto").unwrap();
 
   let load_result = config.try_load_persisted_config_helper().await;
-  assert_eq!(load_result.err().unwrap().to_string(), "Incorrect tag");
+  assert_eq!(
+    load_result.err().unwrap().to_string(),
+    "corrupt deflate stream"
+  );
 
   // Validate that we remove the file if it fails decoding.
   assert!(!config_file.exists());

--- a/bd-logger/src/log_replay.rs
+++ b/bd-logger/src/log_replay.rs
@@ -98,7 +98,7 @@ pub struct ProcessingPipeline {
 }
 
 impl ProcessingPipeline {
-  pub(crate) fn new(
+  pub(crate) async fn new(
     data_upload_tx: Sender<DataUpload>,
     flush_buffers_tx: Sender<BuffersWithAck>,
     flush_stats_trigger: Option<FlushTrigger>,
@@ -123,11 +123,13 @@ impl ProcessingPipeline {
         stats.dynamic_stats.clone(),
       );
 
-      workflows_engine.start(WorkflowsEngineConfig::new(
-        config.workflows_configuration,
-        config.buffer_producers.trigger_buffer_ids.clone(),
-        config.buffer_producers.continuous_buffer_ids.clone(),
-      ));
+      workflows_engine
+        .start(WorkflowsEngineConfig::new(
+          config.workflows_configuration,
+          config.buffer_producers.trigger_buffer_ids.clone(),
+          config.buffer_producers.continuous_buffer_ids.clone(),
+        ))
+        .await;
 
       (workflows_engine, flush_buffers_tx)
     };

--- a/bd-logger/src/logging_state.rs
+++ b/bd-logger/src/logging_state.rs
@@ -141,7 +141,7 @@ impl<T: MemorySized + Debug> UninitializedLoggingContext<T> {
     }
   }
 
-  pub(crate) fn updated(
+  pub(crate) async fn updated(
     self,
     config: ConfigUpdate,
     capture_screenshot_handler: CaptureScreenshotHandler,
@@ -156,7 +156,8 @@ impl<T: MemorySized + Debug> UninitializedLoggingContext<T> {
       &self.sdk_directory,
       &self.runtime,
       InitializedLoggingContextStats::new(&self.stats),
-    );
+    )
+    .await;
 
     let context = InitializedLoggingContext::new(processing_pipeline);
 

--- a/bd-workflows/Cargo.toml
+++ b/bd-workflows/Cargo.toml
@@ -41,7 +41,7 @@ assert_matches.workspace    = true
 bd-log                      = { path = "../bd-log" }
 bd-test-helpers             = { path = "../bd-test-helpers", default-features = false }
 bd-time                     = { path = "../bd-time" }
-criterion                   = "0.5.1"
+criterion.workspace         = true
 ctor.workspace              = true
 futures-util.workspace      = true
 parking_lot.workspace       = true


### PR DESCRIPTION
Use compression for locally stored config as well as the workflow state file, primarily to get free CRC checking of the written data.

Fixes BIT-5088