### PR TITLE
workflows: bump state file name

### DIFF
--- a/bd-logger/src/test/setup.rs
+++ b/bd-logger/src/test/setup.rs
@@ -358,7 +358,7 @@ impl Setup {
     self
       .sdk_directory
       .path()
-      .join("workflows_state_snapshot.6.bin")
+      .join("workflows_state_snapshot.7.bin")
   }
 }
 

--- a/bd-workflows/src/engine.rs
+++ b/bd-workflows/src/engine.rs
@@ -980,7 +980,7 @@ impl StateStore {
     );
 
     Self {
-      state_path: sdk_directory.join("workflows_state_snapshot.6.bin"),
+      state_path: sdk_directory.join("workflows_state_snapshot.7.bin"),
       last_persisted: None,
       stats,
       persistence_write_interval_flag: runtime.register_watch().unwrap(),

--- a/bd-workflows/src/engine_test.rs
+++ b/bd-workflows/src/engine_test.rs
@@ -485,7 +485,7 @@ impl Setup {
     self
       .sdk_directory
       .path()
-      .join("workflows_state_snapshot.6.bin")
+      .join("workflows_state_snapshot.7.bin")
   }
 }
 


### PR DESCRIPTION
When we added compression/CRC to the state file, this causes a crash if the library is downgraded as bincode is not very resilient. We will look at no longer using bincode in a future version.