### PR TITLE
fix(crash-handler): handle case where errors vector is empty

### DIFF
--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -127,7 +127,7 @@ impl Monitor {
     if let Ok(bin_report) = root_as_report(report) {
       return bin_report
         .errors()
-        .map(|errs| errs.get(0))
+        .and_then(|errs| errs.iter().next())
         .map_or((None, None), |err| {
           (
             err.name().map(str::to_owned),


### PR DESCRIPTION
previous expectation was that either errors was None or had an element, but should've instead returned an Option for the first element of the collection.

tl;dr:

```rs
Vector::get(0) -> T // <- crash when empty
Vector::iter().next() -> Option<T> // None when empty
```