### PR TITLE
rework client metrics to use new API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "serde",
  "version_check",
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arbitrary"
@@ -125,9 +125,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
+checksum = "b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07"
 dependencies = [
  "flate2",
  "futures-core",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.28.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f7720b74ed28ca77f90769a71fd8c637a0137f6fae4ae947e1050229cff57f"
+checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
 dependencies = [
  "bindgen",
  "cc",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -298,16 +298,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "instant",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -983,7 +983,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "prometheus",
- "rand 0.9.0",
+ "rand 0.9.1",
  "serde",
  "serde_yaml",
  "tempfile",
@@ -1068,12 +1068,16 @@ dependencies = [
 [[package]]
 name = "bd-stats-common"
 version = "1.0.0"
+dependencies = [
+ "sketches-rust",
+]
 
 [[package]]
 name = "bd-test-helpers"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
  "axum",
  "axum-server",
@@ -1093,6 +1097,7 @@ dependencies = [
  "bd-runtime-config",
  "bd-session",
  "bd-session-replay",
+ "bd-stats-common",
  "bd-time",
  "futures-core",
  "http-body-util",
@@ -1115,7 +1120,7 @@ dependencies = [
  "async-trait",
  "parking_lot",
  "protobuf 4.0.0-alpha.0",
- "rand 0.9.0",
+ "rand 0.9.1",
  "time",
  "tokio",
 ]
@@ -1252,7 +1257,7 @@ checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
 dependencies = [
  "clap",
  "heck 0.4.1",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "log",
  "proc-macro2",
  "quote",
@@ -1265,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -1329,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1339,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1511,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e9666f4a9a948d4f1dff0c08a4512b0f7c86414b23960104c243c10d79f4c3"
+checksum = "a4735f265ba6a1188052ca32d461028a7d1125868be18e287e756019da7607b5"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
@@ -1541,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1595,9 +1600,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dtor"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222ef136a1c687d4aa0395c175f2c4586e379924c352fd02f7870cf7de783c23"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
 dependencies = [
  "dtor-proc-macro",
 ]
@@ -1637,9 +1642,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1887,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1922,9 +1927,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1932,7 +1937,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1963,9 +1968,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -1981,9 +1986,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "home"
@@ -2076,7 +2081,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2266,12 +2271,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -2390,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.0.8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -2422,9 +2427,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2486,9 +2491,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -2571,9 +2576,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -2716,9 +2721,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -2748,9 +2753,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -2878,7 +2883,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -2919,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2938,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -3002,7 +3007,7 @@ version = "4.0.0-alpha.0"
 source = "git+https://github.com/bitdriftlabs/rust-protobuf.git?branch=patch-stack#4d5c5822ad96089057c438616a943aadf6f613ac"
 dependencies = [
  "anyhow",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "log",
  "protobuf 4.0.0-alpha.0",
  "protobuf-support 4.0.0-alpha.0",
@@ -3056,13 +3061,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3091,7 +3095,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -3125,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -3236,7 +3240,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3308,22 +3312,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3345,15 +3349,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3495,7 +3502,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -3504,9 +3511,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3530,9 +3537,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -3556,9 +3563,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "snap"
@@ -3610,7 +3617,7 @@ dependencies = [
  "clap",
  "log",
  "protobuf 4.0.0-alpha.0",
- "rand 0.9.0",
+ "rand 0.9.1",
  "sha2",
  "tempfile",
  "time",
@@ -3632,9 +3639,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3652,9 +3659,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3691,7 +3698,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -3840,9 +3847,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3913,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3926,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3938,25 +3945,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"
@@ -4303,9 +4317,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4536,9 +4559,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -4605,11 +4628,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -4625,9 +4648,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,12 @@ resolver = "2"
 
 [workspace.dependencies]
 android_logger  = "0.15.0"
-anyhow          = "1.0.97"
+anyhow          = "1.0.98"
 arbitrary       = { version = "1.4.1", features = ["derive"] }
 arc-swap        = "1.7.1"
 assert_matches  = "1.5.0"
 async-trait     = "0.1.88"
-axum            = { version = "0.8.3", features = ["http2", "macros"] }
+axum            = { version = "0.8.4", features = ["http2", "macros"] }
 axum-server     = { version = "0.7.2", features = ["tls-rustls-no-provider"] }
 backoff         = "0.4.0"
 base64          = "0.22.1"
@@ -61,14 +61,14 @@ base64ct        = { version = "1.7.3", features = ["alloc", "std"] }
 bincode         = { version = "2.0.1", features = ["serde"] }
 bytes           = "1.10.1"
 cbindgen        = "0.28.0"
-cc              = "1.2.17"
+cc              = "1.2.21"
 cmake           = "0.1.54"
-clap            = { version = "4.5.35", features = ["derive", "env"] }
+clap            = { version = "4.5.37", features = ["derive", "env"] }
 color-backtrace = "0.7.0"
 concat-string   = "1.0.1"
 crc32fast       = "1.4.2"
 criterion       = "0.5.1"
-ctor            = "0.4.1"
+ctor            = "0.4.2"
 dashmap         = "6.1.0"
 flatbuffers     = "25.2.10"
 flatc-rust      = "0.2.0"
@@ -115,14 +115,14 @@ protobuf = { git = "https://github.com/bitdriftlabs/rust-protobuf.git", branch =
 protobuf-codegen = { git = "https://github.com/bitdriftlabs/rust-protobuf.git", branch = "patch-stack" }
 protobuf-json-mapping = { git = "https://github.com/bitdriftlabs/rust-protobuf.git", branch = "patch-stack" }
 
-rand       = "0.9.0"
+rand       = "0.9.1"
 regex      = "1.11.1"
 reqwest    = { version = "0.12.15", features = ["deflate"] }
 rstest     = "0.25.0"
 serde      = { version = "1", features = ["derive", "rc"] }
 serde_json = "1.0.140"
 serde_yaml = "0.9.34"
-sha2       = "0.10.8"
+sha2       = "0.10.9"
 
 sketches-rust = { git = "https://github.com/mattklein123/sketches-rust.git", branch = "patch-stack" }
 
@@ -133,7 +133,7 @@ termcolor         = "1.4.1"
 thiserror         = "2.0.12"
 tikv-jemalloc-ctl = "0.6.0"
 time              = { version = "0.3.41", features = ["serde-well-known", "macros"] }
-tokio             = { version = "1.44.1", features = ["full", "test-util"] }
+tokio             = { version = "1.45.0", features = ["full", "test-util"] }
 tokio-stream      = "0.1.17"
 tokio-test        = "0.4.4"
 tower             = { version = "0.5.2", features = ["retry", "util"] }

--- a/bd-buffer/src/ring_buffer_test.rs
+++ b/bd-buffer/src/ring_buffer_test.rs
@@ -12,7 +12,7 @@ use bd_client_stats_store::test::StatsHelper;
 use bd_client_stats_store::{Collector, Counter};
 use bd_proto::protos::config::v1::config::buffer_config::BufferSizes;
 use bd_proto::protos::config::v1::config::{buffer_config, BufferConfig, BufferConfigList};
-use bd_stats_common::labels;
+use bd_stats_common::{labels, NameType};
 use std::path::{Path, PathBuf};
 
 fn fake_counter() -> Counter {
@@ -257,10 +257,9 @@ async fn ring_buffer_stats() {
   // Verify that we recorded overwrites in the volatile buffer.
   assert!(
     collector
-      .inner()
       .find_counter(
-        "ring_buffer:volatile_overwrite",
-        labels! { "buffer_id" => "some-buffer" },
+        &NameType::Global("ring_buffer:volatile_overwrite".to_string()),
+        &labels! { "buffer_id" => "some-buffer" },
       )
       .unwrap()
       .get()

--- a/bd-client-stats-store/src/lib_test.rs
+++ b/bd-client-stats-store/src/lib_test.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::{Collector, MetricData};
+use crate::{Collector, MetricData, NameType};
 use bd_stats_common::labels;
 
 #[test]
@@ -13,20 +13,32 @@ fn retain() {
   let collector = Collector::default();
   let c = collector.scope("").counter("c");
   let h = collector.scope("").histogram("h");
-  assert!(collector.inner().find_counter("c", labels!()).is_some());
-  assert!(collector.inner().find_histogram("h", labels!()).is_some());
+  assert!(collector
+    .find_counter(&NameType::Global("c".to_string()), &labels!())
+    .is_some());
+  assert!(collector
+    .find_histogram(&NameType::Global("h".to_string()), &labels!())
+    .is_some());
 
   // Dropping c and h should leave them in the map until we retain.
   drop(c);
   drop(h);
-  assert!(collector.inner().find_counter("c", labels!()).is_some());
-  assert!(collector.inner().find_histogram("h", labels!()).is_some());
+  assert!(collector
+    .find_counter(&NameType::Global("c".to_string()), &labels!())
+    .is_some());
+  assert!(collector
+    .find_histogram(&NameType::Global("h".to_string()), &labels!())
+    .is_some());
 
-  collector.inner().retain(|_, metric| match metric {
+  collector.retain(|_, _, metric| match metric {
     MetricData::Counter(c) => c.multiple_references(),
     MetricData::Histogram(h) => h.multiple_references(),
   });
 
-  assert!(collector.inner().find_counter("c", labels!()).is_none());
-  assert!(collector.inner().find_histogram("h", labels!()).is_none());
+  assert!(collector
+    .find_counter(&NameType::Global("c".to_string()), &labels!())
+    .is_none());
+  assert!(collector
+    .find_histogram(&NameType::Global("h".to_string()), &labels!())
+    .is_none());
 }

--- a/bd-client-stats-store/src/test/mod.rs
+++ b/bd-client-stats-store/src/test/mod.rs
@@ -5,42 +5,62 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::{BoundedCollector, Collector, HistogramInner, MetricData};
+use crate::{Collector, HistogramInner, MetricData, NameType};
 use std::collections::BTreeMap;
 
 pub trait StatsHelper {
   fn assert_counter_eq(&self, value: u64, name: &str, labels: BTreeMap<String, String>);
-  fn assert_histogram_observed(&self, value: f64, name: &str, labels: BTreeMap<String, String>);
+  fn assert_workflow_counter_eq(
+    &self,
+    value: u64,
+    action_id: &str,
+    labels: BTreeMap<String, String>,
+  );
+  fn assert_workflow_histogram_observed(
+    &self,
+    value: f64,
+    action_id: &str,
+    labels: BTreeMap<String, String>,
+  );
 }
 
 impl StatsHelper for Collector {
   #[allow(clippy::needless_pass_by_value)]
   fn assert_counter_eq(&self, value: u64, name: &str, labels: BTreeMap<String, String>) {
-    self.inner().assert_counter_eq(value, name, labels);
-  }
-
-  #[allow(clippy::needless_pass_by_value)]
-  fn assert_histogram_observed(&self, value: f64, name: &str, labels: BTreeMap<String, String>) {
-    self.inner().assert_histogram_observed(value, name, labels);
-  }
-}
-
-impl StatsHelper for BoundedCollector {
-  #[allow(clippy::needless_pass_by_value)]
-  fn assert_counter_eq(&self, value: u64, name: &str, labels: BTreeMap<String, String>) {
     assert_eq!(
       value,
       self
-        .find_counter(name, labels.clone())
+        .find_counter(&NameType::Global(name.to_string()), &labels)
         .unwrap_or_else(|| panic!("Counter not found: {name} {labels:?}"))
         .get()
     );
   }
 
-  fn assert_histogram_observed(&self, value: f64, name: &str, labels: BTreeMap<String, String>) {
+  #[allow(clippy::needless_pass_by_value)]
+  fn assert_workflow_counter_eq(
+    &self,
+    value: u64,
+    action_id: &str,
+    labels: BTreeMap<String, String>,
+  ) {
+    assert_eq!(
+      value,
+      self
+        .find_counter(&NameType::ActionId(action_id.to_string()), &labels)
+        .unwrap_or_else(|| panic!("Counter not found: {action_id} {labels:?}"))
+        .get()
+    );
+  }
+
+  fn assert_workflow_histogram_observed(
+    &self,
+    value: f64,
+    action_id: &str,
+    labels: BTreeMap<String, String>,
+  ) {
     let histogram_values = match self
-      .find_histogram(name, labels.clone())
-      .unwrap_or_else(|| panic!("Histogram not found: {name} {labels:?}"))
+      .find_histogram(&NameType::ActionId(action_id.to_string()), &labels)
+      .unwrap_or_else(|| panic!("Histogram not found: {action_id} {labels:?}"))
       .snap()
       .unwrap()
     {

--- a/bd-logger/src/log_replay.rs
+++ b/bd-logger/src/log_replay.rs
@@ -120,7 +120,7 @@ impl ProcessingPipeline {
         sdk_directory,
         runtime,
         data_upload_tx,
-        stats.dynamic_stats.clone(),
+        stats.stats.clone(),
       );
 
       workflows_engine

--- a/bd-logger/src/test/setup.rs
+++ b/bd-logger/src/test/setup.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 use bd_client_stats::test::TestTicker;
 use bd_client_stats::FlushTrigger;
-use bd_client_stats_store::Collector;
 use bd_device::Store;
 use bd_proto::protos::client::api::configuration_update::StateOfTheWorld;
 use bd_proto::protos::client::api::configuration_update_ack::Nack;
@@ -117,7 +116,6 @@ pub struct Setup {
   pub _stats_flush_tx: mpsc::Sender<()>,
   pub stats_upload_tx: mpsc::Sender<()>,
   pub stats_flush_trigger: FlushTrigger,
-  _collector: Collector,
 }
 
 impl Setup {
@@ -152,7 +150,6 @@ impl Setup {
     let (flush_tick_tx, flush_ticker) = TestTicker::new();
     let (upload_tick_tx, upload_ticker) = TestTicker::new();
 
-    let collector = Collector::default();
     let (logger, _, flush_trigger) = crate::LoggerBuilder::new(InitParams {
       sdk_directory: options.sdk_directory.path().into(),
       api_key: "foo-api-key".to_string(),
@@ -171,7 +168,6 @@ impl Setup {
     })
     .with_client_stats(true)
     .with_client_stats_tickers(Box::new(flush_ticker), Box::new(upload_ticker))
-    .with_stats_collector(collector.clone())
     .with_internal_logger(true)
     .build_dedicated_thread()
     .unwrap();
@@ -191,7 +187,6 @@ impl Setup {
       _stats_flush_tx: flush_tick_tx,
       stats_upload_tx: upload_tick_tx,
       stats_flush_trigger: flush_trigger.unwrap(),
-      _collector: collector,
     }
   }
 

--- a/bd-proto/src/protos/client/api.rs
+++ b/bd-proto/src/protos/client/api.rs
@@ -5338,6 +5338,9 @@ pub mod stats_upload_request {
     // @@protoc_insertion_point(message:bitdrift_public.protobuf.client.v1.StatsUploadRequest.Snapshot)
     #[derive(PartialEq,Clone,Default,Debug)]
     pub struct Snapshot {
+        // message fields
+        // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.StatsUploadRequest.Snapshot.metric_id_overflows)
+        pub metric_id_overflows: ::std::collections::HashMap<::std::string::String, u64>,
         // message oneof groups
         pub snapshot_type: ::std::option::Option<snapshot::Snapshot_type>,
         pub occurred_at: ::std::option::Option<snapshot::Occurred_at>,
@@ -5456,7 +5459,7 @@ pub mod stats_upload_request {
         }
 
         pub(in super) fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-            let mut fields = ::std::vec::Vec::with_capacity(2);
+            let mut fields = ::std::vec::Vec::with_capacity(3);
             let mut oneofs = ::std::vec::Vec::with_capacity(2);
             fields.push(::protobuf::reflect::rt::v2::make_oneof_message_has_get_mut_set_accessor::<_, super::super::metric::MetricsList>(
                 "metrics",
@@ -5471,6 +5474,11 @@ pub mod stats_upload_request {
                 Snapshot::aggregated,
                 Snapshot::mut_aggregated,
                 Snapshot::set_aggregated,
+            ));
+            fields.push(::protobuf::reflect::rt::v2::make_map_simpler_accessor_new::<_, _>(
+                "metric_id_overflows",
+                |m: &Snapshot| { &m.metric_id_overflows },
+                |m: &mut Snapshot| { &mut m.metric_id_overflows },
             ));
             oneofs.push(snapshot::Snapshot_type::generated_oneof_descriptor_data());
             oneofs.push(snapshot::Occurred_at::generated_oneof_descriptor_data());
@@ -5498,6 +5506,21 @@ pub mod stats_upload_request {
                     18 => {
                         self.occurred_at = ::std::option::Option::Some(snapshot::Occurred_at::Aggregated(is.read_message()?));
                     },
+                    26 => {
+                        let len = is.read_raw_varint32()?;
+                        let old_limit = is.push_limit(len as u64)?;
+                        let mut key = ::std::default::Default::default();
+                        let mut value = ::std::default::Default::default();
+                        while let Some(tag) = is.read_raw_tag_or_eof()? {
+                            match tag {
+                                10 => key = is.read_string()?,
+                                16 => value = is.read_uint64()?,
+                                _ => ::protobuf::rt::skip_field_for_tag(tag, is)?,
+                            };
+                        }
+                        is.pop_limit(old_limit);
+                        self.metric_id_overflows.insert(key, value);
+                    },
                     tag => {
                         ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                     },
@@ -5510,6 +5533,12 @@ pub mod stats_upload_request {
         #[allow(unused_variables)]
         fn compute_size(&self) -> u64 {
             let mut my_size = 0;
+            for (k, v) in &self.metric_id_overflows {
+                let mut entry_size = 0;
+                entry_size += ::protobuf::rt::string_size(1, &k);
+                entry_size += ::protobuf::rt::uint64_size(2, *v);
+                my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(entry_size) + entry_size
+            };
             if let ::std::option::Option::Some(ref v) = self.snapshot_type {
                 match v {
                     &snapshot::Snapshot_type::Metrics(ref v) => {
@@ -5532,6 +5561,15 @@ pub mod stats_upload_request {
         }
 
         fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+            for (k, v) in &self.metric_id_overflows {
+                let mut entry_size = 0;
+                entry_size += ::protobuf::rt::string_size(1, &k);
+                entry_size += ::protobuf::rt::uint64_size(2, *v);
+                os.write_raw_varint32(26)?; // Tag.
+                os.write_raw_varint32(entry_size as u32)?;
+                os.write_string(1, &k)?;
+                os.write_uint64(2, *v)?;
+            };
             if let ::std::option::Option::Some(ref v) = self.snapshot_type {
                 match v {
                     &snapshot::Snapshot_type::Metrics(ref v) => {
@@ -5565,16 +5603,13 @@ pub mod stats_upload_request {
         fn clear(&mut self) {
             self.snapshot_type = ::std::option::Option::None;
             self.occurred_at = ::std::option::Option::None;
+            self.metric_id_overflows.clear();
             self.special_fields.clear();
         }
 
         fn default_instance() -> &'static Snapshot {
-            static instance: Snapshot = Snapshot {
-                snapshot_type: ::std::option::Option::None,
-                occurred_at: ::std::option::Option::None,
-                special_fields: ::protobuf::SpecialFields::new(),
-            };
-            &instance
+            static instance: ::protobuf::rt::Lazy<Snapshot> = ::protobuf::rt::Lazy::new();
+            instance.get(Snapshot::new)
         }
     }
 
@@ -9072,85 +9107,89 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\
     \x05error\x18\x02\x20\x01(\tR\x05error\x12!\n\x0clogs_dropped\x18\x03\
     \x20\x01(\rR\x0blogsDropped\x12R\n\x0crate_limited\x18\x04\x20\x01(\x0b2\
-    /.bitdrift_public.protobuf.client.v1.RateLimitedR\x0brateLimited\"\xdf\
-    \x04\n\x12StatsUploadRequest\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\n\
+    /.bitdrift_public.protobuf.client.v1.RateLimitedR\x0brateLimited\"\xae\
+    \x06\n\x12StatsUploadRequest\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\n\
     uploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12e\n\x08snapshot\x18\x02\x20\x03\
     (\x0b2?.bitdrift_public.protobuf.client.v1.StatsUploadRequest.SnapshotR\
     \x08snapshotB\x08\xfaB\x05\x92\x01\x02\x08\x01\x123\n\x07sent_at\x18\x03\
-    \x20\x01(\x0b2\x1a.google.protobuf.TimestampR\x06sentAt\x1a\x82\x03\n\
+    \x20\x01(\x0b2\x1a.google.protobuf.TimestampR\x06sentAt\x1a\xd1\x04\n\
     \x08Snapshot\x12K\n\x07metrics\x18\x01\x20\x01(\x0b2/.bitdrift_public.pr\
     otobuf.client.v1.MetricsListH\0R\x07metrics\x12l\n\naggregated\x18\x02\
     \x20\x01(\x0b2J.bitdrift_public.protobuf.client.v1.StatsUploadRequest.Sn\
-    apshot.AggregatedH\x01R\naggregated\x1a\x90\x01\n\nAggregated\x12G\n\x0c\
-    period_start\x18\x04\x20\x01(\x0b2\x1a.google.protobuf.TimestampR\x0bper\
-    iodStartB\x08\xfaB\x05\x8a\x01\x02\x10\x01\x129\n\nperiod_end\x18\x05\
-    \x20\x01(\x0b2\x1a.google.protobuf.TimestampR\tperiodEndB\x14\n\rsnapsho\
-    t_type\x12\x03\xf8B\x01B\x12\n\x0boccurred_at\x12\x03\xf8B\x01\"~\n\x13S\
-    tatsUploadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuid\
-    B\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05er\
-    ror\x12'\n\x0fmetrics_dropped\x18\x03\x20\x01(\rR\x0emetricsDropped\"]\n\
-    \rOpaqueRequest\x12\x12\n\x04uuid\x18\x01\x20\x01(\tR\x04uuid\x128\n\x07\
-    request\x18\x02\x20\x01(\x0b2\x14.google.protobuf.AnyR\x07requestB\x08\
-    \xfaB\x05\x8a\x01\x02\x10\x01\"R\n\x0eOpaqueResponse\x12\x1b\n\x04uuid\
-    \x18\x01\x20\x01(\tR\x04uuidB\x07\xfaB\x04r\x02\x10\x01\x12\x19\n\x05err\
-    or\x18\x02\x20\x01(\tH\0R\x05error\x88\x01\x01B\x08\n\x06_error\"\x0e\n\
-    \x0cPongResponse\"\xba\x05\n\x13ConfigurationUpdate\x12#\n\rversion_nonc\
-    e\x18\x01\x20\x01(\tR\x0cversionNonce\x12v\n\x12state_of_the_world\x18\
-    \x02\x20\x01(\x0b2G.bitdrift_public.protobuf.client.v1.ConfigurationUpda\
-    te.StateOfTheWorldH\0R\x0fstateOfTheWorld\x1a\xf6\x03\n\x0fStateOfTheWor\
-    ld\x12b\n\x12buffer_config_list\x18\x03\x20\x01(\x0b24.bitdrift_public.p\
-    rotobuf.config.v1.BufferConfigListR\x10bufferConfigList\x12u\n\x17workfl\
-    ows_configuration\x18\x04\x20\x01(\x0b2<.bitdrift_public.protobuf.workfl\
-    ow.v1.WorkflowsConfigurationR\x16workflowsConfiguration\x12k\n\x14bdtail\
-    _configuration\x18\x06\x20\x01(\x0b28.bitdrift_public.protobuf.bdtail.v1\
-    .BdTailConfigurationsR\x13bdtailConfiguration\x12m\n\x15filters_configur\
-    ation\x18\x08\x20\x01(\x0b28.bitdrift_public.protobuf.filter.v1.FiltersC\
-    onfigurationR\x14filtersConfigurationJ\x04\x08\x02\x10\x03J\x04\x08\x07\
-    \x10\x08R\x08mll_listR\x16insights_configurationB\r\n\x0bupdate_type\"{\
-    \n\rRuntimeUpdate\x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNo\
-    nce\x12E\n\x07runtime\x18\x02\x20\x01(\x0b2+.bitdrift_public.protobuf.cl\
-    ient.v1.RuntimeR\x07runtime\"S\n\rErrorShutdown\x12\x1f\n\x0bgrpc_status\
-    \x18\x01\x20\x01(\x05R\ngrpcStatus\x12!\n\x0cgrpc_message\x18\x02\x20\
-    \x01(\tR\x0bgrpcMessage\"4\n\x0cFlushBuffers\x12$\n\x0ebuffer_id_list\
-    \x18\x01\x20\x03(\tR\x0cbufferIdList\"Z\n\x18SankeyPathUploadResponse\
-    \x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\
-    \x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05error\"\xcb\x02\n\
-    \x14SankeyIntentResponse\x12(\n\x0bintent_uuid\x18\x01\x20\x01(\tR\ninte\
-    ntUuidB\x07\xfaB\x04r\x02\x10\x01\x12{\n\x12upload_immediately\x18\x03\
-    \x20\x01(\x0b2J.bitdrift_public.protobuf.client.v1.SankeyIntentResponse.\
-    UploadImmediatelyH\0R\x11uploadImmediately\x12S\n\x04drop\x18\x04\x20\
-    \x01(\x0b2=.bitdrift_public.protobuf.client.v1.SankeyIntentResponse.Drop\
-    H\0R\x04drop\x1a\x13\n\x11UploadImmediately\x1a\x06\n\x04DropB\n\n\x08de\
-    cisionJ\x04\x08\x02\x10\x03R\x08decision\"\xf8\x0b\n\x0bApiResponse\x12U\
-    \n\thandshake\x18\x01\x20\x01(\x0b25.bitdrift_public.protobuf.client.v1.\
-    HandshakeResponseH\0R\thandshake\x12V\n\nlog_upload\x18\x02\x20\x01(\x0b\
-    25.bitdrift_public.protobuf.client.v1.LogUploadResponseH\0R\tlogUpload\
-    \x12i\n\x11log_upload_intent\x18\x08\x20\x01(\x0b2;.bitdrift_public.prot\
-    obuf.client.v1.LogUploadIntentResponseH\0R\x0flogUploadIntent\x12\\\n\
-    \x0cstats_upload\x18\x07\x20\x01(\x0b27.bitdrift_public.protobuf.client.\
-    v1.StatsUploadResponseH\0R\x0bstatsUpload\x12F\n\x04pong\x18\x03\x20\x01\
-    (\x0b20.bitdrift_public.protobuf.client.v1.PongResponseH\0R\x04pong\x12l\
-    \n\x14configuration_update\x18\x04\x20\x01(\x0b27.bitdrift_public.protob\
-    uf.client.v1.ConfigurationUpdateH\0R\x13configurationUpdate\x12Z\n\x0eru\
-    ntime_update\x18\x05\x20\x01(\x0b21.bitdrift_public.protobuf.client.v1.R\
-    untimeUpdateH\0R\rruntimeUpdate\x12Z\n\x0eerror_shutdown\x18\x06\x20\x01\
-    (\x0b21.bitdrift_public.protobuf.client.v1.ErrorShutdownH\0R\rerrorShutd\
-    own\x12W\n\rflush_buffers\x18\t\x20\x01(\x0b20.bitdrift_public.protobuf.\
-    client.v1.FlushBuffersH\0R\x0cflushBuffers\x12\x7f\n\x1bopaque_configura\
-    tion_update\x18\n\x20\x01(\x0b2=.bitdrift_public.protobuf.client.v1.Opaq\
-    ueConfigurationUpdateH\0R\x19opaqueConfigurationUpdate\x12Y\n\ropaque_up\
-    load\x18\x0b\x20\x01(\x0b22.bitdrift_public.protobuf.client.v1.OpaqueRes\
-    ponseH\0R\x0copaqueUpload\x12r\n\x15sankey_diagram_upload\x18\x0c\x20\
-    \x01(\x0b2<.bitdrift_public.protobuf.client.v1.SankeyPathUploadResponseH\
-    \0R\x13sankeyDiagramUpload\x12p\n\x16sankey_intent_response\x18\r\x20\
-    \x01(\x0b28.bitdrift_public.protobuf.client.v1.SankeyIntentResponseH\0R\
-    \x14sankeyIntentResponse\x12e\n\x0fartifact_upload\x18\x0e\x20\x01(\x0b2\
-    :.bitdrift_public.protobuf.client.v1.UploadArtifactResponseH\0R\x0eartif\
-    actUpload\x12k\n\x0fartifact_intent\x18\x0f\x20\x01(\x0b2@.bitdrift_publ\
-    ic.protobuf.client.v1.UploadArtifactIntentResponseH\0R\x0eartifactIntent\
-    B\x14\n\rresponse_type\x12\x03\xf8B\x012x\n\nApiService\x12j\n\x03Mux\
-    \x12..bitdrift_public.protobuf.client.v1.ApiRequest\x1a/.bitdrift_public\
-    .protobuf.client.v1.ApiResponse(\x010\x01b\x06proto3\
+    apshot.AggregatedH\x01R\naggregated\x12\x86\x01\n\x13metric_id_overflows\
+    \x18\x03\x20\x03(\x0b2V.bitdrift_public.protobuf.client.v1.StatsUploadRe\
+    quest.Snapshot.MetricIdOverflowsEntryR\x11metricIdOverflows\x1a\x90\x01\
+    \n\nAggregated\x12G\n\x0cperiod_start\x18\x04\x20\x01(\x0b2\x1a.google.p\
+    rotobuf.TimestampR\x0bperiodStartB\x08\xfaB\x05\x8a\x01\x02\x10\x01\x129\
+    \n\nperiod_end\x18\x05\x20\x01(\x0b2\x1a.google.protobuf.TimestampR\tper\
+    iodEnd\x1aD\n\x16MetricIdOverflowsEntry\x12\x10\n\x03key\x18\x01\x20\x01\
+    (\tR\x03key\x12\x14\n\x05value\x18\x02\x20\x01(\x04R\x05value:\x028\x01B\
+    \x14\n\rsnapshot_type\x12\x03\xf8B\x01B\x12\n\x0boccurred_at\x12\x03\xf8\
+    B\x01\"~\n\x13StatsUploadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\
+    \tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\
+    \x20\x01(\tR\x05error\x12'\n\x0fmetrics_dropped\x18\x03\x20\x01(\rR\x0em\
+    etricsDropped\"]\n\rOpaqueRequest\x12\x12\n\x04uuid\x18\x01\x20\x01(\tR\
+    \x04uuid\x128\n\x07request\x18\x02\x20\x01(\x0b2\x14.google.protobuf.Any\
+    R\x07requestB\x08\xfaB\x05\x8a\x01\x02\x10\x01\"R\n\x0eOpaqueResponse\
+    \x12\x1b\n\x04uuid\x18\x01\x20\x01(\tR\x04uuidB\x07\xfaB\x04r\x02\x10\
+    \x01\x12\x19\n\x05error\x18\x02\x20\x01(\tH\0R\x05error\x88\x01\x01B\x08\
+    \n\x06_error\"\x0e\n\x0cPongResponse\"\xba\x05\n\x13ConfigurationUpdate\
+    \x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNonce\x12v\n\x12sta\
+    te_of_the_world\x18\x02\x20\x01(\x0b2G.bitdrift_public.protobuf.client.v\
+    1.ConfigurationUpdate.StateOfTheWorldH\0R\x0fstateOfTheWorld\x1a\xf6\x03\
+    \n\x0fStateOfTheWorld\x12b\n\x12buffer_config_list\x18\x03\x20\x01(\x0b2\
+    4.bitdrift_public.protobuf.config.v1.BufferConfigListR\x10bufferConfigLi\
+    st\x12u\n\x17workflows_configuration\x18\x04\x20\x01(\x0b2<.bitdrift_pub\
+    lic.protobuf.workflow.v1.WorkflowsConfigurationR\x16workflowsConfigurati\
+    on\x12k\n\x14bdtail_configuration\x18\x06\x20\x01(\x0b28.bitdrift_public\
+    .protobuf.bdtail.v1.BdTailConfigurationsR\x13bdtailConfiguration\x12m\n\
+    \x15filters_configuration\x18\x08\x20\x01(\x0b28.bitdrift_public.protobu\
+    f.filter.v1.FiltersConfigurationR\x14filtersConfigurationJ\x04\x08\x02\
+    \x10\x03J\x04\x08\x07\x10\x08R\x08mll_listR\x16insights_configurationB\r\
+    \n\x0bupdate_type\"{\n\rRuntimeUpdate\x12#\n\rversion_nonce\x18\x01\x20\
+    \x01(\tR\x0cversionNonce\x12E\n\x07runtime\x18\x02\x20\x01(\x0b2+.bitdri\
+    ft_public.protobuf.client.v1.RuntimeR\x07runtime\"S\n\rErrorShutdown\x12\
+    \x1f\n\x0bgrpc_status\x18\x01\x20\x01(\x05R\ngrpcStatus\x12!\n\x0cgrpc_m\
+    essage\x18\x02\x20\x01(\tR\x0bgrpcMessage\"4\n\x0cFlushBuffers\x12$\n\
+    \x0ebuffer_id_list\x18\x01\x20\x03(\tR\x0cbufferIdList\"Z\n\x18SankeyPat\
+    hUploadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\
+    \x07\xfaB\x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05err\
+    or\"\xcb\x02\n\x14SankeyIntentResponse\x12(\n\x0bintent_uuid\x18\x01\x20\
+    \x01(\tR\nintentUuidB\x07\xfaB\x04r\x02\x10\x01\x12{\n\x12upload_immedia\
+    tely\x18\x03\x20\x01(\x0b2J.bitdrift_public.protobuf.client.v1.SankeyInt\
+    entResponse.UploadImmediatelyH\0R\x11uploadImmediately\x12S\n\x04drop\
+    \x18\x04\x20\x01(\x0b2=.bitdrift_public.protobuf.client.v1.SankeyIntentR\
+    esponse.DropH\0R\x04drop\x1a\x13\n\x11UploadImmediately\x1a\x06\n\x04Dro\
+    pB\n\n\x08decisionJ\x04\x08\x02\x10\x03R\x08decision\"\xf8\x0b\n\x0bApiR\
+    esponse\x12U\n\thandshake\x18\x01\x20\x01(\x0b25.bitdrift_public.protobu\
+    f.client.v1.HandshakeResponseH\0R\thandshake\x12V\n\nlog_upload\x18\x02\
+    \x20\x01(\x0b25.bitdrift_public.protobuf.client.v1.LogUploadResponseH\0R\
+    \tlogUpload\x12i\n\x11log_upload_intent\x18\x08\x20\x01(\x0b2;.bitdrift_\
+    public.protobuf.client.v1.LogUploadIntentResponseH\0R\x0flogUploadIntent\
+    \x12\\\n\x0cstats_upload\x18\x07\x20\x01(\x0b27.bitdrift_public.protobuf\
+    .client.v1.StatsUploadResponseH\0R\x0bstatsUpload\x12F\n\x04pong\x18\x03\
+    \x20\x01(\x0b20.bitdrift_public.protobuf.client.v1.PongResponseH\0R\x04p\
+    ong\x12l\n\x14configuration_update\x18\x04\x20\x01(\x0b27.bitdrift_publi\
+    c.protobuf.client.v1.ConfigurationUpdateH\0R\x13configurationUpdate\x12Z\
+    \n\x0eruntime_update\x18\x05\x20\x01(\x0b21.bitdrift_public.protobuf.cli\
+    ent.v1.RuntimeUpdateH\0R\rruntimeUpdate\x12Z\n\x0eerror_shutdown\x18\x06\
+    \x20\x01(\x0b21.bitdrift_public.protobuf.client.v1.ErrorShutdownH\0R\rer\
+    rorShutdown\x12W\n\rflush_buffers\x18\t\x20\x01(\x0b20.bitdrift_public.p\
+    rotobuf.client.v1.FlushBuffersH\0R\x0cflushBuffers\x12\x7f\n\x1bopaque_c\
+    onfiguration_update\x18\n\x20\x01(\x0b2=.bitdrift_public.protobuf.client\
+    .v1.OpaqueConfigurationUpdateH\0R\x19opaqueConfigurationUpdate\x12Y\n\ro\
+    paque_upload\x18\x0b\x20\x01(\x0b22.bitdrift_public.protobuf.client.v1.O\
+    paqueResponseH\0R\x0copaqueUpload\x12r\n\x15sankey_diagram_upload\x18\
+    \x0c\x20\x01(\x0b2<.bitdrift_public.protobuf.client.v1.SankeyPathUploadR\
+    esponseH\0R\x13sankeyDiagramUpload\x12p\n\x16sankey_intent_response\x18\
+    \r\x20\x01(\x0b28.bitdrift_public.protobuf.client.v1.SankeyIntentRespons\
+    eH\0R\x14sankeyIntentResponse\x12e\n\x0fartifact_upload\x18\x0e\x20\x01(\
+    \x0b2:.bitdrift_public.protobuf.client.v1.UploadArtifactResponseH\0R\x0e\
+    artifactUpload\x12k\n\x0fartifact_intent\x18\x0f\x20\x01(\x0b2@.bitdrift\
+    _public.protobuf.client.v1.UploadArtifactIntentResponseH\0R\x0eartifactI\
+    ntentB\x14\n\rresponse_type\x12\x03\xf8B\x012x\n\nApiService\x12j\n\x03M\
+    ux\x12..bitdrift_public.protobuf.client.v1.ApiRequest\x1a/.bitdrift_publ\
+    ic.protobuf.client.v1.ApiResponse(\x010\x01b\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file

--- a/bd-proto/src/protos/client/metric.rs
+++ b/bd-proto/src/protos/client/metric.rs
@@ -686,11 +686,10 @@ impl ::protobuf::reflect::ProtobufValue for InlineHistogramValues {
 #[derive(PartialEq,Clone,Default,Debug)]
 pub struct Metric {
     // message fields
-    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.Metric.name)
-    pub name: ::std::string::String,
     // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.Metric.tags)
     pub tags: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
     // message oneof groups
+    pub metric_name_type: ::std::option::Option<metric::Metric_name_type>,
     pub data: ::std::option::Option<metric::Data>,
     // special fields
     // @@protoc_insertion_point(special_field:bitdrift_public.protobuf.client.v1.Metric.special_fields)
@@ -706,6 +705,104 @@ impl<'a> ::std::default::Default for &'a Metric {
 impl Metric {
     pub fn new() -> Metric {
         ::std::default::Default::default()
+    }
+
+    // string name = 1;
+
+    pub fn name(&self) -> &str {
+        match self.metric_name_type {
+            ::std::option::Option::Some(metric::Metric_name_type::Name(ref v)) => v,
+            _ => "",
+        }
+    }
+
+    pub fn clear_name(&mut self) {
+        self.metric_name_type = ::std::option::Option::None;
+    }
+
+    pub fn has_name(&self) -> bool {
+        match self.metric_name_type {
+            ::std::option::Option::Some(metric::Metric_name_type::Name(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_name(&mut self, v: ::std::string::String) {
+        self.metric_name_type = ::std::option::Option::Some(metric::Metric_name_type::Name(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_name(&mut self) -> &mut ::std::string::String {
+        if let ::std::option::Option::Some(metric::Metric_name_type::Name(_)) = self.metric_name_type {
+        } else {
+            self.metric_name_type = ::std::option::Option::Some(metric::Metric_name_type::Name(::std::string::String::new()));
+        }
+        match self.metric_name_type {
+            ::std::option::Option::Some(metric::Metric_name_type::Name(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_name(&mut self) -> ::std::string::String {
+        if self.has_name() {
+            match self.metric_name_type.take() {
+                ::std::option::Option::Some(metric::Metric_name_type::Name(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            ::std::string::String::new()
+        }
+    }
+
+    // string metric_id = 7;
+
+    pub fn metric_id(&self) -> &str {
+        match self.metric_name_type {
+            ::std::option::Option::Some(metric::Metric_name_type::MetricId(ref v)) => v,
+            _ => "",
+        }
+    }
+
+    pub fn clear_metric_id(&mut self) {
+        self.metric_name_type = ::std::option::Option::None;
+    }
+
+    pub fn has_metric_id(&self) -> bool {
+        match self.metric_name_type {
+            ::std::option::Option::Some(metric::Metric_name_type::MetricId(..)) => true,
+            _ => false,
+        }
+    }
+
+    // Param is passed by value, moved
+    pub fn set_metric_id(&mut self, v: ::std::string::String) {
+        self.metric_name_type = ::std::option::Option::Some(metric::Metric_name_type::MetricId(v))
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_metric_id(&mut self) -> &mut ::std::string::String {
+        if let ::std::option::Option::Some(metric::Metric_name_type::MetricId(_)) = self.metric_name_type {
+        } else {
+            self.metric_name_type = ::std::option::Option::Some(metric::Metric_name_type::MetricId(::std::string::String::new()));
+        }
+        match self.metric_name_type {
+            ::std::option::Option::Some(metric::Metric_name_type::MetricId(ref mut v)) => v,
+            _ => panic!(),
+        }
+    }
+
+    // Take field
+    pub fn take_metric_id(&mut self) -> ::std::string::String {
+        if self.has_metric_id() {
+            match self.metric_name_type.take() {
+                ::std::option::Option::Some(metric::Metric_name_type::MetricId(v)) => v,
+                _ => panic!(),
+            }
+        } else {
+            ::std::string::String::new()
+        }
     }
 
     // .bitdrift_public.protobuf.client.v1.Counter counter = 3;
@@ -856,12 +953,19 @@ impl Metric {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(5);
-        let mut oneofs = ::std::vec::Vec::with_capacity(1);
-        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+        let mut fields = ::std::vec::Vec::with_capacity(6);
+        let mut oneofs = ::std::vec::Vec::with_capacity(2);
+        fields.push(::protobuf::reflect::rt::v2::make_oneof_deref_has_get_set_simpler_accessor::<_, _>(
             "name",
-            |m: &Metric| { &m.name },
-            |m: &mut Metric| { &mut m.name },
+            Metric::has_name,
+            Metric::name,
+            Metric::set_name,
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_oneof_deref_has_get_set_simpler_accessor::<_, _>(
+            "metric_id",
+            Metric::has_metric_id,
+            Metric::metric_id,
+            Metric::set_metric_id,
         ));
         fields.push(::protobuf::reflect::rt::v2::make_map_simpler_accessor_new::<_, _>(
             "tags",
@@ -889,6 +993,7 @@ impl Metric {
             Metric::mut_inline_histogram_values,
             Metric::set_inline_histogram_values,
         ));
+        oneofs.push(metric::Metric_name_type::generated_oneof_descriptor_data());
         oneofs.push(metric::Data::generated_oneof_descriptor_data());
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<Metric>(
             "Metric",
@@ -909,7 +1014,10 @@ impl ::protobuf::Message for Metric {
         while let Some(tag) = is.read_raw_tag_or_eof()? {
             match tag {
                 10 => {
-                    self.name = is.read_string()?;
+                    self.metric_name_type = ::std::option::Option::Some(metric::Metric_name_type::Name(is.read_string()?));
+                },
+                58 => {
+                    self.metric_name_type = ::std::option::Option::Some(metric::Metric_name_type::MetricId(is.read_string()?));
                 },
                 18 => {
                     let len = is.read_raw_varint32()?;
@@ -947,15 +1055,22 @@ impl ::protobuf::Message for Metric {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u64 {
         let mut my_size = 0;
-        if !self.name.is_empty() {
-            my_size += ::protobuf::rt::string_size(1, &self.name);
-        }
         for (k, v) in &self.tags {
             let mut entry_size = 0;
             entry_size += ::protobuf::rt::string_size(1, &k);
             entry_size += ::protobuf::rt::string_size(2, &v);
             my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(entry_size) + entry_size
         };
+        if let ::std::option::Option::Some(ref v) = self.metric_name_type {
+            match v {
+                &metric::Metric_name_type::Name(ref v) => {
+                    my_size += ::protobuf::rt::string_size(1, &v);
+                },
+                &metric::Metric_name_type::MetricId(ref v) => {
+                    my_size += ::protobuf::rt::string_size(7, &v);
+                },
+            };
+        }
         if let ::std::option::Option::Some(ref v) = self.data {
             match v {
                 &metric::Data::Counter(ref v) => {
@@ -978,9 +1093,6 @@ impl ::protobuf::Message for Metric {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        if !self.name.is_empty() {
-            os.write_string(1, &self.name)?;
-        }
         for (k, v) in &self.tags {
             let mut entry_size = 0;
             entry_size += ::protobuf::rt::string_size(1, &k);
@@ -990,6 +1102,16 @@ impl ::protobuf::Message for Metric {
             os.write_string(1, &k)?;
             os.write_string(2, &v)?;
         };
+        if let ::std::option::Option::Some(ref v) = self.metric_name_type {
+            match v {
+                &metric::Metric_name_type::Name(ref v) => {
+                    os.write_string(1, v)?;
+                },
+                &metric::Metric_name_type::MetricId(ref v) => {
+                    os.write_string(7, v)?;
+                },
+            };
+        }
         if let ::std::option::Option::Some(ref v) = self.data {
             match v {
                 &metric::Data::Counter(ref v) => {
@@ -1020,7 +1142,8 @@ impl ::protobuf::Message for Metric {
     }
 
     fn clear(&mut self) {
-        self.name.clear();
+        self.metric_name_type = ::std::option::Option::None;
+        self.metric_name_type = ::std::option::Option::None;
         self.tags.clear();
         self.data = ::std::option::Option::None;
         self.data = ::std::option::Option::None;
@@ -1053,6 +1176,31 @@ impl ::protobuf::reflect::ProtobufValue for Metric {
 
 /// Nested message and enums of message `Metric`
 pub mod metric {
+
+    #[derive(Clone,PartialEq,Debug)]
+    // @@protoc_insertion_point(oneof:bitdrift_public.protobuf.client.v1.Metric.metric_name_type)
+    pub enum Metric_name_type {
+        // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.Metric.name)
+        Name(::std::string::String),
+        // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.Metric.metric_id)
+        MetricId(::std::string::String),
+    }
+
+    impl ::protobuf::Oneof for Metric_name_type {
+    }
+
+    impl ::protobuf::OneofFull for Metric_name_type {
+        fn descriptor() -> ::protobuf::reflect::OneofDescriptor {
+            static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::OneofDescriptor> = ::protobuf::rt::Lazy::new();
+            descriptor.get(|| <super::Metric as ::protobuf::MessageFull>::descriptor().oneof_by_name("metric_name_type").unwrap()).clone()
+        }
+    }
+
+    impl Metric_name_type {
+        pub(in super) fn generated_oneof_descriptor_data() -> ::protobuf::reflect::GeneratedOneofDescriptorData {
+            ::protobuf::reflect::GeneratedOneofDescriptorData::new::<Metric_name_type>("metric_name_type")
+        }
+    }
 
     #[derive(Clone,PartialEq,Debug)]
     // @@protoc_insertion_point(oneof:bitdrift_public.protobuf.client.v1.Metric.data)
@@ -1217,19 +1365,20 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     riodEnd\"%\n\x07Counter\x12\x14\n\x05value\x18\x02\x20\x01(\x04R\x05valu\
     eJ\x04\x08\x01\x10\x02\"3\n\x11DDSketchHistogram\x12\x1e\n\nserialized\
     \x18\x01\x20\x01(\x0cR\nserialized\"/\n\x15InlineHistogramValues\x12\x16\
-    \n\x06values\x18\x01\x20\x03(\x01R\x06values\"\xe1\x03\n\x06Metric\x12\
-    \x1b\n\x04name\x18\x01\x20\x01(\tR\x04nameB\x07\xfaB\x04r\x02\x10\x01\
-    \x12H\n\x04tags\x18\x02\x20\x03(\x0b24.bitdrift_public.protobuf.client.v\
-    1.Metric.TagsEntryR\x04tags\x12G\n\x07counter\x18\x03\x20\x01(\x0b2+.bit\
-    drift_public.protobuf.client.v1.CounterH\0R\x07counter\x12f\n\x12ddsketc\
-    h_histogram\x18\x05\x20\x01(\x0b25.bitdrift_public.protobuf.client.v1.DD\
-    SketchHistogramH\0R\x11ddsketchHistogram\x12s\n\x17inline_histogram_valu\
-    es\x18\x06\x20\x01(\x0b29.bitdrift_public.protobuf.client.v1.InlineHisto\
-    gramValuesH\0R\x15inlineHistogramValues\x1a7\n\tTagsEntry\x12\x10\n\x03k\
-    ey\x18\x01\x20\x01(\tR\x03key\x12\x14\n\x05value\x18\x02\x20\x01(\tR\x05\
-    value:\x028\x01B\x0b\n\x04data\x12\x03\xf8B\x01J\x04\x08\x04\x10\x05\"Q\
-    \n\x0bMetricsList\x12B\n\x06metric\x18\x01\x20\x03(\x0b2*.bitdrift_publi\
-    c.protobuf.client.v1.MetricR\x06metricb\x06proto3\
+    \n\x06values\x18\x01\x20\x03(\x01R\x06values\"\x8d\x04\n\x06Metric\x12\
+    \x14\n\x04name\x18\x01\x20\x01(\tH\0R\x04name\x12\x1d\n\tmetric_id\x18\
+    \x07\x20\x01(\tH\0R\x08metricId\x12H\n\x04tags\x18\x02\x20\x03(\x0b24.bi\
+    tdrift_public.protobuf.client.v1.Metric.TagsEntryR\x04tags\x12G\n\x07cou\
+    nter\x18\x03\x20\x01(\x0b2+.bitdrift_public.protobuf.client.v1.CounterH\
+    \x01R\x07counter\x12f\n\x12ddsketch_histogram\x18\x05\x20\x01(\x0b25.bit\
+    drift_public.protobuf.client.v1.DDSketchHistogramH\x01R\x11ddsketchHisto\
+    gram\x12s\n\x17inline_histogram_values\x18\x06\x20\x01(\x0b29.bitdrift_p\
+    ublic.protobuf.client.v1.InlineHistogramValuesH\x01R\x15inlineHistogramV\
+    alues\x1a7\n\tTagsEntry\x12\x10\n\x03key\x18\x01\x20\x01(\tR\x03key\x12\
+    \x14\n\x05value\x18\x02\x20\x01(\tR\x05value:\x028\x01B\x12\n\x10metric_\
+    name_typeB\x0b\n\x04data\x12\x03\xf8B\x01J\x04\x08\x04\x10\x05\"Q\n\x0bM\
+    etricsList\x12B\n\x06metric\x18\x01\x20\x03(\x0b2*.bitdrift_public.proto\
+    buf.client.v1.MetricR\x06metricb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file

--- a/bd-report-writer-tests/Cargo.toml
+++ b/bd-report-writer-tests/Cargo.toml
@@ -5,6 +5,9 @@ version      = "1.0.0"
 license-file = "../LICENSE"
 publish      = false
 
+[lib]
+doctest = false
+
 [dependencies]
 bd-report-writer.path = "../bd-report-writer"
 flatbuffers.workspace = true

--- a/bd-report-writer/Cargo.toml
+++ b/bd-report-writer/Cargo.toml
@@ -5,6 +5,9 @@ version      = "1.0.0"
 license-file = "../LICENSE"
 publish      = false
 
+[lib]
+doctest = false
+
 [dependencies]
 flatbuffers.workspace = true
 bd-proto.path = "../bd-proto"

--- a/bd-runtime/src/runtime.rs
+++ b/bd-runtime/src/runtime.rs
@@ -868,8 +868,9 @@ pub mod stats {
     5.minutes()
   );
 
-  // This controls how many unique counters we allow before rejecting new metrics. This limit
-  // prevents unbounded growth of metrics, which could result in the system running out of memory.
+  // This controls how much tag cardinality we allow before rejecting new metrics *per workflow*.
+  // This limit prevents unbounded growth of metrics, which could result in the system running out
+  // of memory.
   int_feature_flag!(MaxDynamicCountersFlag, "stats.max_dynamic_stats", 500);
 }
 

--- a/bd-server-stats/src/test/util/stats.rs
+++ b/bd-server-stats/src/test/util/stats.rs
@@ -6,6 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use crate::stats;
+use bd_stats_common::NameType;
 use bd_time::TimeDurationExt;
 use prometheus::proto::{Counter, Gauge, Histogram, Metric};
 use std::collections::HashMap;
@@ -221,15 +222,15 @@ pub enum FakeMetricData {
 //
 
 pub struct FakeMetric {
-  pub name: String,
+  pub name: NameType,
   pub tags: HashMap<String, String>,
   pub metric: FakeMetricData,
 }
 
 impl FakeMetric {
-  fn new(name: &str, tags: Vec<(&str, &str)>, metric: FakeMetricData) -> Self {
+  fn new(name: NameType, tags: Vec<(&str, &str)>, metric: FakeMetricData) -> Self {
     Self {
-      name: name.to_string(),
+      name,
       tags: tags
         .into_iter()
         .map(|(key, value)| (key.to_string(), value.to_string()))
@@ -259,12 +260,12 @@ pub fn assert_histogram(histogram: &Histogram, count: u64, sum: f64, buckets: &[
 
 // Create a fake histogram.
 #[must_use]
-pub fn fake_histogram(name: &str, tags: Vec<(&str, &str)>, samples: Vec<f64>) -> FakeMetric {
+pub fn fake_histogram(name: NameType, tags: Vec<(&str, &str)>, samples: Vec<f64>) -> FakeMetric {
   FakeMetric::new(name, tags, FakeMetricData::Histogram(samples))
 }
 
 // Create a fake counter.
 #[must_use]
-pub fn fake_counter(name: &str, tags: Vec<(&str, &str)>, delta: u64) -> FakeMetric {
+pub fn fake_counter(name: NameType, tags: Vec<(&str, &str)>, delta: u64) -> FakeMetric {
   FakeMetric::new(name, tags, FakeMetricData::Counter(delta))
 }

--- a/bd-stats-common/Cargo.toml
+++ b/bd-stats-common/Cargo.toml
@@ -7,3 +7,6 @@ version      = "1.0.0"
 
 [lib]
 doctest = false
+
+[dependencies]
+sketches-rust.workspace = true

--- a/bd-stats-common/src/lib.rs
+++ b/bd-stats-common/src/lib.rs
@@ -5,6 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
+use sketches_rust::DDSketch;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -23,6 +24,44 @@ macro_rules! labels {
       lbs
     }
   };
+}
+
+#[must_use]
+pub fn make_client_sketch() -> DDSketch {
+  // For this sketch, the index parameters must be consistent in order to perform merges.
+  // However, the maximum number of buckets do not have to be the same. This means that
+  // we can use less buckets on the client and more on the server if we like as long as
+  // the other index parameters are the same. For now using the logarithmic collapsing
+  // variant seems the best. 0.02 relative accuracy is arbitrary as well as a max of 128
+  // buckets. We can tune this later as we have more time to devote to understanding the
+  // math.
+  DDSketch::logarithmic_collapsing_lowest_dense(0.02, 128).unwrap()
+}
+
+//
+// NameType
+//
+
+#[derive(Eq, Hash, PartialEq, Clone)]
+pub enum NameType {
+  Global(String),
+  ActionId(String),
+}
+
+impl NameType {
+  #[must_use]
+  pub fn as_str(&self) -> &str {
+    match self {
+      Self::Global(name) | Self::ActionId(name) => name,
+    }
+  }
+
+  #[must_use]
+  pub fn into_string(self) -> String {
+    match self {
+      Self::Global(name) | Self::ActionId(name) => name,
+    }
+  }
 }
 
 //

--- a/bd-test-helpers/Cargo.toml
+++ b/bd-test-helpers/Cargo.toml
@@ -10,17 +10,18 @@ doctest = false
 
 [dependencies]
 anyhow.workspace         = true
+assert_matches.workspace = true
 async-trait.workspace    = true
-axum-server.workspace    = true
 axum.workspace           = true
+axum-server.workspace    = true
 bd-client-common.path    = "../bd-client-common"
 bd-events.path           = "../bd-events"
-bd-grpc-codec.path       = "../bd-grpc-codec"
 bd-grpc.path             = "../bd-grpc"
+bd-grpc-codec.path       = "../bd-grpc-codec"
 bd-key-value.path        = "../bd-key-value"
+bd-log.path              = "../bd-log"
 bd-log-metadata.path     = "../bd-log-metadata"
 bd-log-primitives.path   = "../bd-log-primitives"
-bd-log.path              = "../bd-log"
 bd-matcher.path          = "../bd-matcher"
 bd-metadata.path         = "../bd-metadata"
 bd-panic.path            = "../bd-panic"
@@ -29,6 +30,7 @@ bd-resource-utilization  = { path = "../bd-resource-utilization" }
 bd-runtime-config        = { path = "../bd-runtime-config", optional = true }
 bd-session               = { path = "../bd-session" }
 bd-session-replay        = { path = "../bd-session-replay" }
+bd-stats-common.path     = "../bd-stats-common"
 bd-time.path             = "../bd-time"
 futures-core.workspace   = true
 http-body-util.workspace = true
@@ -39,10 +41,10 @@ prometheus.workspace     = true
 protobuf.workspace       = true
 serde.workspace          = true
 time.workspace           = true
-tokio-stream.workspace   = true
 tokio.workspace          = true
+tokio-stream.workspace   = true
 tracing.workspace        = true
 
 [features]
-default     = ["runtime"]
-runtime     = ["bd-runtime-config", "mockall"]
+default = ["runtime"]
+runtime = ["bd-runtime-config", "mockall"]

--- a/bd-workflows/benches/matcher.rs
+++ b/bd-workflows/benches/matcher.rs
@@ -6,7 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use bd_api::DataUpload;
-use bd_client_stats::DynamicStats;
+use bd_client_stats::Stats;
 use bd_client_stats_store::Collector;
 use bd_log_primitives::{log_level, FieldsRef, LogFields, LogRef, LogType};
 use bd_proto::protos::workflow::workflow::Workflow;
@@ -17,7 +17,6 @@ use bd_workflows::engine::{WorkflowsEngine, WorkflowsEngineConfig};
 use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use std::collections::BTreeSet;
 use std::future::Future;
-use std::sync::Arc;
 use time::OffsetDateTime;
 
 struct Setup {
@@ -40,13 +39,14 @@ impl Setup {
 
   async fn new_engine(&self, workflows: Vec<Workflow>) -> WorkflowsEngine {
     let config_loader = &ConfigLoader::new(self.tmp_dir.path());
-    let scope = &Collector::default().scope("test");
+    let collector = Collector::default();
+    let scope = &collector.scope("test");
     let (mut engine, _) = WorkflowsEngine::new(
       scope,
       self.tmp_dir.path(),
       config_loader,
       self.data_upload_tx.clone(),
-      Arc::new(DynamicStats::new(scope, config_loader)),
+      Stats::new(collector),
     );
     assert!(!workflows.is_empty());
 

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,7 @@ allow = [
   "Apache-2.0",
   "BSD-3-Clause",
   "CC0-1.0",
+  "CDLA-Permissive-2.0",
   "ISC",
   "MIT",
   "MPL-2.0",


### PR DESCRIPTION
1) Workflow metrics are now strongly typed by ID.
2) Cardinality limits are now per action ID.
3) Correctly respect limits when merging metrics to disk.