### PR TITLE
cache config safety part 1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -40,6 +40,7 @@ rustflags = [
   "-Aclippy::missing-panics-doc",
   "-Aclippy::module-name-repetitions",
   "-Aclippy::similar-names",
+  "-Aclippy::struct-field-names",
   "-Aclippy::too-long-first-doc-paragraph",
   "-Aclippy::too-many-arguments",
   "-Aclippy::too-many-lines",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "serde",
  "version_check",
@@ -183,9 +183,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
 dependencies = [
  "bindgen",
  "cc",
@@ -1196,7 +1196,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -1221,9 +1221,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -1273,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
@@ -1442,25 +1442,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -1645,9 +1642,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1677,7 +1674,7 @@ version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "rustc_version",
 ]
 
@@ -1906,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1986,12 +1983,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "home"
@@ -2105,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2125,21 +2116,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2149,30 +2141,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -2180,65 +2152,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2254,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2288,7 +2247,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "inotify-sys",
  "libc",
 ]
@@ -2327,17 +2286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,6 +2311,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2382,7 +2339,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -2446,12 +2403,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -2460,7 +2417,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
 ]
@@ -2500,9 +2457,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -2657,7 +2614,7 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "filetime",
  "fsevent-sys",
  "inotify",
@@ -2728,7 +2685,7 @@ version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2872,6 +2829,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -3107,7 +3073,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -3136,7 +3102,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3306,7 +3272,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3319,7 +3285,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -3361,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.2"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3413,7 +3379,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3677,7 +3643,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3699,7 +3665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
@@ -3830,9 +3796,9 @@ checksum = "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a"
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3997,7 +3963,7 @@ version = "0.6.2"
 source = "git+https://github.com/tower-rs/tower-http?rev=d0c522b6da2620bf5314302d12e4cded7295b11c#d0c522b6da2620bf5314302d12e4cded7295b11c"
 dependencies = [
  "async-compression",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "bytes",
  "futures-core",
  "http",
@@ -4153,12 +4119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4176,7 +4136,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -4398,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -4575,20 +4535,14 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "yansi"
@@ -4598,9 +4552,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4610,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4668,10 +4622,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4680,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,13 +61,13 @@ base64ct        = { version = "1.7.3", features = ["alloc", "std"] }
 bincode         = { version = "2.0.1", features = ["serde"] }
 bytes           = "1.10.1"
 cbindgen        = "0.28.0"
-cc              = "1.2.22"
+cc              = "1.2.23"
 cmake           = "0.1.54"
 clap            = { version = "4.5.38", features = ["derive", "env"] }
 color-backtrace = "0.7.0"
 concat-string   = "1.0.1"
 crc32fast       = "1.4.2"
-criterion       = "0.5.1"
+criterion       = "0.6.0"
 ctor            = "0.4.2"
 dashmap         = "6.1.0"
 flatbuffers     = "25.2.10"
@@ -89,7 +89,7 @@ hyper-rustls = { version = "0.27.5", default-features = false, features = [
 ] }
 
 ahash                 = { version = "0.8.12", features = ["serde"] }
-hyper-util            = { version = "0.1.11", features = ["client", "client-legacy"] }
+hyper-util            = { version = "0.1.12", features = ["client", "client-legacy"] }
 intrusive-collections = "0.9.7"
 itertools             = "0.14.0"
 jni                   = "0.21.1"

--- a/bd-api/src/lib.rs
+++ b/bd-api/src/lib.rs
@@ -16,7 +16,6 @@ use bd_proto::protos::client::api::{
   LogUploadIntentResponse,
   LogUploadRequest,
   LogUploadResponse,
-  OpaqueResponse,
   PongResponse,
   SankeyIntentRequest,
   SankeyIntentResponse,
@@ -73,12 +72,11 @@ pub trait ConfigurationUpdate: Send + Sync {
   /// Attempts to load persisted config from disk if supported by the configuration type.
   async fn try_load_persisted_config(&mut self);
 
-  /// Provides a partial handshake that is used to include the version nonce for this configuration
-  /// type into the handshake request.
-  fn partial_handshake(&self) -> HandshakeRequest;
+  /// Fill a handshake with version nonce information if available.
+  fn fill_handshake(&self, handshake: &mut HandshakeRequest);
 
   /// Called to allow the configuration pipeline to react to the server being available.
-  fn on_handshake_complete(&self);
+  async fn on_handshake_complete(&self);
 }
 
 //
@@ -96,7 +94,6 @@ pub enum ResponseKind<'a> {
   FlushBuffers(&'a FlushBuffers),
   SankeyPathUpload(&'a SankeyPathUploadResponse),
   SankeyPathUploadIntent(&'a SankeyIntentResponse),
-  Opaque(&'a OpaqueResponse),
   ArtifactUploadIntent(&'a UploadArtifactIntentResponse),
   ArtifactUpload(&'a UploadArtifactResponse),
   Untyped,

--- a/bd-api/src/payload_conversion.rs
+++ b/bd-api/src/payload_conversion.rs
@@ -122,7 +122,6 @@ mod client {
         Response_type::FlushBuffers(f) => Some(ResponseKind::FlushBuffers(f)),
         Response_type::SankeyDiagramUpload(s) => Some(ResponseKind::SankeyPathUpload(s)),
         Response_type::SankeyIntentResponse(s) => Some(ResponseKind::SankeyPathUploadIntent(s)),
-        Response_type::OpaqueUpload(o) => Some(ResponseKind::Opaque(o)),
         _ => Some(ResponseKind::Untyped),
       }
     }

--- a/bd-client-common/src/lib.rs
+++ b/bd-client-common/src/lib.rs
@@ -11,6 +11,7 @@ use std::future::Future;
 pub mod error;
 pub mod fb;
 pub mod file;
+pub mod safe_file_cache;
 pub mod zlib;
 
 pub fn spawn_error_handling_task<E: std::error::Error + Sync + Send + 'static>(

--- a/bd-client-common/src/safe_file_cache.rs
+++ b/bd-client-common/src/safe_file_cache.rs
@@ -1,0 +1,171 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use crate::error::handle_unexpected;
+use crate::file::{read_compressed_protobuf, write_compressed_protobuf};
+use anyhow::anyhow;
+use protobuf::Message;
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub struct SafeFileCache<T> {
+  directory: PathBuf,
+  cached_config_validated: AtomicBool,
+  phantom: PhantomData<T>,
+}
+
+impl<T: Message> SafeFileCache<T> {
+  #[must_use]
+  pub fn new(sdk_directory: &Path, subdirectory: &str) -> Self {
+    // Create the directory if it doesn't exist.
+    let directory = sdk_directory.join(subdirectory);
+    log::debug!("creating file cache directory at {}", directory.display());
+    let _ignored = std::fs::create_dir(&directory);
+
+    Self {
+      directory,
+      cached_config_validated: AtomicBool::new(false),
+      phantom: PhantomData,
+    }
+  }
+
+  /// Called to mark the cached config as "safe", meaning that we feel comfortable about letting
+  /// the app continue to read this from disk.
+  pub async fn mark_safe(&self) {
+    // We load the config from cache only at startup, so we only need to update the file once.
+    if !self.cached_config_validated.swap(true, Ordering::SeqCst) {
+      // If this fails worst case we'll use a stale retry count and eventually disable caching.
+      let _ignored = self.persist_cache_load_retry_count(0).await;
+    }
+  }
+
+  fn retry_count_file(&self) -> PathBuf {
+    self.directory.join("retry_count")
+  }
+
+  fn protobuf_file(&self) -> PathBuf {
+    self.directory.join("protobuf.pb")
+  }
+
+  async fn persist_cache_load_retry_count(&self, retry_count: u32) -> anyhow::Result<()> {
+    // This could fail, but by being defensive when we read this we should ideally worst case just
+    // fall back to not reading from cache.
+    // TODO(mattklein123): Switch this over to using compression or at least adding a CRC.
+    tokio::fs::write(
+      &self.retry_count_file(),
+      format!("{retry_count}").as_bytes(),
+    )
+    .await
+    .map_err(|e| anyhow!("an io error occurred: {e}"))
+  }
+
+  pub async fn handle_cached_config(&self) -> Option<T> {
+    // Attempt to load the cached config from disk. Should we run into any unexpected issues,
+    // eagerly wipe out all the disk state by recreating the directory. This should help
+    // us clean up any dirty state we see on disk and avoid issues persisting between process
+    // restarts. As the errors bubble up through the error handler we may find we can handle some
+    // of these failures. We also wipe the cache on a few expected cases, like hitting the retry
+    // limit or a partial cache state.
+    let (reset, cached) = match self.try_load_cached_config().await {
+      Ok(result) => result,
+      Err(e) => {
+        handle_unexpected::<(), anyhow::Error>(Err(e), "cache load");
+        (true, None)
+      },
+    };
+
+    if reset {
+      // Recreate the directory instead of deleting individual files, making sure we really clean
+      // up any bad state.
+      let _ignored = tokio::fs::remove_dir_all(&self.directory).await;
+      let _ignored = tokio::fs::create_dir(&self.directory).await;
+    }
+
+    cached
+  }
+
+  // Attempts to apply cached configuration. Returns true if the underlying cache state should be
+  // reset.
+  async fn try_load_cached_config(&self) -> anyhow::Result<(bool, Option<T>)> {
+    log::debug!("attempting to load cached config");
+
+    // We expect at most two files in this directory: a protobuf.pb which contains the cached
+    // protobuf and a retry_count file which contains the number of times this cached
+    // file has been attempted applied during startup. The idea behind the retry count is
+    // allow a client that received bad configuration to eventually recover, avoiding an infinite
+    // crash loop.
+
+    // If either of the files don't exist, we're not going to try to load the config and we'll wipe
+    // out the other file if it's there. This could handle naturally if the system shuts down in the
+    // middle of caching config.
+    if !tokio::fs::try_exists(self.retry_count_file())
+      .await
+      .is_ok_and(|e| e)
+      || !tokio::fs::try_exists(self.protobuf_file())
+        .await
+        .is_ok_and(|e| e)
+    {
+      log::debug!("cached retry count or config not found, resetting cache");
+      return Ok((true, None));
+    }
+
+    // If the retry count file contains invalid data we defensively bail on reading the cached
+    // value. If we were to treat an empty file as count=0 we could theoretically find ourselves in
+    // a loop where the file is not properly updated.
+    let Ok(retry_count) = Self::parse_retry_count(
+      &tokio::fs::read(&self.retry_count_file())
+        .await
+        .map_err(|e| anyhow!("an io error occurred: {e}"))?,
+    ) else {
+      return Ok((true, None));
+    };
+
+    log::debug!("loaded file at retry count {retry_count}");
+
+    // Update the retry count before we apply the config. If this fails, we bail out (which will
+    // attempt to clear the cache directory) and disable caching. We do this because being unable
+    // to update the retry count may result in us getting stuck processing what we think is retry
+    // 0 over and over again.
+    self.persist_cache_load_retry_count(retry_count + 1).await?;
+
+    // TODO(snowp): Should we read this from runtime as well? It would make it possible for a bad
+    // runtime config to accidentally set this really high, but right now this is not
+    // configurable at all.
+    if retry_count > 5 {
+      // Note that eventually if the client is killed this is going to kick in and delete cached
+      // config. This is OK since we are still covered by the kill file, and ultimately we would
+      // like the client to come up and get fresh config anyway.
+      return Ok((true, None));
+    }
+
+    // TODO(snowp): Add stats for how often the read fails beyond ENOENT.
+    // TODO(snowp): When we add a callback, only trigger it if we successfully loaded the config.
+    let bytes = tokio::fs::read(&self.protobuf_file()).await?;
+    let protobuf: T = read_compressed_protobuf(&bytes)?;
+
+    Ok((false, Some(protobuf)))
+  }
+
+  fn parse_retry_count(data: &[u8]) -> anyhow::Result<u32> {
+    Ok(std::str::from_utf8(data)?.parse()?)
+  }
+
+  pub async fn cache_update(&self, protobuf: &T) {
+    if let Err(e) =
+      tokio::fs::write(&self.protobuf_file(), write_compressed_protobuf(protobuf)).await
+    {
+      log::debug!("failed to write cached config: {e}");
+    }
+
+    // Failing here is fine, worst case we'll use an old retry count or leave is missing, which
+    // will eventually disable caching.
+    if let Err(e) = self.persist_cache_load_retry_count(0).await {
+      log::debug!("failed to write retry count: {e}");
+    }
+  }
+}

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -67,11 +67,14 @@ impl Setup {
     std::fs::write(crash_directory.join(name), data).unwrap();
   }
 
-  fn configure_ingestion_runtime_flag(&self, value: &str) {
-    self.runtime.update_snapshot(&make_simple_update(vec![(
-      CrashDirectories::path(),
-      ValueKind::String(value.to_string()),
-    )]));
+  async fn configure_ingestion_runtime_flag(&self, value: &str) {
+    self
+      .runtime
+      .update_snapshot(&make_simple_update(vec![(
+        CrashDirectories::path(),
+        ValueKind::String(value.to_string()),
+      )]))
+      .await;
   }
 
   async fn write_config_file(&self, name: &str, contents: &str) {
@@ -191,7 +194,7 @@ async fn crash_handling_missing_reason() {
 async fn config_file() {
   let setup = Setup::new();
 
-  setup.configure_ingestion_runtime_flag("a");
+  setup.configure_ingestion_runtime_flag("a").await;
 
   setup.write_config_file(INGESTION_CONFIG_FILE, "a").await;
   assert_eq!("a", setup.read_config_file(INGESTION_CONFIG_FILE));

--- a/bd-events/src/listener_test.rs
+++ b/bd-events/src/listener_test.rs
@@ -39,11 +39,14 @@ impl Setup {
   }
 
   #[allow(dead_code)]
-  fn make_runtime_update(&self, events_listener_enabled: bool) {
-    self.runtime.update_snapshot(&make_simple_update(vec![(
-      bd_runtime::runtime::platform_events::ListenerEnabledFlag::path(),
-      ValueKind::Bool(events_listener_enabled),
-    )]));
+  async fn make_runtime_update(&self, events_listener_enabled: bool) {
+    self
+      .runtime
+      .update_snapshot(&make_simple_update(vec![(
+        bd_runtime::runtime::platform_events::ListenerEnabledFlag::path(),
+        ValueKind::Bool(events_listener_enabled),
+      )]))
+      .await;
   }
 }
 
@@ -103,7 +106,7 @@ async fn does_not_interact_with_target_if_listener_is_disabled() {
     () = listener.run_with_shutdown(shutdown).await;
   });
 
-  setup.make_runtime_update(false);
+  setup.make_runtime_update(false).await;
 
   200.milliseconds().sleep().await;
 
@@ -131,7 +134,7 @@ async fn starts_target() {
     () = listener.run_with_shutdown(shutdown).await;
   });
 
-  setup.make_runtime_update(true);
+  setup.make_runtime_update(true).await;
 
   200.milliseconds().sleep().await;
 
@@ -159,10 +162,10 @@ async fn starts_and_stops_target() {
     () = listener.run_with_shutdown(shutdown).await;
   });
 
-  setup.make_runtime_update(true);
+  setup.make_runtime_update(true).await;
   200.milliseconds().sleep().await;
 
-  setup.make_runtime_update(false);
+  setup.make_runtime_update(false).await;
   200.milliseconds().sleep().await;
 
   shutdown_trigger.shutdown().await;

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -658,7 +658,8 @@ async fn logs_resource_utilization_log() {
         bd_runtime::runtime::resource_utilization::ResourceUtilizationReportingIntervalFlag::path(),
         ValueKind::Int(250),
       ),
-    ]));
+    ]))
+    .await;
 
   let config_update = setup.make_config_update(WorkflowsConfiguration::default());
   let task = std::thread::spawn(move || {

--- a/bd-logger/src/bounded_buffer/mod.rs
+++ b/bd-logger/src/bounded_buffer/mod.rs
@@ -54,30 +54,18 @@ pub fn channel<L: MemorySized>(
 pub struct MemoryReservationErrorNoMemory {}
 
 #[derive(Debug, thiserror::Error)]
-pub enum TrySendError<T: MemorySized> {
+pub enum TrySendError {
   // Adding a message to the buffer would cause the buffer to
   // exceed the maximum number of messages it was configured to
   // hold.
-  FullCountOverflow(T),
+  #[error("buffer count overflow")]
+  FullCountOverflow,
   // Adding a message to the buffer would cause the buffer to exceed it's
   // memory capacity.
-  FullSizeOverflow(T),
-  Closed(T),
-}
-
-impl<T: MemorySized + std::fmt::Display> std::fmt::Display for TrySendError<T> {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match self {
-      Self::FullCountOverflow(message) => write!(f, "log \"{message}\", channel count overflow"),
-      Self::FullSizeOverflow(message) => write!(
-        f,
-        "log \"{}\" (size {}), channel size overflow",
-        message,
-        message.size()
-      ),
-      Self::Closed(_) => write!(f, "channel Closed"),
-    }
-  }
+  #[error("buffer size overflow")]
+  FullSizeOverflow,
+  #[error("buffer closed")]
+  Closed,
 }
 
 pub struct Sender<T: MemorySized> {
@@ -88,12 +76,12 @@ pub struct Sender<T: MemorySized> {
 
 impl<T: MemorySized> Sender<T> {
   // Try to send a given message to the channel. Fails when the channel is closed or full.
-  pub fn try_send(&self, message: T) -> Result<(), TrySendError<T>> {
+  pub fn try_send(&self, message: T) -> Result<(), TrySendError> {
     let message_size = message.size() as u64;
     let result = self.try_reserve_memory(message_size);
 
     let Ok(()) = result else {
-      return Err(TrySendError::FullSizeOverflow(message));
+      return Err(TrySendError::FullSizeOverflow);
     };
 
     match self.tx.try_send(message) {
@@ -101,15 +89,15 @@ impl<T: MemorySized> Sender<T> {
         log::trace!("Added {message_size:?} bytes to the channel");
         Ok(())
       },
-      Err(TokioTrySendError::Closed(message)) => {
+      Err(TokioTrySendError::Closed(_)) => {
         log::debug!("Failed to add {message_size:?} bytes to the channel: Channel is closed");
         self.void_memory_reservation(message_size);
-        Err(TrySendError::Closed(message))
+        Err(TrySendError::Closed)
       },
-      Err(TokioTrySendError::Full(message)) => {
+      Err(TokioTrySendError::Full(_)) => {
         log::debug!("Failed to add {message_size:?} bytes to the channel: Channel is full");
         self.void_memory_reservation(message_size);
-        Err(TrySendError::FullCountOverflow(message))
+        Err(TrySendError::FullCountOverflow)
       },
     }
   }
@@ -221,16 +209,16 @@ impl SendCounters {
     }
   }
 
-  pub(crate) fn record<T: MemorySized>(&self, result: &std::result::Result<(), TrySendError<T>>) {
+  pub(crate) fn record(&self, result: &std::result::Result<(), TrySendError>) {
     match result {
       Ok(()) => self.ok.inc(),
-      Err(TrySendError::FullCountOverflow(_)) => {
+      Err(TrySendError::FullCountOverflow) => {
         self.err_full_count_overflow.inc();
       },
-      Err(TrySendError::FullSizeOverflow(_)) => {
+      Err(TrySendError::FullSizeOverflow) => {
         self.err_full_size_overflow.inc();
       },
-      Err(TrySendError::Closed(_)) => self.err_closed.inc(),
+      Err(TrySendError::Closed) => self.err_closed.inc(),
     }
   }
 }

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -245,8 +245,7 @@ impl LoggerBuilder {
         config_update_tx,
         &scope.scope("config"),
       ),
-      &scope,
-    )?);
+    ));
 
     let mut crash_monitor = bd_crash_handler::Monitor::new(
       &runtime_loader,

--- a/bd-logger/src/client_config.rs
+++ b/bd-logger/src/client_config.rs
@@ -14,7 +14,7 @@ use anyhow::anyhow;
 use bd_api::{ClientConfigurationUpdate, FromResponse, IntoRequest};
 use bd_buffer::{AbslCode, RingBuffer as _};
 use bd_client_common::fb::make_log;
-use bd_client_common::file::{read_compressed_protobuf, write_compressed_protobuf};
+use bd_client_common::safe_file_cache::SafeFileCache;
 use bd_client_stats_store::{Counter, Scope};
 use bd_log_filter::FilterChain;
 use bd_log_primitives::LogRef;
@@ -34,7 +34,7 @@ use bd_proto::protos::workflow::workflow::WorkflowsConfiguration as WorkflowsCon
 use bd_workflows::config::WorkflowsConfiguration;
 use itertools::Itertools;
 use protobuf::Chars;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 
@@ -66,15 +66,10 @@ impl Configuration {
 
 // Manages config validation and persistence.
 pub struct Config<A: ApplyConfig> {
-  // The file to write the configuration data to.
-  configuration_file: PathBuf,
+  file_cache: SafeFileCache<ConfigurationUpdate>,
 
   // The currently applied version id, if a configuration has been applied.
   configuration_version_id: Option<String>,
-
-  // Tracks how often we fail to serialize the configuration to disk.
-  #[allow(clippy::struct_field_names)]
-  config_cache_failure: Counter,
 
   // Delegate used to apply the configuration. This allows for easier testing.
   #[allow(clippy::struct_field_names)]
@@ -82,22 +77,17 @@ pub struct Config<A: ApplyConfig> {
 }
 
 impl<A: ApplyConfig> Config<A> {
-  pub fn new(sdk_directory: &Path, apply_config: A, stats: &Scope) -> anyhow::Result<Self> {
-    if !sdk_directory.exists() {
-      anyhow::bail!("an invalid sdk directory was provided: {sdk_directory:?}");
-    }
-
-    Ok(Self {
-      configuration_file: sdk_directory.join("config.pb"),
+  pub fn new(sdk_directory: &Path, apply_config: A) -> Self {
+    Self {
+      file_cache: SafeFileCache::new(sdk_directory, "config"),
       configuration_version_id: None,
-      config_cache_failure: stats.scope("config").counter("cache_failure"),
       apply_config,
-    })
+    }
   }
 
   // Process a new configuration update. If the configuration failed to apply, returns a Nack
   // containing the error details.
-  pub async fn process_configuration_update(
+  async fn process_configuration_update_inner(
     &mut self,
     update: &ConfigurationUpdate,
   ) -> anyhow::Result<()> {
@@ -113,6 +103,20 @@ impl<A: ApplyConfig> Config<A> {
       .apply_configuration(Configuration::new(sotw))
       .await?;
 
+    // Since we've validated that the configuration works and has been applied, we keep track
+    // of the id here in order to surface it both via handshake requests sent on stream creation
+    // as well as configuration acks/nacks.
+    self.configuration_version_id = Some(update.version_nonce.clone());
+
+    Ok(())
+  }
+
+  pub async fn process_configuration_update(
+    &mut self,
+    update: &ConfigurationUpdate,
+  ) -> anyhow::Result<()> {
+    self.process_configuration_update_inner(update).await?;
+
     // Upon applying the configuration successfully, write the configuration proto to disk.
     // This ensures that when we come up we can immediately start processing logs without
     // having to wait for the API server to respond.
@@ -124,50 +128,23 @@ impl<A: ApplyConfig> Config<A> {
     // check if this is an out of disk issue without parsing the error message (not platform
     // independent) so it's tricky to avoid this being noisy. We may consider doing such
     // parsing on the server side.
-    if tokio::fs::write(&self.configuration_file, write_compressed_protobuf(update))
-      .await
-      .is_err()
-    {
-      self.config_cache_failure.inc();
-    }
-
-    // Since we've validated that the configuration works and has been applied, we keep track
-    // of the id here in order to surface it both via handshake requests sent on stream creation
-    // as well as configuration acks/nacks.
-    self.configuration_version_id = Some(update.version_nonce.clone());
+    self.file_cache.cache_update(update).await;
 
     Ok(())
   }
 
   // Attempts to load persisted config and apply as if it was a newly received configuration.
-  pub async fn try_load_persisted_config_helper(&mut self) -> anyhow::Result<()> {
-    let result: anyhow::Result<()> = {
-      // We don't use handle_unexpected_error here for custom logging and to let us unit test this
-      // code path.
-      // TODO(snowp): Track failures here via analytic events.
-      let result =
-        async { read_compressed_protobuf(&tokio::fs::read(&self.configuration_file).await?) }.await;
-
-      // As soon as we've read the file contents, delete it. If we fail to parse the contents,
-      // the file will be gone and it won't be read again. If we succeed to parse and apply the
-      // contents, we end up writing the file back to disk.
-      tokio::fs::remove_file(&self.configuration_file).await?;
-
-      let configuration_update: ConfigurationUpdate = result?;
-
+  pub async fn try_load_persisted_config_helper(&mut self) {
+    if let Some(configuration_update) = self.file_cache.handle_cached_config().await {
       // If this function succeeds, it should write back the file to disk.
       let maybe_nack = self
-        .process_configuration_update(&configuration_update)
+        .process_configuration_update_inner(&configuration_update)
         .await;
 
-      // We should never persist config that results in a Nack, but if we do we effectively drop the
-      // config on startup as the above function won't write it back.
+      // We should never persist config that results in a Nack, but if we do we effectively drop
+      // the config on startup as the above function won't write it back.
       debug_assert!(maybe_nack.is_ok());
-
-      Ok(())
-    };
-
-    result.map_err(|e| e.context("failed to load persisted config"))
+    }
   }
 }
 
@@ -201,17 +178,17 @@ impl<A: ApplyConfig + Send + Sync> bd_api::ConfigurationUpdate for Config<A> {
   }
 
   async fn try_load_persisted_config(&mut self) {
-    let _ignored = self.try_load_persisted_config_helper().await;
+    self.try_load_persisted_config_helper().await;
   }
 
-  fn partial_handshake(&self) -> HandshakeRequest {
-    HandshakeRequest {
-      configuration_version_nonce: self.configuration_version_id.clone().unwrap_or_default(),
-      ..Default::default()
-    }
+  fn fill_handshake(&self, handshake: &mut HandshakeRequest) {
+    handshake.configuration_version_nonce =
+      self.configuration_version_id.clone().unwrap_or_default();
   }
 
-  fn on_handshake_complete(&self) {}
+  async fn on_handshake_complete(&self) {
+    self.file_cache.mark_safe().await;
+  }
 }
 
 // Update handle that updates the buffer configuration and thread local state for a given logger.

--- a/bd-logger/src/client_config_test.rs
+++ b/bd-logger/src/client_config_test.rs
@@ -7,12 +7,10 @@
 
 use super::{Config, Configuration};
 use anyhow::anyhow;
-use bd_client_stats_store::Collector;
 use bd_proto::protos::client::api::configuration_update::{StateOfTheWorld, Update_type};
 use bd_proto::protos::client::api::ConfigurationUpdate;
 use bd_proto::protos::config::v1::config::BufferConfigList;
 use pretty_assertions::assert_eq;
-use std::path::Path;
 use tempfile::TempDir;
 use tokio::sync::mpsc::channel;
 
@@ -44,11 +42,10 @@ fn configuration_update() -> ConfigurationUpdate {
 
 #[tokio::test]
 async fn process_and_load() {
-  let stats = Collector::default();
   let (configuration_tx, mut configuration_rx) = channel(2);
   let update = TestUpdate { configuration_tx };
   let directory = TempDir::with_prefix("sdk").unwrap();
-  let mut config = Config::new(directory.path(), update, &stats.scope("")).unwrap();
+  let mut config = Config::new(directory.path(), update);
 
   config
     .process_configuration_update(&configuration_update())
@@ -60,21 +57,9 @@ async fn process_and_load() {
     configuration_rx.recv().await.unwrap()
   );
 
-  config.try_load_persisted_config_helper().await.unwrap();
+  config.try_load_persisted_config_helper().await;
 
   configuration_rx.recv().await;
-}
-
-#[tokio::test]
-async fn load_bad_file() {
-  let (configuration_tx, _configuration_rx) = channel(2);
-  let update = TestUpdate { configuration_tx };
-  let stats = Collector::default();
-  let config = Config::new(Path::new("doesntexist"), update, &stats.scope(""));
-  assert_eq!(
-    "an invalid sdk directory was provided: \"doesntexist\"",
-    config.err().unwrap().to_string(),
-  );
 }
 
 #[tokio::test]
@@ -82,12 +67,11 @@ async fn cache_write_fails() {
   let (configuration_tx, mut configuration_rx) = channel(2);
   let update = TestUpdate { configuration_tx };
   let directory = TempDir::with_prefix("sdk").unwrap();
-  let stats = Collector::default();
-  let mut config = Config::new(directory.path(), update, &stats.scope("")).unwrap();
+  let mut config = Config::new(directory.path(), update);
 
   // Create the config file, then make it read only. This should make the attempt to cache fail,
   // which should result in this being reported as an error.
-  let config_file = directory.path().join("config.pb");
+  let config_file = directory.path().join("config").join("protobuf.pb");
   std::fs::write(&config_file, []).unwrap();
   let mut perms = std::fs::metadata(&config_file).unwrap().permissions();
   perms.set_readonly(true);
@@ -112,18 +96,13 @@ async fn cache_write_fails() {
 async fn load_malformed_file() {
   let (configuration_tx, _configuration_rx) = channel(2);
   let update = TestUpdate { configuration_tx };
-  let stats = Collector::default();
-  let mut config = Config::new(Path::new("."), update, &stats.scope("")).unwrap();
+  let directory = TempDir::with_prefix("sdk").unwrap();
+  let mut config = Config::new(directory.path(), update);
 
-  let config_file = Path::new("./config.pb");
+  let config_file = directory.path().join("config").join("protobuf.pb");
+  std::fs::write(&config_file, "not a proto").unwrap();
 
-  std::fs::write(config_file, "not a proto").unwrap();
-
-  let load_result = config.try_load_persisted_config_helper().await;
-  assert_eq!(
-    load_result.err().unwrap().to_string(),
-    "corrupt deflate stream"
-  );
+  config.try_load_persisted_config_helper().await;
 
   // Validate that we remove the file if it fails decoding.
   assert!(!config_file.exists());

--- a/bd-logger/src/logging_state.rs
+++ b/bd-logger/src/logging_state.rs
@@ -38,6 +38,7 @@ use tokio::sync::mpsc::Sender;
 /// The logging state used by the `AsyncLogBuffer` to encapsulate objects
 /// that are needed to process incoming logs.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum LoggingState<T: MemorySized + Debug> {
   /// The initial state that each `AsyncLogBuffer` starts in. While in this state
   /// the buffer takes incoming logs, populates them with extra information using

--- a/bd-logger/src/ratelimit_test.rs
+++ b/bd-logger/src/ratelimit_test.rs
@@ -51,16 +51,18 @@ async fn ratelimit() {
   let runtime_loader = ConfigLoader::new(directory.path());
 
   // Set the ratelimit parameters to 10 characters per minute.
-  runtime_loader.update_snapshot(&make_simple_update(vec![
-    (
-      bd_runtime::runtime::log_upload::RatelimitByteCountPerPeriodFlag::path(),
-      ValueKind::Int(10),
-    ),
-    (
-      bd_runtime::runtime::log_upload::RatelimitPeriodFlag::path(),
-      ValueKind::Int(1000),
-    ),
-  ]));
+  runtime_loader
+    .update_snapshot(&make_simple_update(vec![
+      (
+        bd_runtime::runtime::log_upload::RatelimitByteCountPerPeriodFlag::path(),
+        ValueKind::Int(10),
+      ),
+      (
+        bd_runtime::runtime::log_upload::RatelimitPeriodFlag::path(),
+        ValueKind::Int(1000),
+      ),
+    ]))
+    .await;
 
   let rate_limit = RateLimitLayer::new(super::Rate::new(&runtime_loader).unwrap());
   let mut service = tower::ServiceBuilder::new()
@@ -93,16 +95,18 @@ async fn shared_quota() {
   let runtime_loader = ConfigLoader::new(directory.path());
 
   // Set the ratelimit parameters to 2 characters per second.
-  runtime_loader.update_snapshot(&make_simple_update(vec![
-    (
-      bd_runtime::runtime::log_upload::RatelimitByteCountPerPeriodFlag::path(),
-      ValueKind::Int(2),
-    ),
-    (
-      bd_runtime::runtime::log_upload::RatelimitPeriodFlag::path(),
-      ValueKind::Int(1000),
-    ),
-  ]));
+  runtime_loader
+    .update_snapshot(&make_simple_update(vec![
+      (
+        bd_runtime::runtime::log_upload::RatelimitByteCountPerPeriodFlag::path(),
+        ValueKind::Int(2),
+      ),
+      (
+        bd_runtime::runtime::log_upload::RatelimitPeriodFlag::path(),
+        ValueKind::Int(1000),
+      ),
+    ]))
+    .await;
 
   let rate_limit = RateLimitLayer::new(super::Rate::new(&runtime_loader).unwrap());
   let mut service1 = tower::ServiceBuilder::new()

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -1941,7 +1941,7 @@ fn runtime_caching() {
   assert!(sdk_directory
     .path()
     .join("runtime")
-    .join("update.pb")
+    .join("protobuf.pb")
     .exists());
   assert!(retry_file.exists());
   assert_eq!(std::fs::read(&retry_file).unwrap(), b"0");

--- a/bd-proto/src/protos/client/api.rs
+++ b/bd-proto/src/protos/client/api.rs
@@ -182,8 +182,6 @@ pub struct HandshakeRequest {
     pub configuration_version_nonce: ::std::string::String,
     // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.HandshakeRequest.runtime_version_nonce)
     pub runtime_version_nonce: ::std::string::String,
-    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.HandshakeRequest.opqaue_version_nonces)
-    pub opqaue_version_nonces: ::std::collections::HashMap<::std::string::String, ::std::string::String>,
     // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.HandshakeRequest.previous_disconnect_reason)
     pub previous_disconnect_reason: ::std::string::String,
     // special fields
@@ -203,7 +201,7 @@ impl HandshakeRequest {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(5);
+        let mut fields = ::std::vec::Vec::with_capacity(4);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_map_simpler_accessor_new::<_, _>(
             "static_device_metadata",
@@ -219,11 +217,6 @@ impl HandshakeRequest {
             "runtime_version_nonce",
             |m: &HandshakeRequest| { &m.runtime_version_nonce },
             |m: &mut HandshakeRequest| { &mut m.runtime_version_nonce },
-        ));
-        fields.push(::protobuf::reflect::rt::v2::make_map_simpler_accessor_new::<_, _>(
-            "opqaue_version_nonces",
-            |m: &HandshakeRequest| { &m.opqaue_version_nonces },
-            |m: &mut HandshakeRequest| { &mut m.opqaue_version_nonces },
         ));
         fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
             "previous_disconnect_reason",
@@ -269,21 +262,6 @@ impl ::protobuf::Message for HandshakeRequest {
                 34 => {
                     self.runtime_version_nonce = is.read_string()?;
                 },
-                42 => {
-                    let len = is.read_raw_varint32()?;
-                    let old_limit = is.push_limit(len as u64)?;
-                    let mut key = ::std::default::Default::default();
-                    let mut value = ::std::default::Default::default();
-                    while let Some(tag) = is.read_raw_tag_or_eof()? {
-                        match tag {
-                            10 => key = is.read_string()?,
-                            18 => value = is.read_string()?,
-                            _ => ::protobuf::rt::skip_field_for_tag(tag, is)?,
-                        };
-                    }
-                    is.pop_limit(old_limit);
-                    self.opqaue_version_nonces.insert(key, value);
-                },
                 50 => {
                     self.previous_disconnect_reason = is.read_string()?;
                 },
@@ -312,12 +290,6 @@ impl ::protobuf::Message for HandshakeRequest {
         if !self.runtime_version_nonce.is_empty() {
             my_size += ::protobuf::rt::string_size(4, &self.runtime_version_nonce);
         }
-        for (k, v) in &self.opqaue_version_nonces {
-            let mut entry_size = 0;
-            entry_size += ::protobuf::rt::string_size(1, &k);
-            entry_size += ::protobuf::rt::string_size(2, &v);
-            my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(entry_size) + entry_size
-        };
         if !self.previous_disconnect_reason.is_empty() {
             my_size += ::protobuf::rt::string_size(6, &self.previous_disconnect_reason);
         }
@@ -343,15 +315,6 @@ impl ::protobuf::Message for HandshakeRequest {
         if !self.runtime_version_nonce.is_empty() {
             os.write_string(4, &self.runtime_version_nonce)?;
         }
-        for (k, v) in &self.opqaue_version_nonces {
-            let mut entry_size = 0;
-            entry_size += ::protobuf::rt::string_size(1, &k);
-            entry_size += ::protobuf::rt::string_size(2, &v);
-            os.write_raw_varint32(42)?; // Tag.
-            os.write_raw_varint32(entry_size as u32)?;
-            os.write_string(1, &k)?;
-            os.write_string(2, &v)?;
-        };
         if !self.previous_disconnect_reason.is_empty() {
             os.write_string(6, &self.previous_disconnect_reason)?;
         }
@@ -375,7 +338,6 @@ impl ::protobuf::Message for HandshakeRequest {
         self.static_device_metadata.clear();
         self.configuration_version_nonce.clear();
         self.runtime_version_nonce.clear();
-        self.opqaue_version_nonces.clear();
         self.previous_disconnect_reason.clear();
         self.special_fields.clear();
     }
@@ -400,288 +362,6 @@ impl ::std::fmt::Display for HandshakeRequest {
 }
 
 impl ::protobuf::reflect::ProtobufValue for HandshakeRequest {
-    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
-}
-
-// @@protoc_insertion_point(message:bitdrift_public.protobuf.client.v1.OpaqueConfigurationUpdate)
-#[derive(PartialEq,Clone,Default,Debug)]
-pub struct OpaqueConfigurationUpdate {
-    // message fields
-    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.OpaqueConfigurationUpdate.version_nonce)
-    pub version_nonce: ::std::string::String,
-    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.OpaqueConfigurationUpdate.configuration)
-    pub configuration: ::protobuf::MessageField<::protobuf::well_known_types::any::Any>,
-    // special fields
-    // @@protoc_insertion_point(special_field:bitdrift_public.protobuf.client.v1.OpaqueConfigurationUpdate.special_fields)
-    pub special_fields: ::protobuf::SpecialFields,
-}
-
-impl<'a> ::std::default::Default for &'a OpaqueConfigurationUpdate {
-    fn default() -> &'a OpaqueConfigurationUpdate {
-        <OpaqueConfigurationUpdate as ::protobuf::Message>::default_instance()
-    }
-}
-
-impl OpaqueConfigurationUpdate {
-    pub fn new() -> OpaqueConfigurationUpdate {
-        ::std::default::Default::default()
-    }
-
-    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(2);
-        let mut oneofs = ::std::vec::Vec::with_capacity(0);
-        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
-            "version_nonce",
-            |m: &OpaqueConfigurationUpdate| { &m.version_nonce },
-            |m: &mut OpaqueConfigurationUpdate| { &mut m.version_nonce },
-        ));
-        fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, ::protobuf::well_known_types::any::Any>(
-            "configuration",
-            |m: &OpaqueConfigurationUpdate| { &m.configuration },
-            |m: &mut OpaqueConfigurationUpdate| { &mut m.configuration },
-        ));
-        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<OpaqueConfigurationUpdate>(
-            "OpaqueConfigurationUpdate",
-            fields,
-            oneofs,
-        )
-    }
-}
-
-impl ::protobuf::Message for OpaqueConfigurationUpdate {
-    const NAME: &'static str = "OpaqueConfigurationUpdate";
-
-    fn is_initialized(&self) -> bool {
-        true
-    }
-
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
-        while let Some(tag) = is.read_raw_tag_or_eof()? {
-            match tag {
-                10 => {
-                    self.version_nonce = is.read_string()?;
-                },
-                18 => {
-                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.configuration)?;
-                },
-                tag => {
-                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
-                },
-            };
-        }
-        ::std::result::Result::Ok(())
-    }
-
-    // Compute sizes of nested messages
-    #[allow(unused_variables)]
-    fn compute_size(&self) -> u64 {
-        let mut my_size = 0;
-        if !self.version_nonce.is_empty() {
-            my_size += ::protobuf::rt::string_size(1, &self.version_nonce);
-        }
-        if let Some(v) = self.configuration.as_ref() {
-            let len = v.compute_size();
-            my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
-        }
-        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
-        self.special_fields.cached_size().set(my_size as u32);
-        my_size
-    }
-
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        if !self.version_nonce.is_empty() {
-            os.write_string(1, &self.version_nonce)?;
-        }
-        if let Some(v) = self.configuration.as_ref() {
-            ::protobuf::rt::write_message_field_with_cached_size(2, v, os)?;
-        }
-        os.write_unknown_fields(self.special_fields.unknown_fields())?;
-        ::std::result::Result::Ok(())
-    }
-
-    fn special_fields(&self) -> &::protobuf::SpecialFields {
-        &self.special_fields
-    }
-
-    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
-        &mut self.special_fields
-    }
-
-    fn new() -> OpaqueConfigurationUpdate {
-        OpaqueConfigurationUpdate::new()
-    }
-
-    fn clear(&mut self) {
-        self.version_nonce.clear();
-        self.configuration.clear();
-        self.special_fields.clear();
-    }
-
-    fn default_instance() -> &'static OpaqueConfigurationUpdate {
-        static instance: OpaqueConfigurationUpdate = OpaqueConfigurationUpdate {
-            version_nonce: ::std::string::String::new(),
-            configuration: ::protobuf::MessageField::none(),
-            special_fields: ::protobuf::SpecialFields::new(),
-        };
-        &instance
-    }
-}
-
-impl ::protobuf::MessageFull for OpaqueConfigurationUpdate {
-    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
-        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
-        descriptor.get(|| file_descriptor().message_by_package_relative_name("OpaqueConfigurationUpdate").unwrap()).clone()
-    }
-}
-
-impl ::std::fmt::Display for OpaqueConfigurationUpdate {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
-impl ::protobuf::reflect::ProtobufValue for OpaqueConfigurationUpdate {
-    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
-}
-
-// @@protoc_insertion_point(message:bitdrift_public.protobuf.client.v1.OpaqueConfigurationUpdateAck)
-#[derive(PartialEq,Clone,Default,Debug)]
-pub struct OpaqueConfigurationUpdateAck {
-    // message fields
-    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.OpaqueConfigurationUpdateAck.type_url)
-    pub type_url: ::std::string::String,
-    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.OpaqueConfigurationUpdateAck.ack)
-    pub ack: ::protobuf::MessageField<ConfigurationUpdateAck>,
-    // special fields
-    // @@protoc_insertion_point(special_field:bitdrift_public.protobuf.client.v1.OpaqueConfigurationUpdateAck.special_fields)
-    pub special_fields: ::protobuf::SpecialFields,
-}
-
-impl<'a> ::std::default::Default for &'a OpaqueConfigurationUpdateAck {
-    fn default() -> &'a OpaqueConfigurationUpdateAck {
-        <OpaqueConfigurationUpdateAck as ::protobuf::Message>::default_instance()
-    }
-}
-
-impl OpaqueConfigurationUpdateAck {
-    pub fn new() -> OpaqueConfigurationUpdateAck {
-        ::std::default::Default::default()
-    }
-
-    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(2);
-        let mut oneofs = ::std::vec::Vec::with_capacity(0);
-        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
-            "type_url",
-            |m: &OpaqueConfigurationUpdateAck| { &m.type_url },
-            |m: &mut OpaqueConfigurationUpdateAck| { &mut m.type_url },
-        ));
-        fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, ConfigurationUpdateAck>(
-            "ack",
-            |m: &OpaqueConfigurationUpdateAck| { &m.ack },
-            |m: &mut OpaqueConfigurationUpdateAck| { &mut m.ack },
-        ));
-        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<OpaqueConfigurationUpdateAck>(
-            "OpaqueConfigurationUpdateAck",
-            fields,
-            oneofs,
-        )
-    }
-}
-
-impl ::protobuf::Message for OpaqueConfigurationUpdateAck {
-    const NAME: &'static str = "OpaqueConfigurationUpdateAck";
-
-    fn is_initialized(&self) -> bool {
-        true
-    }
-
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
-        while let Some(tag) = is.read_raw_tag_or_eof()? {
-            match tag {
-                10 => {
-                    self.type_url = is.read_string()?;
-                },
-                18 => {
-                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.ack)?;
-                },
-                tag => {
-                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
-                },
-            };
-        }
-        ::std::result::Result::Ok(())
-    }
-
-    // Compute sizes of nested messages
-    #[allow(unused_variables)]
-    fn compute_size(&self) -> u64 {
-        let mut my_size = 0;
-        if !self.type_url.is_empty() {
-            my_size += ::protobuf::rt::string_size(1, &self.type_url);
-        }
-        if let Some(v) = self.ack.as_ref() {
-            let len = v.compute_size();
-            my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
-        }
-        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
-        self.special_fields.cached_size().set(my_size as u32);
-        my_size
-    }
-
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        if !self.type_url.is_empty() {
-            os.write_string(1, &self.type_url)?;
-        }
-        if let Some(v) = self.ack.as_ref() {
-            ::protobuf::rt::write_message_field_with_cached_size(2, v, os)?;
-        }
-        os.write_unknown_fields(self.special_fields.unknown_fields())?;
-        ::std::result::Result::Ok(())
-    }
-
-    fn special_fields(&self) -> &::protobuf::SpecialFields {
-        &self.special_fields
-    }
-
-    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
-        &mut self.special_fields
-    }
-
-    fn new() -> OpaqueConfigurationUpdateAck {
-        OpaqueConfigurationUpdateAck::new()
-    }
-
-    fn clear(&mut self) {
-        self.type_url.clear();
-        self.ack.clear();
-        self.special_fields.clear();
-    }
-
-    fn default_instance() -> &'static OpaqueConfigurationUpdateAck {
-        static instance: OpaqueConfigurationUpdateAck = OpaqueConfigurationUpdateAck {
-            type_url: ::std::string::String::new(),
-            ack: ::protobuf::MessageField::none(),
-            special_fields: ::protobuf::SpecialFields::new(),
-        };
-        &instance
-    }
-}
-
-impl ::protobuf::MessageFull for OpaqueConfigurationUpdateAck {
-    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
-        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
-        descriptor.get(|| file_descriptor().message_by_package_relative_name("OpaqueConfigurationUpdateAck").unwrap()).clone()
-    }
-}
-
-impl ::std::fmt::Display for OpaqueConfigurationUpdateAck {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
-impl ::protobuf::reflect::ProtobufValue for OpaqueConfigurationUpdateAck {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
@@ -2517,104 +2197,6 @@ impl ApiRequest {
         }
     }
 
-    // .bitdrift_public.protobuf.client.v1.OpaqueConfigurationUpdateAck opaque_configuration_update_ack = 8;
-
-    pub fn opaque_configuration_update_ack(&self) -> &OpaqueConfigurationUpdateAck {
-        match self.request_type {
-            ::std::option::Option::Some(api_request::Request_type::OpaqueConfigurationUpdateAck(ref v)) => v,
-            _ => <OpaqueConfigurationUpdateAck as ::protobuf::Message>::default_instance(),
-        }
-    }
-
-    pub fn clear_opaque_configuration_update_ack(&mut self) {
-        self.request_type = ::std::option::Option::None;
-    }
-
-    pub fn has_opaque_configuration_update_ack(&self) -> bool {
-        match self.request_type {
-            ::std::option::Option::Some(api_request::Request_type::OpaqueConfigurationUpdateAck(..)) => true,
-            _ => false,
-        }
-    }
-
-    // Param is passed by value, moved
-    pub fn set_opaque_configuration_update_ack(&mut self, v: OpaqueConfigurationUpdateAck) {
-        self.request_type = ::std::option::Option::Some(api_request::Request_type::OpaqueConfigurationUpdateAck(v))
-    }
-
-    // Mutable pointer to the field.
-    pub fn mut_opaque_configuration_update_ack(&mut self) -> &mut OpaqueConfigurationUpdateAck {
-        if let ::std::option::Option::Some(api_request::Request_type::OpaqueConfigurationUpdateAck(_)) = self.request_type {
-        } else {
-            self.request_type = ::std::option::Option::Some(api_request::Request_type::OpaqueConfigurationUpdateAck(OpaqueConfigurationUpdateAck::new()));
-        }
-        match self.request_type {
-            ::std::option::Option::Some(api_request::Request_type::OpaqueConfigurationUpdateAck(ref mut v)) => v,
-            _ => panic!(),
-        }
-    }
-
-    // Take field
-    pub fn take_opaque_configuration_update_ack(&mut self) -> OpaqueConfigurationUpdateAck {
-        if self.has_opaque_configuration_update_ack() {
-            match self.request_type.take() {
-                ::std::option::Option::Some(api_request::Request_type::OpaqueConfigurationUpdateAck(v)) => v,
-                _ => panic!(),
-            }
-        } else {
-            OpaqueConfigurationUpdateAck::new()
-        }
-    }
-
-    // .bitdrift_public.protobuf.client.v1.OpaqueRequest opaque_upload = 9;
-
-    pub fn opaque_upload(&self) -> &OpaqueRequest {
-        match self.request_type {
-            ::std::option::Option::Some(api_request::Request_type::OpaqueUpload(ref v)) => v,
-            _ => <OpaqueRequest as ::protobuf::Message>::default_instance(),
-        }
-    }
-
-    pub fn clear_opaque_upload(&mut self) {
-        self.request_type = ::std::option::Option::None;
-    }
-
-    pub fn has_opaque_upload(&self) -> bool {
-        match self.request_type {
-            ::std::option::Option::Some(api_request::Request_type::OpaqueUpload(..)) => true,
-            _ => false,
-        }
-    }
-
-    // Param is passed by value, moved
-    pub fn set_opaque_upload(&mut self, v: OpaqueRequest) {
-        self.request_type = ::std::option::Option::Some(api_request::Request_type::OpaqueUpload(v))
-    }
-
-    // Mutable pointer to the field.
-    pub fn mut_opaque_upload(&mut self) -> &mut OpaqueRequest {
-        if let ::std::option::Option::Some(api_request::Request_type::OpaqueUpload(_)) = self.request_type {
-        } else {
-            self.request_type = ::std::option::Option::Some(api_request::Request_type::OpaqueUpload(OpaqueRequest::new()));
-        }
-        match self.request_type {
-            ::std::option::Option::Some(api_request::Request_type::OpaqueUpload(ref mut v)) => v,
-            _ => panic!(),
-        }
-    }
-
-    // Take field
-    pub fn take_opaque_upload(&mut self) -> OpaqueRequest {
-        if self.has_opaque_upload() {
-            match self.request_type.take() {
-                ::std::option::Option::Some(api_request::Request_type::OpaqueUpload(v)) => v,
-                _ => panic!(),
-            }
-        } else {
-            OpaqueRequest::new()
-        }
-    }
-
     // .bitdrift_public.protobuf.client.v1.SankeyPathUploadRequest sankey_path_upload = 10;
 
     pub fn sankey_path_upload(&self) -> &SankeyPathUploadRequest {
@@ -2812,7 +2394,7 @@ impl ApiRequest {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(13);
+        let mut fields = ::std::vec::Vec::with_capacity(11);
         let mut oneofs = ::std::vec::Vec::with_capacity(1);
         fields.push(::protobuf::reflect::rt::v2::make_oneof_message_has_get_mut_set_accessor::<_, HandshakeRequest>(
             "handshake",
@@ -2862,20 +2444,6 @@ impl ApiRequest {
             ApiRequest::runtime_update_ack,
             ApiRequest::mut_runtime_update_ack,
             ApiRequest::set_runtime_update_ack,
-        ));
-        fields.push(::protobuf::reflect::rt::v2::make_oneof_message_has_get_mut_set_accessor::<_, OpaqueConfigurationUpdateAck>(
-            "opaque_configuration_update_ack",
-            ApiRequest::has_opaque_configuration_update_ack,
-            ApiRequest::opaque_configuration_update_ack,
-            ApiRequest::mut_opaque_configuration_update_ack,
-            ApiRequest::set_opaque_configuration_update_ack,
-        ));
-        fields.push(::protobuf::reflect::rt::v2::make_oneof_message_has_get_mut_set_accessor::<_, OpaqueRequest>(
-            "opaque_upload",
-            ApiRequest::has_opaque_upload,
-            ApiRequest::opaque_upload,
-            ApiRequest::mut_opaque_upload,
-            ApiRequest::set_opaque_upload,
         ));
         fields.push(::protobuf::reflect::rt::v2::make_oneof_message_has_get_mut_set_accessor::<_, SankeyPathUploadRequest>(
             "sankey_path_upload",
@@ -2945,12 +2513,6 @@ impl ::protobuf::Message for ApiRequest {
                 42 => {
                     self.request_type = ::std::option::Option::Some(api_request::Request_type::RuntimeUpdateAck(is.read_message()?));
                 },
-                66 => {
-                    self.request_type = ::std::option::Option::Some(api_request::Request_type::OpaqueConfigurationUpdateAck(is.read_message()?));
-                },
-                74 => {
-                    self.request_type = ::std::option::Option::Some(api_request::Request_type::OpaqueUpload(is.read_message()?));
-                },
                 82 => {
                     self.request_type = ::std::option::Option::Some(api_request::Request_type::SankeyPathUpload(is.read_message()?));
                 },
@@ -3005,14 +2567,6 @@ impl ::protobuf::Message for ApiRequest {
                     let len = v.compute_size();
                     my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
                 },
-                &api_request::Request_type::OpaqueConfigurationUpdateAck(ref v) => {
-                    let len = v.compute_size();
-                    my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
-                },
-                &api_request::Request_type::OpaqueUpload(ref v) => {
-                    let len = v.compute_size();
-                    my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
-                },
                 &api_request::Request_type::SankeyPathUpload(ref v) => {
                     let len = v.compute_size();
                     my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
@@ -3060,12 +2614,6 @@ impl ::protobuf::Message for ApiRequest {
                 &api_request::Request_type::RuntimeUpdateAck(ref v) => {
                     ::protobuf::rt::write_message_field_with_cached_size(5, v, os)?;
                 },
-                &api_request::Request_type::OpaqueConfigurationUpdateAck(ref v) => {
-                    ::protobuf::rt::write_message_field_with_cached_size(8, v, os)?;
-                },
-                &api_request::Request_type::OpaqueUpload(ref v) => {
-                    ::protobuf::rt::write_message_field_with_cached_size(9, v, os)?;
-                },
                 &api_request::Request_type::SankeyPathUpload(ref v) => {
                     ::protobuf::rt::write_message_field_with_cached_size(10, v, os)?;
                 },
@@ -3097,8 +2645,6 @@ impl ::protobuf::Message for ApiRequest {
     }
 
     fn clear(&mut self) {
-        self.request_type = ::std::option::Option::None;
-        self.request_type = ::std::option::Option::None;
         self.request_type = ::std::option::Option::None;
         self.request_type = ::std::option::Option::None;
         self.request_type = ::std::option::Option::None;
@@ -3159,10 +2705,6 @@ pub mod api_request {
         ConfigurationUpdateAck(super::ConfigurationUpdateAck),
         // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.ApiRequest.runtime_update_ack)
         RuntimeUpdateAck(super::ConfigurationUpdateAck),
-        // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.ApiRequest.opaque_configuration_update_ack)
-        OpaqueConfigurationUpdateAck(super::OpaqueConfigurationUpdateAck),
-        // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.ApiRequest.opaque_upload)
-        OpaqueUpload(super::OpaqueRequest),
         // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.ApiRequest.sankey_path_upload)
         SankeyPathUpload(super::SankeyPathUploadRequest),
         // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.ApiRequest.sankey_intent)
@@ -4650,6 +4192,8 @@ pub struct HandshakeResponse {
     // message fields
     // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.HandshakeResponse.stream_settings)
     pub stream_settings: ::protobuf::MessageField<handshake_response::StreamSettings>,
+    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.HandshakeResponse.configuration_update_status)
+    pub configuration_update_status: u32,
     // special fields
     // @@protoc_insertion_point(special_field:bitdrift_public.protobuf.client.v1.HandshakeResponse.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -4667,12 +4211,17 @@ impl HandshakeResponse {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(1);
+        let mut fields = ::std::vec::Vec::with_capacity(2);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, handshake_response::StreamSettings>(
             "stream_settings",
             |m: &HandshakeResponse| { &m.stream_settings },
             |m: &mut HandshakeResponse| { &mut m.stream_settings },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
+            "configuration_update_status",
+            |m: &HandshakeResponse| { &m.configuration_update_status },
+            |m: &mut HandshakeResponse| { &mut m.configuration_update_status },
         ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<HandshakeResponse>(
             "HandshakeResponse",
@@ -4695,6 +4244,9 @@ impl ::protobuf::Message for HandshakeResponse {
                 10 => {
                     ::protobuf::rt::read_singular_message_into_field(is, &mut self.stream_settings)?;
                 },
+                16 => {
+                    self.configuration_update_status = is.read_uint32()?;
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -4711,6 +4263,9 @@ impl ::protobuf::Message for HandshakeResponse {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
         }
+        if self.configuration_update_status != 0 {
+            my_size += ::protobuf::rt::uint32_size(2, self.configuration_update_status);
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -4719,6 +4274,9 @@ impl ::protobuf::Message for HandshakeResponse {
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
         if let Some(v) = self.stream_settings.as_ref() {
             ::protobuf::rt::write_message_field_with_cached_size(1, v, os)?;
+        }
+        if self.configuration_update_status != 0 {
+            os.write_uint32(2, self.configuration_update_status)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -4738,12 +4296,14 @@ impl ::protobuf::Message for HandshakeResponse {
 
     fn clear(&mut self) {
         self.stream_settings.clear();
+        self.configuration_update_status = 0;
         self.special_fields.clear();
     }
 
     fn default_instance() -> &'static HandshakeResponse {
         static instance: HandshakeResponse = HandshakeResponse {
             stream_settings: ::protobuf::MessageField::none(),
+            configuration_update_status: 0,
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -5977,287 +5537,6 @@ impl ::std::fmt::Display for StatsUploadResponse {
 }
 
 impl ::protobuf::reflect::ProtobufValue for StatsUploadResponse {
-    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
-}
-
-// @@protoc_insertion_point(message:bitdrift_public.protobuf.client.v1.OpaqueRequest)
-#[derive(PartialEq,Clone,Default,Debug)]
-pub struct OpaqueRequest {
-    // message fields
-    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.OpaqueRequest.uuid)
-    pub uuid: ::std::string::String,
-    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.OpaqueRequest.request)
-    pub request: ::protobuf::MessageField<::protobuf::well_known_types::any::Any>,
-    // special fields
-    // @@protoc_insertion_point(special_field:bitdrift_public.protobuf.client.v1.OpaqueRequest.special_fields)
-    pub special_fields: ::protobuf::SpecialFields,
-}
-
-impl<'a> ::std::default::Default for &'a OpaqueRequest {
-    fn default() -> &'a OpaqueRequest {
-        <OpaqueRequest as ::protobuf::Message>::default_instance()
-    }
-}
-
-impl OpaqueRequest {
-    pub fn new() -> OpaqueRequest {
-        ::std::default::Default::default()
-    }
-
-    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(2);
-        let mut oneofs = ::std::vec::Vec::with_capacity(0);
-        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
-            "uuid",
-            |m: &OpaqueRequest| { &m.uuid },
-            |m: &mut OpaqueRequest| { &mut m.uuid },
-        ));
-        fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, ::protobuf::well_known_types::any::Any>(
-            "request",
-            |m: &OpaqueRequest| { &m.request },
-            |m: &mut OpaqueRequest| { &mut m.request },
-        ));
-        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<OpaqueRequest>(
-            "OpaqueRequest",
-            fields,
-            oneofs,
-        )
-    }
-}
-
-impl ::protobuf::Message for OpaqueRequest {
-    const NAME: &'static str = "OpaqueRequest";
-
-    fn is_initialized(&self) -> bool {
-        true
-    }
-
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
-        while let Some(tag) = is.read_raw_tag_or_eof()? {
-            match tag {
-                10 => {
-                    self.uuid = is.read_string()?;
-                },
-                18 => {
-                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.request)?;
-                },
-                tag => {
-                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
-                },
-            };
-        }
-        ::std::result::Result::Ok(())
-    }
-
-    // Compute sizes of nested messages
-    #[allow(unused_variables)]
-    fn compute_size(&self) -> u64 {
-        let mut my_size = 0;
-        if !self.uuid.is_empty() {
-            my_size += ::protobuf::rt::string_size(1, &self.uuid);
-        }
-        if let Some(v) = self.request.as_ref() {
-            let len = v.compute_size();
-            my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
-        }
-        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
-        self.special_fields.cached_size().set(my_size as u32);
-        my_size
-    }
-
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        if !self.uuid.is_empty() {
-            os.write_string(1, &self.uuid)?;
-        }
-        if let Some(v) = self.request.as_ref() {
-            ::protobuf::rt::write_message_field_with_cached_size(2, v, os)?;
-        }
-        os.write_unknown_fields(self.special_fields.unknown_fields())?;
-        ::std::result::Result::Ok(())
-    }
-
-    fn special_fields(&self) -> &::protobuf::SpecialFields {
-        &self.special_fields
-    }
-
-    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
-        &mut self.special_fields
-    }
-
-    fn new() -> OpaqueRequest {
-        OpaqueRequest::new()
-    }
-
-    fn clear(&mut self) {
-        self.uuid.clear();
-        self.request.clear();
-        self.special_fields.clear();
-    }
-
-    fn default_instance() -> &'static OpaqueRequest {
-        static instance: OpaqueRequest = OpaqueRequest {
-            uuid: ::std::string::String::new(),
-            request: ::protobuf::MessageField::none(),
-            special_fields: ::protobuf::SpecialFields::new(),
-        };
-        &instance
-    }
-}
-
-impl ::protobuf::MessageFull for OpaqueRequest {
-    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
-        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
-        descriptor.get(|| file_descriptor().message_by_package_relative_name("OpaqueRequest").unwrap()).clone()
-    }
-}
-
-impl ::std::fmt::Display for OpaqueRequest {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
-impl ::protobuf::reflect::ProtobufValue for OpaqueRequest {
-    type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
-}
-
-// @@protoc_insertion_point(message:bitdrift_public.protobuf.client.v1.OpaqueResponse)
-#[derive(PartialEq,Clone,Default,Debug)]
-pub struct OpaqueResponse {
-    // message fields
-    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.OpaqueResponse.uuid)
-    pub uuid: ::std::string::String,
-    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.OpaqueResponse.error)
-    pub error: ::std::option::Option<::std::string::String>,
-    // special fields
-    // @@protoc_insertion_point(special_field:bitdrift_public.protobuf.client.v1.OpaqueResponse.special_fields)
-    pub special_fields: ::protobuf::SpecialFields,
-}
-
-impl<'a> ::std::default::Default for &'a OpaqueResponse {
-    fn default() -> &'a OpaqueResponse {
-        <OpaqueResponse as ::protobuf::Message>::default_instance()
-    }
-}
-
-impl OpaqueResponse {
-    pub fn new() -> OpaqueResponse {
-        ::std::default::Default::default()
-    }
-
-    fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(2);
-        let mut oneofs = ::std::vec::Vec::with_capacity(0);
-        fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
-            "uuid",
-            |m: &OpaqueResponse| { &m.uuid },
-            |m: &mut OpaqueResponse| { &mut m.uuid },
-        ));
-        fields.push(::protobuf::reflect::rt::v2::make_option_accessor::<_, _>(
-            "error",
-            |m: &OpaqueResponse| { &m.error },
-            |m: &mut OpaqueResponse| { &mut m.error },
-        ));
-        ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<OpaqueResponse>(
-            "OpaqueResponse",
-            fields,
-            oneofs,
-        )
-    }
-}
-
-impl ::protobuf::Message for OpaqueResponse {
-    const NAME: &'static str = "OpaqueResponse";
-
-    fn is_initialized(&self) -> bool {
-        true
-    }
-
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
-        while let Some(tag) = is.read_raw_tag_or_eof()? {
-            match tag {
-                10 => {
-                    self.uuid = is.read_string()?;
-                },
-                18 => {
-                    self.error = ::std::option::Option::Some(is.read_string()?);
-                },
-                tag => {
-                    ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
-                },
-            };
-        }
-        ::std::result::Result::Ok(())
-    }
-
-    // Compute sizes of nested messages
-    #[allow(unused_variables)]
-    fn compute_size(&self) -> u64 {
-        let mut my_size = 0;
-        if !self.uuid.is_empty() {
-            my_size += ::protobuf::rt::string_size(1, &self.uuid);
-        }
-        if let Some(v) = self.error.as_ref() {
-            my_size += ::protobuf::rt::string_size(2, &v);
-        }
-        my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
-        self.special_fields.cached_size().set(my_size as u32);
-        my_size
-    }
-
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
-        if !self.uuid.is_empty() {
-            os.write_string(1, &self.uuid)?;
-        }
-        if let Some(v) = self.error.as_ref() {
-            os.write_string(2, v)?;
-        }
-        os.write_unknown_fields(self.special_fields.unknown_fields())?;
-        ::std::result::Result::Ok(())
-    }
-
-    fn special_fields(&self) -> &::protobuf::SpecialFields {
-        &self.special_fields
-    }
-
-    fn mut_special_fields(&mut self) -> &mut ::protobuf::SpecialFields {
-        &mut self.special_fields
-    }
-
-    fn new() -> OpaqueResponse {
-        OpaqueResponse::new()
-    }
-
-    fn clear(&mut self) {
-        self.uuid.clear();
-        self.error = ::std::option::Option::None;
-        self.special_fields.clear();
-    }
-
-    fn default_instance() -> &'static OpaqueResponse {
-        static instance: OpaqueResponse = OpaqueResponse {
-            uuid: ::std::string::String::new(),
-            error: ::std::option::Option::None,
-            special_fields: ::protobuf::SpecialFields::new(),
-        };
-        &instance
-    }
-}
-
-impl ::protobuf::MessageFull for OpaqueResponse {
-    fn descriptor() -> ::protobuf::reflect::MessageDescriptor {
-        static descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::Lazy::new();
-        descriptor.get(|| file_descriptor().message_by_package_relative_name("OpaqueResponse").unwrap()).clone()
-    }
-}
-
-impl ::std::fmt::Display for OpaqueResponse {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        ::protobuf::text_format::fmt(self, f)
-    }
-}
-
-impl ::protobuf::reflect::ProtobufValue for OpaqueResponse {
     type RuntimeType = ::protobuf::reflect::rt::RuntimeTypeMessage<Self>;
 }
 
@@ -8278,104 +7557,6 @@ impl ApiResponse {
         }
     }
 
-    // .bitdrift_public.protobuf.client.v1.OpaqueConfigurationUpdate opaque_configuration_update = 10;
-
-    pub fn opaque_configuration_update(&self) -> &OpaqueConfigurationUpdate {
-        match self.response_type {
-            ::std::option::Option::Some(api_response::Response_type::OpaqueConfigurationUpdate(ref v)) => v,
-            _ => <OpaqueConfigurationUpdate as ::protobuf::Message>::default_instance(),
-        }
-    }
-
-    pub fn clear_opaque_configuration_update(&mut self) {
-        self.response_type = ::std::option::Option::None;
-    }
-
-    pub fn has_opaque_configuration_update(&self) -> bool {
-        match self.response_type {
-            ::std::option::Option::Some(api_response::Response_type::OpaqueConfigurationUpdate(..)) => true,
-            _ => false,
-        }
-    }
-
-    // Param is passed by value, moved
-    pub fn set_opaque_configuration_update(&mut self, v: OpaqueConfigurationUpdate) {
-        self.response_type = ::std::option::Option::Some(api_response::Response_type::OpaqueConfigurationUpdate(v))
-    }
-
-    // Mutable pointer to the field.
-    pub fn mut_opaque_configuration_update(&mut self) -> &mut OpaqueConfigurationUpdate {
-        if let ::std::option::Option::Some(api_response::Response_type::OpaqueConfigurationUpdate(_)) = self.response_type {
-        } else {
-            self.response_type = ::std::option::Option::Some(api_response::Response_type::OpaqueConfigurationUpdate(OpaqueConfigurationUpdate::new()));
-        }
-        match self.response_type {
-            ::std::option::Option::Some(api_response::Response_type::OpaqueConfigurationUpdate(ref mut v)) => v,
-            _ => panic!(),
-        }
-    }
-
-    // Take field
-    pub fn take_opaque_configuration_update(&mut self) -> OpaqueConfigurationUpdate {
-        if self.has_opaque_configuration_update() {
-            match self.response_type.take() {
-                ::std::option::Option::Some(api_response::Response_type::OpaqueConfigurationUpdate(v)) => v,
-                _ => panic!(),
-            }
-        } else {
-            OpaqueConfigurationUpdate::new()
-        }
-    }
-
-    // .bitdrift_public.protobuf.client.v1.OpaqueResponse opaque_upload = 11;
-
-    pub fn opaque_upload(&self) -> &OpaqueResponse {
-        match self.response_type {
-            ::std::option::Option::Some(api_response::Response_type::OpaqueUpload(ref v)) => v,
-            _ => <OpaqueResponse as ::protobuf::Message>::default_instance(),
-        }
-    }
-
-    pub fn clear_opaque_upload(&mut self) {
-        self.response_type = ::std::option::Option::None;
-    }
-
-    pub fn has_opaque_upload(&self) -> bool {
-        match self.response_type {
-            ::std::option::Option::Some(api_response::Response_type::OpaqueUpload(..)) => true,
-            _ => false,
-        }
-    }
-
-    // Param is passed by value, moved
-    pub fn set_opaque_upload(&mut self, v: OpaqueResponse) {
-        self.response_type = ::std::option::Option::Some(api_response::Response_type::OpaqueUpload(v))
-    }
-
-    // Mutable pointer to the field.
-    pub fn mut_opaque_upload(&mut self) -> &mut OpaqueResponse {
-        if let ::std::option::Option::Some(api_response::Response_type::OpaqueUpload(_)) = self.response_type {
-        } else {
-            self.response_type = ::std::option::Option::Some(api_response::Response_type::OpaqueUpload(OpaqueResponse::new()));
-        }
-        match self.response_type {
-            ::std::option::Option::Some(api_response::Response_type::OpaqueUpload(ref mut v)) => v,
-            _ => panic!(),
-        }
-    }
-
-    // Take field
-    pub fn take_opaque_upload(&mut self) -> OpaqueResponse {
-        if self.has_opaque_upload() {
-            match self.response_type.take() {
-                ::std::option::Option::Some(api_response::Response_type::OpaqueUpload(v)) => v,
-                _ => panic!(),
-            }
-        } else {
-            OpaqueResponse::new()
-        }
-    }
-
     // .bitdrift_public.protobuf.client.v1.SankeyPathUploadResponse sankey_diagram_upload = 12;
 
     pub fn sankey_diagram_upload(&self) -> &SankeyPathUploadResponse {
@@ -8573,7 +7754,7 @@ impl ApiResponse {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(15);
+        let mut fields = ::std::vec::Vec::with_capacity(13);
         let mut oneofs = ::std::vec::Vec::with_capacity(1);
         fields.push(::protobuf::reflect::rt::v2::make_oneof_message_has_get_mut_set_accessor::<_, HandshakeResponse>(
             "handshake",
@@ -8637,20 +7818,6 @@ impl ApiResponse {
             ApiResponse::flush_buffers,
             ApiResponse::mut_flush_buffers,
             ApiResponse::set_flush_buffers,
-        ));
-        fields.push(::protobuf::reflect::rt::v2::make_oneof_message_has_get_mut_set_accessor::<_, OpaqueConfigurationUpdate>(
-            "opaque_configuration_update",
-            ApiResponse::has_opaque_configuration_update,
-            ApiResponse::opaque_configuration_update,
-            ApiResponse::mut_opaque_configuration_update,
-            ApiResponse::set_opaque_configuration_update,
-        ));
-        fields.push(::protobuf::reflect::rt::v2::make_oneof_message_has_get_mut_set_accessor::<_, OpaqueResponse>(
-            "opaque_upload",
-            ApiResponse::has_opaque_upload,
-            ApiResponse::opaque_upload,
-            ApiResponse::mut_opaque_upload,
-            ApiResponse::set_opaque_upload,
         ));
         fields.push(::protobuf::reflect::rt::v2::make_oneof_message_has_get_mut_set_accessor::<_, SankeyPathUploadResponse>(
             "sankey_diagram_upload",
@@ -8726,12 +7893,6 @@ impl ::protobuf::Message for ApiResponse {
                 74 => {
                     self.response_type = ::std::option::Option::Some(api_response::Response_type::FlushBuffers(is.read_message()?));
                 },
-                82 => {
-                    self.response_type = ::std::option::Option::Some(api_response::Response_type::OpaqueConfigurationUpdate(is.read_message()?));
-                },
-                90 => {
-                    self.response_type = ::std::option::Option::Some(api_response::Response_type::OpaqueUpload(is.read_message()?));
-                },
                 98 => {
                     self.response_type = ::std::option::Option::Some(api_response::Response_type::SankeyDiagramUpload(is.read_message()?));
                 },
@@ -8794,14 +7955,6 @@ impl ::protobuf::Message for ApiResponse {
                     let len = v.compute_size();
                     my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
                 },
-                &api_response::Response_type::OpaqueConfigurationUpdate(ref v) => {
-                    let len = v.compute_size();
-                    my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
-                },
-                &api_response::Response_type::OpaqueUpload(ref v) => {
-                    let len = v.compute_size();
-                    my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
-                },
                 &api_response::Response_type::SankeyDiagramUpload(ref v) => {
                     let len = v.compute_size();
                     my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
@@ -8855,12 +8008,6 @@ impl ::protobuf::Message for ApiResponse {
                 &api_response::Response_type::FlushBuffers(ref v) => {
                     ::protobuf::rt::write_message_field_with_cached_size(9, v, os)?;
                 },
-                &api_response::Response_type::OpaqueConfigurationUpdate(ref v) => {
-                    ::protobuf::rt::write_message_field_with_cached_size(10, v, os)?;
-                },
-                &api_response::Response_type::OpaqueUpload(ref v) => {
-                    ::protobuf::rt::write_message_field_with_cached_size(11, v, os)?;
-                },
                 &api_response::Response_type::SankeyDiagramUpload(ref v) => {
                     ::protobuf::rt::write_message_field_with_cached_size(12, v, os)?;
                 },
@@ -8892,8 +8039,6 @@ impl ::protobuf::Message for ApiResponse {
     }
 
     fn clear(&mut self) {
-        self.response_type = ::std::option::Option::None;
-        self.response_type = ::std::option::Option::None;
         self.response_type = ::std::option::Option::None;
         self.response_type = ::std::option::Option::None;
         self.response_type = ::std::option::Option::None;
@@ -8960,10 +8105,6 @@ pub mod api_response {
         ErrorShutdown(super::ErrorShutdown),
         // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.ApiResponse.flush_buffers)
         FlushBuffers(super::FlushBuffers),
-        // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.ApiResponse.opaque_configuration_update)
-        OpaqueConfigurationUpdate(super::OpaqueConfigurationUpdate),
-        // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.ApiResponse.opaque_upload)
-        OpaqueUpload(super::OpaqueResponse),
         // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.ApiResponse.sankey_diagram_upload)
         SankeyDiagramUpload(super::SankeyPathUploadResponse),
         // @@protoc_insertion_point(oneof_field:bitdrift_public.protobuf.client.v1.ApiResponse.sankey_intent_response)
@@ -8994,192 +8135,171 @@ pub mod api_response {
 static file_descriptor_proto_data: &'static [u8] = b"\
     \n,bitdrift_public/protobuf/client/v1/api.proto\x12\"bitdrift_public.pro\
     tobuf.client.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/pro\
-    tobuf/duration.proto\x1a\x19google/protobuf/any.proto\x1a0bitdrift_publi\
-    c/protobuf/client/v1/runtime.proto\x1a/bitdrift_public/protobuf/client/v\
-    1/metric.proto\x1a/bitdrift_public/protobuf/filter/v1/filter.proto\x1a3b\
-    itdrift_public/protobuf/workflow/v1/workflow.proto\x1a6bitdrift_public/p\
-    rotobuf/bdtail/v1/bdtail_config.proto\x1a/bitdrift_public/protobuf/confi\
-    g/v1/config.proto\x1a1bitdrift_public/protobuf/logging/v1/payload.proto\
-    \x1a\x17validate/validate.proto\"m\n\x0eClientKillFile\x12\x20\n\x0capi_\
-    key_hash\x18\x01\x20\x01(\x0cR\napiKeyHash\x129\n\nkill_until\x18\x02\
-    \x20\x01(\x0b2\x1a.google.protobuf.TimestampR\tkillUntil\"\xa6\x05\n\x10\
-    HandshakeRequest\x12\x84\x01\n\x16static_device_metadata\x18\x01\x20\x03\
-    (\x0b2N.bitdrift_public.protobuf.client.v1.HandshakeRequest.StaticDevice\
-    MetadataEntryR\x14staticDeviceMetadata\x12>\n\x1bconfiguration_version_n\
-    once\x18\x03\x20\x01(\tR\x19configurationVersionNonce\x122\n\x15runtime_\
-    version_nonce\x18\x04\x20\x01(\tR\x13runtimeVersionNonce\x12\x81\x01\n\
-    \x15opqaue_version_nonces\x18\x05\x20\x03(\x0b2M.bitdrift_public.protobu\
-    f.client.v1.HandshakeRequest.OpqaueVersionNoncesEntryR\x13opqaueVersionN\
-    onces\x12<\n\x1aprevious_disconnect_reason\x18\x06\x20\x01(\tR\x18previo\
-    usDisconnectReason\x1ar\n\x19StaticDeviceMetadataEntry\x12\x10\n\x03key\
-    \x18\x01\x20\x01(\tR\x03key\x12?\n\x05value\x18\x02\x20\x01(\x0b2).bitdr\
-    ift_public.protobuf.logging.v1.DataR\x05value:\x028\x01\x1aF\n\x18Opqaue\
-    VersionNoncesEntry\x12\x10\n\x03key\x18\x01\x20\x01(\tR\x03key\x12\x14\n\
-    \x05value\x18\x02\x20\x01(\tR\x05value:\x028\x01J\x04\x08\x02\x10\x03R\
-    \x13fields_for_all_logs\"|\n\x19OpaqueConfigurationUpdate\x12#\n\rversio\
-    n_nonce\x18\x01\x20\x01(\tR\x0cversionNonce\x12:\n\rconfiguration\x18\
-    \x02\x20\x01(\x0b2\x14.google.protobuf.AnyR\rconfiguration\"\x87\x01\n\
-    \x1cOpaqueConfigurationUpdateAck\x12\x19\n\x08type_url\x18\x01\x20\x01(\
-    \tR\x07typeUrl\x12L\n\x03ack\x18\x02\x20\x01(\x0b2:.bitdrift_public.prot\
-    obuf.client.v1.ConfigurationUpdateAckR\x03ack\"\x92\x03\n\x16LogUploadIn\
-    tentRequest\x12\x1b\n\tlog_count\x18\x01\x20\x01(\rR\x08logCount\x12\x1d\
-    \n\nbyte_count\x18\x02\x20\x01(\rR\tbyteCount\x12\x1b\n\tbuffer_id\x18\
-    \x03\x20\x01(\tR\x08bufferId\x12\x1f\n\x0bintent_uuid\x18\x04\x20\x01(\t\
-    R\nintentUuid\x12\x1d\n\nsession_id\x18\x06\x20\x01(\tR\tsessionId\x12\
-    \x87\x01\n\x16workflow_action_upload\x18\x05\x20\x01(\x0b2O.bitdrift_pub\
-    lic.protobuf.client.v1.LogUploadIntentRequest.WorkflowActionUploadH\0R\
-    \x14workflowActionUpload\x1aF\n\x14WorkflowActionUpload\x12.\n\x13workfl\
-    ow_action_ids\x18\x01\x20\x03(\tR\x11workflowActionIdsB\r\n\x0bintent_ty\
-    pe\"\xbb\x02\n\x17LogUploadIntentResponse\x12\x1f\n\x0bintent_uuid\x18\
-    \x01\x20\x01(\tR\nintentUuid\x12~\n\x12upload_immediately\x18\x02\x20\
-    \x01(\x0b2M.bitdrift_public.protobuf.client.v1.LogUploadIntentResponse.U\
-    ploadImmediatelyH\0R\x11uploadImmediately\x12V\n\x04drop\x18\x03\x20\x01\
-    (\x0b2@.bitdrift_public.protobuf.client.v1.LogUploadIntentResponse.DropH\
-    \0R\x04drop\x1a\x13\n\x11UploadImmediately\x1a\x06\n\x04DropB\n\n\x08dec\
-    ision\"\x84\x01\n\x10LogUploadRequest\x12(\n\x0bupload_uuid\x18\x01\x20\
-    \x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x1c\n\x04logs\x18\
-    \x02\x20\x03(\x0cR\x04logsB\x08\xfaB\x05\x92\x01\x02\x08\x01\x12(\n\x0bb\
-    uffer_uuid\x18\x03\x20\x01(\tR\nbufferUuidB\x07\xfaB\x04r\x02\x10\x01\"\
-    \r\n\x0bPingRequest\"\xfc\x01\n\x16ConfigurationUpdateAck\x12;\n\x1alast\
-    _applied_version_nonce\x18\x01\x20\x01(\tR\x17lastAppliedVersionNonce\
-    \x12S\n\x04nack\x18\x02\x20\x01(\x0b2?.bitdrift_public.protobuf.client.v\
-    1.ConfigurationUpdateAck.NackR\x04nack\x1aP\n\x04Nack\x12#\n\rversion_no\
-    nce\x18\x01\x20\x01(\tR\x0cversionNonce\x12#\n\rerror_details\x18\x02\
-    \x20\x01(\tR\x0cerrorDetails\"\xc5\n\n\nApiRequest\x12T\n\thandshake\x18\
-    \x01\x20\x01(\x0b24.bitdrift_public.protobuf.client.v1.HandshakeRequestH\
-    \0R\thandshake\x12h\n\x11log_upload_intent\x18\x07\x20\x01(\x0b2:.bitdri\
-    ft_public.protobuf.client.v1.LogUploadIntentRequestH\0R\x0flogUploadInte\
-    nt\x12U\n\nlog_upload\x18\x02\x20\x01(\x0b24.bitdrift_public.protobuf.cl\
-    ient.v1.LogUploadRequestH\0R\tlogUpload\x12[\n\x0cstats_upload\x18\x06\
-    \x20\x01(\x0b26.bitdrift_public.protobuf.client.v1.StatsUploadRequestH\0\
-    R\x0bstatsUpload\x12E\n\x04ping\x18\x03\x20\x01(\x0b2/.bitdrift_public.p\
-    rotobuf.client.v1.PingRequestH\0R\x04ping\x12v\n\x18configuration_update\
-    _ack\x18\x04\x20\x01(\x0b2:.bitdrift_public.protobuf.client.v1.Configura\
-    tionUpdateAckH\0R\x16configurationUpdateAck\x12j\n\x12runtime_update_ack\
-    \x18\x05\x20\x01(\x0b2:.bitdrift_public.protobuf.client.v1.Configuration\
-    UpdateAckH\0R\x10runtimeUpdateAck\x12\x89\x01\n\x1fopaque_configuration_\
-    update_ack\x18\x08\x20\x01(\x0b2@.bitdrift_public.protobuf.client.v1.Opa\
-    queConfigurationUpdateAckH\0R\x1copaqueConfigurationUpdateAck\x12X\n\rop\
-    aque_upload\x18\t\x20\x01(\x0b21.bitdrift_public.protobuf.client.v1.Opaq\
-    ueRequestH\0R\x0copaqueUpload\x12k\n\x12sankey_path_upload\x18\n\x20\x01\
-    (\x0b2;.bitdrift_public.protobuf.client.v1.SankeyPathUploadRequestH\0R\
-    \x10sankeyPathUpload\x12^\n\rsankey_intent\x18\x0b\x20\x01(\x0b27.bitdri\
-    ft_public.protobuf.client.v1.SankeyIntentRequestH\0R\x0csankeyIntent\x12\
-    d\n\x0fartifact_upload\x18\x0c\x20\x01(\x0b29.bitdrift_public.protobuf.c\
-    lient.v1.UploadArtifactRequestH\0R\x0eartifactUpload\x12j\n\x0fartifact_\
-    intent\x18\r\x20\x01(\x0b2?.bitdrift_public.protobuf.client.v1.UploadArt\
-    ifactIntentRequestH\0R\x0eartifactIntentB\x13\n\x0crequest_type\x12\x03\
-    \xf8B\x01\"\x9a\x02\n\x17SankeyPathUploadRequest\x12(\n\x0bupload_uuid\
-    \x18\x04\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x17\n\
-    \x02id\x18\x01\x20\x01(\tR\x02idB\x07\xfaB\x04r\x02\x10\x01\x12\x20\n\
-    \x07path_id\x18\x02\x20\x01(\tR\x06pathIdB\x07\xfaB\x04r\x02\x10\x01\x12\
-    `\n\x05nodes\x18\x03\x20\x03(\x0b2@.bitdrift_public.protobuf.client.v1.S\
-    ankeyPathUploadRequest.NodeR\x05nodesB\x08\xfaB\x05\x92\x01\x02\x08\x01\
-    \x1a8\n\x04Node\x120\n\x0fextracted_value\x18\x01\x20\x01(\tR\x0eextract\
-    edValueB\x07\xfaB\x04r\x02\x10\x01\"\x96\x01\n\x13SankeyIntentRequest\
-    \x12(\n\x0bintent_uuid\x18\x01\x20\x01(\tR\nintentUuidB\x07\xfaB\x04r\
-    \x02\x10\x01\x12\x20\n\x07path_id\x18\x02\x20\x01(\tR\x06pathIdB\x07\xfa\
-    B\x04r\x02\x10\x01\x123\n\x11sankey_diagram_id\x18\x03\x20\x01(\tR\x0fsa\
-    nkeyDiagramIdB\x07\xfaB\x04r\x02\x10\x01\"\xaf\x01\n\x1bUploadArtifactIn\
-    tentRequest\x12(\n\x0bintent_uuid\x18\x01\x20\x01(\tR\nintentUuidB\x07\
-    \xfaB\x04r\x02\x10\x01\x12\x20\n\x07type_id\x18\x02\x20\x01(\tR\x06typeI\
-    dB\x07\xfaB\x04r\x02\x10\x01\x12\x1a\n\x08metadata\x18\x03\x20\x01(\x0cR\
-    \x08metadata\x12(\n\x0bartifact_id\x18\x04\x20\x01(\tR\nartifactIdB\x07\
-    \xfaB\x04r\x02\x10\x01\"\xd4\x02\n\x1cUploadArtifactIntentResponse\x12(\
-    \n\x0bintent_uuid\x18\x01\x20\x01(\tR\nintentUuidB\x07\xfaB\x04r\x02\x10\
-    \x01\x12\x83\x01\n\x12upload_immediately\x18\x03\x20\x01(\x0b2R.bitdrift\
-    _public.protobuf.client.v1.UploadArtifactIntentResponse.UploadImmediatel\
-    yH\0R\x11uploadImmediately\x12[\n\x04drop\x18\x04\x20\x01(\x0b2E.bitdrif\
-    t_public.protobuf.client.v1.UploadArtifactIntentResponse.DropH\0R\x04dro\
-    p\x1a\x13\n\x11UploadImmediately\x1a\x06\n\x04DropB\n\n\x08decision\"\
-    \xa9\x01\n\x15UploadArtifactRequest\x12(\n\x0bupload_uuid\x18\x01\x20\
-    \x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x20\n\x07type_id\x18\
-    \x02\x20\x01(\tR\x06typeIdB\x07\xfaB\x04r\x02\x10\x01\x12\x1a\n\x08conte\
-    nts\x18\x03\x20\x01(\x0cR\x08contents\x12(\n\x0bartifact_id\x18\x04\x20\
-    \x01(\tR\nartifactIdB\x07\xfaB\x04r\x02\x10\x01\"X\n\x16UploadArtifactRe\
-    sponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\
-    \x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05error\"\xd4\
-    \x01\n\x11HandshakeResponse\x12m\n\x0fstream_settings\x18\x01\x20\x01(\
-    \x0b2D.bitdrift_public.protobuf.client.v1.HandshakeResponse.StreamSettin\
-    gsR\x0estreamSettings\x1aP\n\x0eStreamSettings\x12>\n\rping_interval\x18\
-    \x01\x20\x01(\x0b2\x19.google.protobuf.DurationR\x0cpingInterval\"\r\n\
-    \x0bRateLimited\"\xca\x01\n\x11LogUploadResponse\x12(\n\x0bupload_uuid\
-    \x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\
-    \x05error\x18\x02\x20\x01(\tR\x05error\x12!\n\x0clogs_dropped\x18\x03\
-    \x20\x01(\rR\x0blogsDropped\x12R\n\x0crate_limited\x18\x04\x20\x01(\x0b2\
-    /.bitdrift_public.protobuf.client.v1.RateLimitedR\x0brateLimited\"\xae\
-    \x06\n\x12StatsUploadRequest\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\n\
-    uploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12e\n\x08snapshot\x18\x02\x20\x03\
-    (\x0b2?.bitdrift_public.protobuf.client.v1.StatsUploadRequest.SnapshotR\
-    \x08snapshotB\x08\xfaB\x05\x92\x01\x02\x08\x01\x123\n\x07sent_at\x18\x03\
-    \x20\x01(\x0b2\x1a.google.protobuf.TimestampR\x06sentAt\x1a\xd1\x04\n\
-    \x08Snapshot\x12K\n\x07metrics\x18\x01\x20\x01(\x0b2/.bitdrift_public.pr\
-    otobuf.client.v1.MetricsListH\0R\x07metrics\x12l\n\naggregated\x18\x02\
-    \x20\x01(\x0b2J.bitdrift_public.protobuf.client.v1.StatsUploadRequest.Sn\
-    apshot.AggregatedH\x01R\naggregated\x12\x86\x01\n\x13metric_id_overflows\
-    \x18\x03\x20\x03(\x0b2V.bitdrift_public.protobuf.client.v1.StatsUploadRe\
-    quest.Snapshot.MetricIdOverflowsEntryR\x11metricIdOverflows\x1a\x90\x01\
-    \n\nAggregated\x12G\n\x0cperiod_start\x18\x04\x20\x01(\x0b2\x1a.google.p\
-    rotobuf.TimestampR\x0bperiodStartB\x08\xfaB\x05\x8a\x01\x02\x10\x01\x129\
-    \n\nperiod_end\x18\x05\x20\x01(\x0b2\x1a.google.protobuf.TimestampR\tper\
-    iodEnd\x1aD\n\x16MetricIdOverflowsEntry\x12\x10\n\x03key\x18\x01\x20\x01\
-    (\tR\x03key\x12\x14\n\x05value\x18\x02\x20\x01(\x04R\x05value:\x028\x01B\
-    \x14\n\rsnapshot_type\x12\x03\xf8B\x01B\x12\n\x0boccurred_at\x12\x03\xf8\
-    B\x01\"~\n\x13StatsUploadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\
+    tobuf/duration.proto\x1a0bitdrift_public/protobuf/client/v1/runtime.prot\
+    o\x1a/bitdrift_public/protobuf/client/v1/metric.proto\x1a/bitdrift_publi\
+    c/protobuf/filter/v1/filter.proto\x1a3bitdrift_public/protobuf/workflow/\
+    v1/workflow.proto\x1a6bitdrift_public/protobuf/bdtail/v1/bdtail_config.p\
+    roto\x1a/bitdrift_public/protobuf/config/v1/config.proto\x1a1bitdrift_pu\
+    blic/protobuf/logging/v1/payload.proto\x1a\x17validate/validate.proto\"m\
+    \n\x0eClientKillFile\x12\x20\n\x0capi_key_hash\x18\x01\x20\x01(\x0cR\nap\
+    iKeyHash\x129\n\nkill_until\x18\x02\x20\x01(\x0b2\x1a.google.protobuf.Ti\
+    mestampR\tkillUntil\"\xe0\x03\n\x10HandshakeRequest\x12\x84\x01\n\x16sta\
+    tic_device_metadata\x18\x01\x20\x03(\x0b2N.bitdrift_public.protobuf.clie\
+    nt.v1.HandshakeRequest.StaticDeviceMetadataEntryR\x14staticDeviceMetadat\
+    a\x12>\n\x1bconfiguration_version_nonce\x18\x03\x20\x01(\tR\x19configura\
+    tionVersionNonce\x122\n\x15runtime_version_nonce\x18\x04\x20\x01(\tR\x13\
+    runtimeVersionNonce\x12<\n\x1aprevious_disconnect_reason\x18\x06\x20\x01\
+    (\tR\x18previousDisconnectReason\x1ar\n\x19StaticDeviceMetadataEntry\x12\
+    \x10\n\x03key\x18\x01\x20\x01(\tR\x03key\x12?\n\x05value\x18\x02\x20\x01\
+    (\x0b2).bitdrift_public.protobuf.logging.v1.DataR\x05value:\x028\x01J\
+    \x04\x08\x02\x10\x03J\x04\x08\x05\x10\x06R\x13fields_for_all_logs\"\x92\
+    \x03\n\x16LogUploadIntentRequest\x12\x1b\n\tlog_count\x18\x01\x20\x01(\r\
+    R\x08logCount\x12\x1d\n\nbyte_count\x18\x02\x20\x01(\rR\tbyteCount\x12\
+    \x1b\n\tbuffer_id\x18\x03\x20\x01(\tR\x08bufferId\x12\x1f\n\x0bintent_uu\
+    id\x18\x04\x20\x01(\tR\nintentUuid\x12\x1d\n\nsession_id\x18\x06\x20\x01\
+    (\tR\tsessionId\x12\x87\x01\n\x16workflow_action_upload\x18\x05\x20\x01(\
+    \x0b2O.bitdrift_public.protobuf.client.v1.LogUploadIntentRequest.Workflo\
+    wActionUploadH\0R\x14workflowActionUpload\x1aF\n\x14WorkflowActionUpload\
+    \x12.\n\x13workflow_action_ids\x18\x01\x20\x03(\tR\x11workflowActionIdsB\
+    \r\n\x0bintent_type\"\xbb\x02\n\x17LogUploadIntentResponse\x12\x1f\n\x0b\
+    intent_uuid\x18\x01\x20\x01(\tR\nintentUuid\x12~\n\x12upload_immediately\
+    \x18\x02\x20\x01(\x0b2M.bitdrift_public.protobuf.client.v1.LogUploadInte\
+    ntResponse.UploadImmediatelyH\0R\x11uploadImmediately\x12V\n\x04drop\x18\
+    \x03\x20\x01(\x0b2@.bitdrift_public.protobuf.client.v1.LogUploadIntentRe\
+    sponse.DropH\0R\x04drop\x1a\x13\n\x11UploadImmediately\x1a\x06\n\x04Drop\
+    B\n\n\x08decision\"\x84\x01\n\x10LogUploadRequest\x12(\n\x0bupload_uuid\
+    \x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x1c\n\
+    \x04logs\x18\x02\x20\x03(\x0cR\x04logsB\x08\xfaB\x05\x92\x01\x02\x08\x01\
+    \x12(\n\x0bbuffer_uuid\x18\x03\x20\x01(\tR\nbufferUuidB\x07\xfaB\x04r\
+    \x02\x10\x01\"\r\n\x0bPingRequest\"\xfc\x01\n\x16ConfigurationUpdateAck\
+    \x12;\n\x1alast_applied_version_nonce\x18\x01\x20\x01(\tR\x17lastApplied\
+    VersionNonce\x12S\n\x04nack\x18\x02\x20\x01(\x0b2?.bitdrift_public.proto\
+    buf.client.v1.ConfigurationUpdateAck.NackR\x04nack\x1aP\n\x04Nack\x12#\n\
+    \rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNonce\x12#\n\rerror_detail\
+    s\x18\x02\x20\x01(\tR\x0cerrorDetails\"\xeb\x08\n\nApiRequest\x12T\n\tha\
+    ndshake\x18\x01\x20\x01(\x0b24.bitdrift_public.protobuf.client.v1.Handsh\
+    akeRequestH\0R\thandshake\x12h\n\x11log_upload_intent\x18\x07\x20\x01(\
+    \x0b2:.bitdrift_public.protobuf.client.v1.LogUploadIntentRequestH\0R\x0f\
+    logUploadIntent\x12U\n\nlog_upload\x18\x02\x20\x01(\x0b24.bitdrift_publi\
+    c.protobuf.client.v1.LogUploadRequestH\0R\tlogUpload\x12[\n\x0cstats_upl\
+    oad\x18\x06\x20\x01(\x0b26.bitdrift_public.protobuf.client.v1.StatsUploa\
+    dRequestH\0R\x0bstatsUpload\x12E\n\x04ping\x18\x03\x20\x01(\x0b2/.bitdri\
+    ft_public.protobuf.client.v1.PingRequestH\0R\x04ping\x12v\n\x18configura\
+    tion_update_ack\x18\x04\x20\x01(\x0b2:.bitdrift_public.protobuf.client.v\
+    1.ConfigurationUpdateAckH\0R\x16configurationUpdateAck\x12j\n\x12runtime\
+    _update_ack\x18\x05\x20\x01(\x0b2:.bitdrift_public.protobuf.client.v1.Co\
+    nfigurationUpdateAckH\0R\x10runtimeUpdateAck\x12k\n\x12sankey_path_uploa\
+    d\x18\n\x20\x01(\x0b2;.bitdrift_public.protobuf.client.v1.SankeyPathUplo\
+    adRequestH\0R\x10sankeyPathUpload\x12^\n\rsankey_intent\x18\x0b\x20\x01(\
+    \x0b27.bitdrift_public.protobuf.client.v1.SankeyIntentRequestH\0R\x0csan\
+    keyIntent\x12d\n\x0fartifact_upload\x18\x0c\x20\x01(\x0b29.bitdrift_publ\
+    ic.protobuf.client.v1.UploadArtifactRequestH\0R\x0eartifactUpload\x12j\n\
+    \x0fartifact_intent\x18\r\x20\x01(\x0b2?.bitdrift_public.protobuf.client\
+    .v1.UploadArtifactIntentRequestH\0R\x0eartifactIntentB\x13\n\x0crequest_\
+    type\x12\x03\xf8B\x01J\x04\x08\x08\x10\tJ\x04\x08\t\x10\n\"\x9a\x02\n\
+    \x17SankeyPathUploadRequest\x12(\n\x0bupload_uuid\x18\x04\x20\x01(\tR\nu\
+    ploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x17\n\x02id\x18\x01\x20\x01(\tR\
+    \x02idB\x07\xfaB\x04r\x02\x10\x01\x12\x20\n\x07path_id\x18\x02\x20\x01(\
+    \tR\x06pathIdB\x07\xfaB\x04r\x02\x10\x01\x12`\n\x05nodes\x18\x03\x20\x03\
+    (\x0b2@.bitdrift_public.protobuf.client.v1.SankeyPathUploadRequest.NodeR\
+    \x05nodesB\x08\xfaB\x05\x92\x01\x02\x08\x01\x1a8\n\x04Node\x120\n\x0fext\
+    racted_value\x18\x01\x20\x01(\tR\x0eextractedValueB\x07\xfaB\x04r\x02\
+    \x10\x01\"\x96\x01\n\x13SankeyIntentRequest\x12(\n\x0bintent_uuid\x18\
+    \x01\x20\x01(\tR\nintentUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x20\n\x07pat\
+    h_id\x18\x02\x20\x01(\tR\x06pathIdB\x07\xfaB\x04r\x02\x10\x01\x123\n\x11\
+    sankey_diagram_id\x18\x03\x20\x01(\tR\x0fsankeyDiagramIdB\x07\xfaB\x04r\
+    \x02\x10\x01\"\xaf\x01\n\x1bUploadArtifactIntentRequest\x12(\n\x0bintent\
+    _uuid\x18\x01\x20\x01(\tR\nintentUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x20\
+    \n\x07type_id\x18\x02\x20\x01(\tR\x06typeIdB\x07\xfaB\x04r\x02\x10\x01\
+    \x12\x1a\n\x08metadata\x18\x03\x20\x01(\x0cR\x08metadata\x12(\n\x0bartif\
+    act_id\x18\x04\x20\x01(\tR\nartifactIdB\x07\xfaB\x04r\x02\x10\x01\"\xd4\
+    \x02\n\x1cUploadArtifactIntentResponse\x12(\n\x0bintent_uuid\x18\x01\x20\
+    \x01(\tR\nintentUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x83\x01\n\x12upload_\
+    immediately\x18\x03\x20\x01(\x0b2R.bitdrift_public.protobuf.client.v1.Up\
+    loadArtifactIntentResponse.UploadImmediatelyH\0R\x11uploadImmediately\
+    \x12[\n\x04drop\x18\x04\x20\x01(\x0b2E.bitdrift_public.protobuf.client.v\
+    1.UploadArtifactIntentResponse.DropH\0R\x04drop\x1a\x13\n\x11UploadImmed\
+    iately\x1a\x06\n\x04DropB\n\n\x08decision\"\xa9\x01\n\x15UploadArtifactR\
+    equest\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\
+    \x04r\x02\x10\x01\x12\x20\n\x07type_id\x18\x02\x20\x01(\tR\x06typeIdB\
+    \x07\xfaB\x04r\x02\x10\x01\x12\x1a\n\x08contents\x18\x03\x20\x01(\x0cR\
+    \x08contents\x12(\n\x0bartifact_id\x18\x04\x20\x01(\tR\nartifactIdB\x07\
+    \xfaB\x04r\x02\x10\x01\"X\n\x16UploadArtifactResponse\x12(\n\x0bupload_u\
+    uid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\
+    \x05error\x18\x02\x20\x01(\tR\x05error\"\x94\x02\n\x11HandshakeResponse\
+    \x12m\n\x0fstream_settings\x18\x01\x20\x01(\x0b2D.bitdrift_public.protob\
+    uf.client.v1.HandshakeResponse.StreamSettingsR\x0estreamSettings\x12>\n\
+    \x1bconfiguration_update_status\x18\x02\x20\x01(\rR\x19configurationUpda\
+    teStatus\x1aP\n\x0eStreamSettings\x12>\n\rping_interval\x18\x01\x20\x01(\
+    \x0b2\x19.google.protobuf.DurationR\x0cpingInterval\"\r\n\x0bRateLimited\
+    \"\xca\x01\n\x11LogUploadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\
     \tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\
-    \x20\x01(\tR\x05error\x12'\n\x0fmetrics_dropped\x18\x03\x20\x01(\rR\x0em\
-    etricsDropped\"]\n\rOpaqueRequest\x12\x12\n\x04uuid\x18\x01\x20\x01(\tR\
-    \x04uuid\x128\n\x07request\x18\x02\x20\x01(\x0b2\x14.google.protobuf.Any\
-    R\x07requestB\x08\xfaB\x05\x8a\x01\x02\x10\x01\"R\n\x0eOpaqueResponse\
-    \x12\x1b\n\x04uuid\x18\x01\x20\x01(\tR\x04uuidB\x07\xfaB\x04r\x02\x10\
-    \x01\x12\x19\n\x05error\x18\x02\x20\x01(\tH\0R\x05error\x88\x01\x01B\x08\
-    \n\x06_error\"\x0e\n\x0cPongResponse\"\xba\x05\n\x13ConfigurationUpdate\
-    \x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNonce\x12v\n\x12sta\
-    te_of_the_world\x18\x02\x20\x01(\x0b2G.bitdrift_public.protobuf.client.v\
-    1.ConfigurationUpdate.StateOfTheWorldH\0R\x0fstateOfTheWorld\x1a\xf6\x03\
-    \n\x0fStateOfTheWorld\x12b\n\x12buffer_config_list\x18\x03\x20\x01(\x0b2\
-    4.bitdrift_public.protobuf.config.v1.BufferConfigListR\x10bufferConfigLi\
-    st\x12u\n\x17workflows_configuration\x18\x04\x20\x01(\x0b2<.bitdrift_pub\
-    lic.protobuf.workflow.v1.WorkflowsConfigurationR\x16workflowsConfigurati\
-    on\x12k\n\x14bdtail_configuration\x18\x06\x20\x01(\x0b28.bitdrift_public\
-    .protobuf.bdtail.v1.BdTailConfigurationsR\x13bdtailConfiguration\x12m\n\
-    \x15filters_configuration\x18\x08\x20\x01(\x0b28.bitdrift_public.protobu\
-    f.filter.v1.FiltersConfigurationR\x14filtersConfigurationJ\x04\x08\x02\
-    \x10\x03J\x04\x08\x07\x10\x08R\x08mll_listR\x16insights_configurationB\r\
-    \n\x0bupdate_type\"{\n\rRuntimeUpdate\x12#\n\rversion_nonce\x18\x01\x20\
-    \x01(\tR\x0cversionNonce\x12E\n\x07runtime\x18\x02\x20\x01(\x0b2+.bitdri\
-    ft_public.protobuf.client.v1.RuntimeR\x07runtime\"S\n\rErrorShutdown\x12\
-    \x1f\n\x0bgrpc_status\x18\x01\x20\x01(\x05R\ngrpcStatus\x12!\n\x0cgrpc_m\
-    essage\x18\x02\x20\x01(\tR\x0bgrpcMessage\"4\n\x0cFlushBuffers\x12$\n\
-    \x0ebuffer_id_list\x18\x01\x20\x03(\tR\x0cbufferIdList\"Z\n\x18SankeyPat\
-    hUploadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\
-    \x07\xfaB\x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05err\
-    or\"\xcb\x02\n\x14SankeyIntentResponse\x12(\n\x0bintent_uuid\x18\x01\x20\
-    \x01(\tR\nintentUuidB\x07\xfaB\x04r\x02\x10\x01\x12{\n\x12upload_immedia\
-    tely\x18\x03\x20\x01(\x0b2J.bitdrift_public.protobuf.client.v1.SankeyInt\
-    entResponse.UploadImmediatelyH\0R\x11uploadImmediately\x12S\n\x04drop\
-    \x18\x04\x20\x01(\x0b2=.bitdrift_public.protobuf.client.v1.SankeyIntentR\
-    esponse.DropH\0R\x04drop\x1a\x13\n\x11UploadImmediately\x1a\x06\n\x04Dro\
-    pB\n\n\x08decisionJ\x04\x08\x02\x10\x03R\x08decision\"\xf8\x0b\n\x0bApiR\
-    esponse\x12U\n\thandshake\x18\x01\x20\x01(\x0b25.bitdrift_public.protobu\
-    f.client.v1.HandshakeResponseH\0R\thandshake\x12V\n\nlog_upload\x18\x02\
-    \x20\x01(\x0b25.bitdrift_public.protobuf.client.v1.LogUploadResponseH\0R\
-    \tlogUpload\x12i\n\x11log_upload_intent\x18\x08\x20\x01(\x0b2;.bitdrift_\
-    public.protobuf.client.v1.LogUploadIntentResponseH\0R\x0flogUploadIntent\
-    \x12\\\n\x0cstats_upload\x18\x07\x20\x01(\x0b27.bitdrift_public.protobuf\
-    .client.v1.StatsUploadResponseH\0R\x0bstatsUpload\x12F\n\x04pong\x18\x03\
-    \x20\x01(\x0b20.bitdrift_public.protobuf.client.v1.PongResponseH\0R\x04p\
-    ong\x12l\n\x14configuration_update\x18\x04\x20\x01(\x0b27.bitdrift_publi\
-    c.protobuf.client.v1.ConfigurationUpdateH\0R\x13configurationUpdate\x12Z\
-    \n\x0eruntime_update\x18\x05\x20\x01(\x0b21.bitdrift_public.protobuf.cli\
-    ent.v1.RuntimeUpdateH\0R\rruntimeUpdate\x12Z\n\x0eerror_shutdown\x18\x06\
-    \x20\x01(\x0b21.bitdrift_public.protobuf.client.v1.ErrorShutdownH\0R\rer\
-    rorShutdown\x12W\n\rflush_buffers\x18\t\x20\x01(\x0b20.bitdrift_public.p\
-    rotobuf.client.v1.FlushBuffersH\0R\x0cflushBuffers\x12\x7f\n\x1bopaque_c\
-    onfiguration_update\x18\n\x20\x01(\x0b2=.bitdrift_public.protobuf.client\
-    .v1.OpaqueConfigurationUpdateH\0R\x19opaqueConfigurationUpdate\x12Y\n\ro\
-    paque_upload\x18\x0b\x20\x01(\x0b22.bitdrift_public.protobuf.client.v1.O\
-    paqueResponseH\0R\x0copaqueUpload\x12r\n\x15sankey_diagram_upload\x18\
+    \x20\x01(\tR\x05error\x12!\n\x0clogs_dropped\x18\x03\x20\x01(\rR\x0blogs\
+    Dropped\x12R\n\x0crate_limited\x18\x04\x20\x01(\x0b2/.bitdrift_public.pr\
+    otobuf.client.v1.RateLimitedR\x0brateLimited\"\xae\x06\n\x12StatsUploadR\
+    equest\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\
+    \x04r\x02\x10\x01\x12e\n\x08snapshot\x18\x02\x20\x03(\x0b2?.bitdrift_pub\
+    lic.protobuf.client.v1.StatsUploadRequest.SnapshotR\x08snapshotB\x08\xfa\
+    B\x05\x92\x01\x02\x08\x01\x123\n\x07sent_at\x18\x03\x20\x01(\x0b2\x1a.go\
+    ogle.protobuf.TimestampR\x06sentAt\x1a\xd1\x04\n\x08Snapshot\x12K\n\x07m\
+    etrics\x18\x01\x20\x01(\x0b2/.bitdrift_public.protobuf.client.v1.Metrics\
+    ListH\0R\x07metrics\x12l\n\naggregated\x18\x02\x20\x01(\x0b2J.bitdrift_p\
+    ublic.protobuf.client.v1.StatsUploadRequest.Snapshot.AggregatedH\x01R\na\
+    ggregated\x12\x86\x01\n\x13metric_id_overflows\x18\x03\x20\x03(\x0b2V.bi\
+    tdrift_public.protobuf.client.v1.StatsUploadRequest.Snapshot.MetricIdOve\
+    rflowsEntryR\x11metricIdOverflows\x1a\x90\x01\n\nAggregated\x12G\n\x0cpe\
+    riod_start\x18\x04\x20\x01(\x0b2\x1a.google.protobuf.TimestampR\x0bperio\
+    dStartB\x08\xfaB\x05\x8a\x01\x02\x10\x01\x129\n\nperiod_end\x18\x05\x20\
+    \x01(\x0b2\x1a.google.protobuf.TimestampR\tperiodEnd\x1aD\n\x16MetricIdO\
+    verflowsEntry\x12\x10\n\x03key\x18\x01\x20\x01(\tR\x03key\x12\x14\n\x05v\
+    alue\x18\x02\x20\x01(\x04R\x05value:\x028\x01B\x14\n\rsnapshot_type\x12\
+    \x03\xf8B\x01B\x12\n\x0boccurred_at\x12\x03\xf8B\x01\"~\n\x13StatsUpload\
+    Response\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\
+    \x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05error\x12'\n\
+    \x0fmetrics_dropped\x18\x03\x20\x01(\rR\x0emetricsDropped\"\x0e\n\x0cPon\
+    gResponse\"\xba\x05\n\x13ConfigurationUpdate\x12#\n\rversion_nonce\x18\
+    \x01\x20\x01(\tR\x0cversionNonce\x12v\n\x12state_of_the_world\x18\x02\
+    \x20\x01(\x0b2G.bitdrift_public.protobuf.client.v1.ConfigurationUpdate.S\
+    tateOfTheWorldH\0R\x0fstateOfTheWorld\x1a\xf6\x03\n\x0fStateOfTheWorld\
+    \x12b\n\x12buffer_config_list\x18\x03\x20\x01(\x0b24.bitdrift_public.pro\
+    tobuf.config.v1.BufferConfigListR\x10bufferConfigList\x12u\n\x17workflow\
+    s_configuration\x18\x04\x20\x01(\x0b2<.bitdrift_public.protobuf.workflow\
+    .v1.WorkflowsConfigurationR\x16workflowsConfiguration\x12k\n\x14bdtail_c\
+    onfiguration\x18\x06\x20\x01(\x0b28.bitdrift_public.protobuf.bdtail.v1.B\
+    dTailConfigurationsR\x13bdtailConfiguration\x12m\n\x15filters_configurat\
+    ion\x18\x08\x20\x01(\x0b28.bitdrift_public.protobuf.filter.v1.FiltersCon\
+    figurationR\x14filtersConfigurationJ\x04\x08\x02\x10\x03J\x04\x08\x07\
+    \x10\x08R\x08mll_listR\x16insights_configurationB\r\n\x0bupdate_type\"{\
+    \n\rRuntimeUpdate\x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNo\
+    nce\x12E\n\x07runtime\x18\x02\x20\x01(\x0b2+.bitdrift_public.protobuf.cl\
+    ient.v1.RuntimeR\x07runtime\"S\n\rErrorShutdown\x12\x1f\n\x0bgrpc_status\
+    \x18\x01\x20\x01(\x05R\ngrpcStatus\x12!\n\x0cgrpc_message\x18\x02\x20\
+    \x01(\tR\x0bgrpcMessage\"4\n\x0cFlushBuffers\x12$\n\x0ebuffer_id_list\
+    \x18\x01\x20\x03(\tR\x0cbufferIdList\"Z\n\x18SankeyPathUploadResponse\
+    \x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\
+    \x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05error\"\xcb\x02\n\
+    \x14SankeyIntentResponse\x12(\n\x0bintent_uuid\x18\x01\x20\x01(\tR\ninte\
+    ntUuidB\x07\xfaB\x04r\x02\x10\x01\x12{\n\x12upload_immediately\x18\x03\
+    \x20\x01(\x0b2J.bitdrift_public.protobuf.client.v1.SankeyIntentResponse.\
+    UploadImmediatelyH\0R\x11uploadImmediately\x12S\n\x04drop\x18\x04\x20\
+    \x01(\x0b2=.bitdrift_public.protobuf.client.v1.SankeyIntentResponse.Drop\
+    H\0R\x04drop\x1a\x13\n\x11UploadImmediately\x1a\x06\n\x04DropB\n\n\x08de\
+    cisionJ\x04\x08\x02\x10\x03R\x08decision\"\xa8\n\n\x0bApiResponse\x12U\n\
+    \thandshake\x18\x01\x20\x01(\x0b25.bitdrift_public.protobuf.client.v1.Ha\
+    ndshakeResponseH\0R\thandshake\x12V\n\nlog_upload\x18\x02\x20\x01(\x0b25\
+    .bitdrift_public.protobuf.client.v1.LogUploadResponseH\0R\tlogUpload\x12\
+    i\n\x11log_upload_intent\x18\x08\x20\x01(\x0b2;.bitdrift_public.protobuf\
+    .client.v1.LogUploadIntentResponseH\0R\x0flogUploadIntent\x12\\\n\x0csta\
+    ts_upload\x18\x07\x20\x01(\x0b27.bitdrift_public.protobuf.client.v1.Stat\
+    sUploadResponseH\0R\x0bstatsUpload\x12F\n\x04pong\x18\x03\x20\x01(\x0b20\
+    .bitdrift_public.protobuf.client.v1.PongResponseH\0R\x04pong\x12l\n\x14c\
+    onfiguration_update\x18\x04\x20\x01(\x0b27.bitdrift_public.protobuf.clie\
+    nt.v1.ConfigurationUpdateH\0R\x13configurationUpdate\x12Z\n\x0eruntime_u\
+    pdate\x18\x05\x20\x01(\x0b21.bitdrift_public.protobuf.client.v1.RuntimeU\
+    pdateH\0R\rruntimeUpdate\x12Z\n\x0eerror_shutdown\x18\x06\x20\x01(\x0b21\
+    .bitdrift_public.protobuf.client.v1.ErrorShutdownH\0R\rerrorShutdown\x12\
+    W\n\rflush_buffers\x18\t\x20\x01(\x0b20.bitdrift_public.protobuf.client.\
+    v1.FlushBuffersH\0R\x0cflushBuffers\x12r\n\x15sankey_diagram_upload\x18\
     \x0c\x20\x01(\x0b2<.bitdrift_public.protobuf.client.v1.SankeyPathUploadR\
     esponseH\0R\x13sankeyDiagramUpload\x12p\n\x16sankey_intent_response\x18\
     \r\x20\x01(\x0b28.bitdrift_public.protobuf.client.v1.SankeyIntentRespons\
@@ -9187,9 +8307,10 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x0b2:.bitdrift_public.protobuf.client.v1.UploadArtifactResponseH\0R\x0e\
     artifactUpload\x12k\n\x0fartifact_intent\x18\x0f\x20\x01(\x0b2@.bitdrift\
     _public.protobuf.client.v1.UploadArtifactIntentResponseH\0R\x0eartifactI\
-    ntentB\x14\n\rresponse_type\x12\x03\xf8B\x012x\n\nApiService\x12j\n\x03M\
-    ux\x12..bitdrift_public.protobuf.client.v1.ApiRequest\x1a/.bitdrift_publ\
-    ic.protobuf.client.v1.ApiResponse(\x010\x01b\x06proto3\
+    ntentB\x14\n\rresponse_type\x12\x03\xf8B\x01J\x04\x08\n\x10\x0bJ\x04\x08\
+    \x0b\x10\x0c2x\n\nApiService\x12j\n\x03Mux\x12..bitdrift_public.protobuf\
+    .client.v1.ApiRequest\x1a/.bitdrift_public.protobuf.client.v1.ApiRespons\
+    e(\x010\x01b\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -9206,10 +8327,9 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
     static file_descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::FileDescriptor> = ::protobuf::rt::Lazy::new();
     file_descriptor.get(|| {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
-            let mut deps = ::std::vec::Vec::with_capacity(11);
+            let mut deps = ::std::vec::Vec::with_capacity(10);
             deps.push(::protobuf::well_known_types::timestamp::file_descriptor().clone());
             deps.push(::protobuf::well_known_types::duration::file_descriptor().clone());
-            deps.push(::protobuf::well_known_types::any::file_descriptor().clone());
             deps.push(super::runtime::file_descriptor().clone());
             deps.push(super::metric::file_descriptor().clone());
             deps.push(super::filter::file_descriptor().clone());
@@ -9218,11 +8338,9 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             deps.push(super::config::file_descriptor().clone());
             deps.push(super::payload::file_descriptor().clone());
             deps.push(super::validate::file_descriptor().clone());
-            let mut messages = ::std::vec::Vec::with_capacity(44);
+            let mut messages = ::std::vec::Vec::with_capacity(40);
             messages.push(ClientKillFile::generated_message_descriptor_data());
             messages.push(HandshakeRequest::generated_message_descriptor_data());
-            messages.push(OpaqueConfigurationUpdate::generated_message_descriptor_data());
-            messages.push(OpaqueConfigurationUpdateAck::generated_message_descriptor_data());
             messages.push(LogUploadIntentRequest::generated_message_descriptor_data());
             messages.push(LogUploadIntentResponse::generated_message_descriptor_data());
             messages.push(LogUploadRequest::generated_message_descriptor_data());
@@ -9240,8 +8358,6 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
             messages.push(LogUploadResponse::generated_message_descriptor_data());
             messages.push(StatsUploadRequest::generated_message_descriptor_data());
             messages.push(StatsUploadResponse::generated_message_descriptor_data());
-            messages.push(OpaqueRequest::generated_message_descriptor_data());
-            messages.push(OpaqueResponse::generated_message_descriptor_data());
             messages.push(PongResponse::generated_message_descriptor_data());
             messages.push(ConfigurationUpdate::generated_message_descriptor_data());
             messages.push(RuntimeUpdate::generated_message_descriptor_data());

--- a/bd-runtime-config/src/loader.rs
+++ b/bd-runtime-config/src/loader.rs
@@ -297,7 +297,7 @@ impl<ConfigType: Send + Sync + 'static + ?Sized> WatchedFileLoader<ConfigType> {
     conversion_function: &ConversionFunc,
     stats: &impl StatsCallbacks,
   ) -> ConfigPtr<ConfigType> {
-    log::info!("attempting to reload: {file_to_load:?}");
+    log::info!("attempting to reload: {}", file_to_load.display());
     conversion_function(match std::fs::read_to_string(file_to_load) {
       Ok(file_data) => match serde_yaml::from_str::<SerializedType>(&file_data) {
         Ok(config) => {

--- a/bd-runtime/src/runtime_test.rs
+++ b/bd-runtime/src/runtime_test.rs
@@ -10,11 +10,10 @@ use crate::{bool_feature_flag, duration_feature_flag, int_feature_flag};
 use bd_test_helpers::runtime::{make_update, ValueKind};
 use bd_test_helpers::RecordingErrorReporter;
 use std::borrow::Borrow;
-use std::path::PathBuf;
 use std::sync::Arc;
 
-#[test]
-fn feature_flag_registration() {
+#[tokio::test]
+async fn feature_flag_registration() {
   int_feature_flag!(TestFlag, "test.path", 1);
   bool_feature_flag!(BoolFlag, "test.bool", false);
 
@@ -29,38 +28,46 @@ fn feature_flag_registration() {
   assert!(!*bool_feature_flag.read_mark_update());
 
   // After updating the value it now reflects the updated value.
-  loader.update_snapshot(&make_update(
-    vec![
-      (TestFlag::path(), ValueKind::Int(10)),
-      (BoolFlag::path(), ValueKind::Bool(true)),
-    ],
-    "1".to_string(),
-  ));
+  loader
+    .update_snapshot(&make_update(
+      vec![
+        (TestFlag::path(), ValueKind::Int(10)),
+        (BoolFlag::path(), ValueKind::Bool(true)),
+      ],
+      "1".to_string(),
+    ))
+    .await;
   assert_eq!(*int_feature_flag.read_mark_update(), 10);
   assert!(*bool_feature_flag.read_mark_update());
 
   // When we clear out the runtime, it reverts to the default.
-  loader.update_snapshot(&make_update(vec![], String::new()));
+  loader
+    .update_snapshot(&make_update(vec![], String::new()))
+    .await;
   assert_eq!(*int_feature_flag.read_mark_update(), 1);
   assert!(!*bool_feature_flag.read_mark_update());
 
   // If the value doesn't change, no events are pushed.
-  loader.update_snapshot(&make_update(vec![], String::new()));
+  loader
+    .update_snapshot(&make_update(vec![], String::new()))
+    .await;
   assert!(!int_feature_flag.watch.has_changed().unwrap());
   assert!(!bool_feature_flag.watch.has_changed().unwrap());
 }
 
-#[test]
-fn registration_after_update() {
+#[tokio::test]
+async fn registration_after_update() {
   int_feature_flag!(TestFlag, "test.path", 1);
 
   let sdk_directory = tempfile::TempDir::with_prefix("sdk").unwrap();
   let loader = ConfigLoader::new(sdk_directory.path());
 
-  loader.update_snapshot(&make_update(
-    vec![(TestFlag::path(), ValueKind::Int(10))],
-    "1".to_string(),
-  ));
+  loader
+    .update_snapshot(&make_update(
+      vec![(TestFlag::path(), ValueKind::Int(10))],
+      "1".to_string(),
+    ))
+    .await;
 
   let feature_flag = TestFlag::register(&loader).unwrap();
 
@@ -85,8 +92,8 @@ fn incompatible_registration() {
   );
 }
 
-#[test]
-fn duration_flag() {
+#[tokio::test]
+async fn duration_flag() {
   duration_feature_flag!(DurationFlag, "test.duration_ms", time::Duration::seconds(5));
 
   let sdk_directory = tempfile::TempDir::with_prefix("sdk").unwrap();
@@ -96,67 +103,72 @@ fn duration_flag() {
 
   assert_eq!(*flag.borrow().read(), time::Duration::seconds(5));
 
-  loader.update_snapshot(&make_update(
-    vec![(DurationFlag::path(), ValueKind::Int(100))],
-    "1".to_string(),
-  ));
+  loader
+    .update_snapshot(&make_update(
+      vec![(DurationFlag::path(), ValueKind::Int(100))],
+      "1".to_string(),
+    ))
+    .await;
 
   assert_eq!(*flag.borrow().read(), time::Duration::milliseconds(100));
 }
 
 struct SetupDiskPersistence {
   directory: tempfile::TempDir,
-  protobuf_file: PathBuf,
-  retry_file: PathBuf,
 }
 
 impl SetupDiskPersistence {
   fn new() -> Self {
     let directory = tempfile::TempDir::with_prefix("runtime").unwrap();
 
-    let loader = ConfigLoader::new(directory.path());
-    Self {
-      directory,
-      protobuf_file: loader.protobuf_file.clone(),
-      retry_file: loader.retry_count_file.clone(),
-    }
+    Self { directory }
   }
 
   fn new_loader(&self) -> Arc<ConfigLoader> {
     ConfigLoader::new(self.directory.path())
   }
+
+  fn protobuf_file(&self) -> std::path::PathBuf {
+    self.directory.path().join("runtime").join("protobuf.pb")
+  }
+
+  fn retry_file(&self) -> std::path::PathBuf {
+    self.directory.path().join("runtime").join("retry_count")
+  }
 }
 
 int_feature_flag!(TestFlag, "test.path", 1);
 
-#[test]
-fn disk_persistence_happy_path() {
+#[tokio::test]
+async fn disk_persistence_happy_path() {
   let setup = SetupDiskPersistence::new();
 
   // Load a value into the snapshot then immediately tear down the loader.
   {
     let loader = setup.new_loader();
-    loader.update_snapshot(&bd_test_helpers::runtime::make_update(
-      vec![(TestFlag::path(), ValueKind::Int(10))],
-      "1".to_string(),
-    ));
+    loader
+      .update_snapshot(&bd_test_helpers::runtime::make_update(
+        vec![(TestFlag::path(), ValueKind::Int(10))],
+        "1".to_string(),
+      ))
+      .await;
   }
 
   // At this point the value should be cached and we should see the previously set value on read.
-  assert!(setup.protobuf_file.exists());
-  assert!(setup.retry_file.exists());
+  assert!(setup.protobuf_file().exists());
+  assert!(setup.retry_file().exists());
 
   let loader = setup.new_loader();
 
-  loader.handle_cached_config();
+  loader.handle_cached_config().await;
 
   let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(*flag.read(), 10);
   assert_eq!(loader.snapshot().nonce, Some("1".to_string()));
 }
 
-#[test]
-fn disk_persistence_config_corruption() {
+#[tokio::test]
+async fn disk_persistence_config_corruption() {
   let setup = SetupDiskPersistence::new();
 
   // First write some data to the cached file by setting a new snapshot.
@@ -166,19 +178,23 @@ fn disk_persistence_config_corruption() {
       .update_snapshot(&bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
-      ));
+      ))
+      .await;
   }
 
   // Corrupt the file, verifying that we don't blow up when we read a bad file and fall back to
   // the default.
-  std::fs::write(&setup.protobuf_file, [0; 10]).unwrap();
+  std::fs::write(setup.protobuf_file(), [0; 10]).unwrap();
 
   let loader = setup.new_loader();
-  let ((), unexpected_error) =
-    RecordingErrorReporter::record_error(|| loader.handle_cached_config());
+  let cloned_loader = loader.clone();
+  let ((), unexpected_error) = RecordingErrorReporter::async_record_error(async move {
+    cloned_loader.handle_cached_config().await;
+  })
+  .await;
 
   assert_eq!(
-    "runtime cache load: Incorrect tag".to_string(),
+    "cache load: corrupt deflate stream".to_string(),
     unexpected_error,
   );
   let flag = TestFlag::register(&loader).unwrap();
@@ -186,8 +202,8 @@ fn disk_persistence_config_corruption() {
   assert_eq!(loader.snapshot().nonce, None);
 }
 
-#[test]
-fn disk_persistence_retry_corruption() {
+#[tokio::test]
+async fn disk_persistence_retry_corruption() {
   let setup = SetupDiskPersistence::new();
 
   // First write some data to the cached file by setting a new snapshot.
@@ -197,23 +213,24 @@ fn disk_persistence_retry_corruption() {
       .update_snapshot(&bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
-      ));
+      ))
+      .await;
   }
 
   // Corrupt the retry file, verifying that we don't blow up when we read a bad file and fall back
   // to the default.
-  std::fs::write(&setup.retry_file, []).unwrap();
+  std::fs::write(setup.retry_file(), []).unwrap();
 
   let loader = setup.new_loader();
-  loader.handle_cached_config();
+  loader.handle_cached_config().await;
 
   let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(*flag.read(), 1);
   assert_eq!(loader.snapshot().nonce, None);
 }
 
-#[test]
-fn disk_persistence_retry_limit() {
+#[tokio::test]
+async fn disk_persistence_retry_limit() {
   let setup = SetupDiskPersistence::new();
 
   // First write some data to the cached file by setting a new snapshot.
@@ -223,28 +240,29 @@ fn disk_persistence_retry_limit() {
       .update_snapshot(&bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
-      ));
+      ))
+      .await;
   }
 
   // Load the configuration 5 times without marking it as safe.
   for _ in 0 .. 6 {
     let loader = setup.new_loader();
-    loader.handle_cached_config();
+    loader.handle_cached_config().await;
     let flag = TestFlag::register(&loader).unwrap();
     assert_eq!(*flag.read(), 10);
   }
 
   // On the 6th go we hit the limit and will treat it as an error, wiping all state.
   let loader = setup.new_loader();
-  loader.handle_cached_config();
+  loader.handle_cached_config().await;
   let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(*flag.read(), 1);
-  assert!(!loader.protobuf_file.exists());
-  assert!(!loader.retry_count_file.exists());
+  assert!(!setup.protobuf_file().exists());
+  assert!(!setup.retry_file().exists());
 }
 
-#[test]
-fn disk_persistence_retry_marked_safe() {
+#[tokio::test]
+async fn disk_persistence_retry_marked_safe() {
   let setup = SetupDiskPersistence::new();
 
   // First write some data to the cached file by setting a new snapshot.
@@ -254,29 +272,30 @@ fn disk_persistence_retry_marked_safe() {
       .update_snapshot(&bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
-      ));
+      ))
+      .await;
   }
 
   // Load the configuration 5 times without marking it as safe.
   for _ in 0 .. 6 {
     let loader = setup.new_loader();
-    loader.handle_cached_config();
+    loader.handle_cached_config().await;
     let flag = TestFlag::register(&loader).unwrap();
     assert_eq!(*flag.read(), 10);
 
-    loader.mark_safe();
+    loader.file_cache.mark_safe().await;
   }
 
   // On the 6th we would have hit the limit but we've been marking the uploads as safe.
   let loader = setup.new_loader();
-  loader.handle_cached_config();
+  loader.handle_cached_config().await;
   let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(*flag.read(), 10);
-  assert_eq!(std::fs::read(&setup.retry_file).unwrap(), b"1");
+  assert_eq!(std::fs::read(setup.retry_file()).unwrap(), b"1");
 }
 
-#[test]
-fn disk_persistence_missing_config_file() {
+#[tokio::test]
+async fn disk_persistence_missing_config_file() {
   let setup = SetupDiskPersistence::new();
 
   // First write some data to the cached file by setting a new snapshot.
@@ -286,26 +305,27 @@ fn disk_persistence_missing_config_file() {
       .update_snapshot(&bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
-      ));
+      ))
+      .await;
   }
 
-  assert!(setup.protobuf_file.exists());
-  assert!(setup.retry_file.exists());
+  assert!(setup.protobuf_file().exists());
+  assert!(setup.retry_file().exists());
 
-  std::fs::remove_file(&setup.protobuf_file).unwrap();
+  std::fs::remove_file(setup.protobuf_file()).unwrap();
 
   // If the config file is missing, we should handle this gracefully and clean up the other file,
   // falling back to the default.
   let loader = setup.new_loader();
-  loader.handle_cached_config();
+  loader.handle_cached_config().await;
   let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(*flag.read(), 1);
 
-  assert!(!setup.retry_file.exists());
+  assert!(!setup.retry_file().exists());
 }
 
-#[test]
-fn disk_persistence_missing_retry_file() {
+#[tokio::test]
+async fn disk_persistence_missing_retry_file() {
   let setup = SetupDiskPersistence::new();
 
   // First write some data to the cached file by setting a new snapshot.
@@ -315,26 +335,27 @@ fn disk_persistence_missing_retry_file() {
       .update_snapshot(&bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
-      ));
+      ))
+      .await;
   }
 
-  assert!(setup.protobuf_file.exists());
-  assert!(setup.retry_file.exists());
+  assert!(setup.protobuf_file().exists());
+  assert!(setup.retry_file().exists());
 
-  std::fs::remove_file(&setup.retry_file).unwrap();
+  std::fs::remove_file(setup.retry_file()).unwrap();
 
   // If the retry file is missing, we should handle this gracefully and clean up the other file,
   // falling back to the default.
   let loader = setup.new_loader();
-  loader.handle_cached_config();
+  loader.handle_cached_config().await;
   let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(*flag.read(), 1);
 
-  assert!(!setup.protobuf_file.exists());
+  assert!(!setup.protobuf_file().exists());
 }
 
-#[test]
-fn disk_persistence_cannot_update_retry() {
+#[tokio::test]
+async fn disk_persistence_cannot_update_retry() {
   let setup = SetupDiskPersistence::new();
 
   // First write some data to the cached file by setting a new snapshot.
@@ -344,25 +365,30 @@ fn disk_persistence_cannot_update_retry() {
       .update_snapshot(&bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
-      ));
+      ))
+      .await;
   }
 
-  assert!(setup.protobuf_file.exists());
-  assert!(setup.retry_file.exists());
+  assert!(setup.protobuf_file().exists());
+  assert!(setup.retry_file().exists());
 
   // Set readonly. We can read the retry value, but won't be able to update it.
-  let mut perms = std::fs::metadata(&setup.retry_file).unwrap().permissions();
+  let mut perms = std::fs::metadata(setup.retry_file()).unwrap().permissions();
   perms.set_readonly(true);
-  std::fs::set_permissions(&setup.retry_file, perms).unwrap();
+  std::fs::set_permissions(setup.retry_file(), perms).unwrap();
 
   let loader = setup.new_loader();
-  let ((), error) = RecordingErrorReporter::record_error(|| loader.handle_cached_config());
+  let cloned_loader = loader.clone();
+  let ((), error) = RecordingErrorReporter::async_record_error(async move {
+    cloned_loader.handle_cached_config().await;
+  })
+  .await;
   assert_eq!(
-    "runtime cache load: an io error occurred: Permission denied (os error 13)",
+    "cache load: an io error occurred: Permission denied (os error 13)",
     error
   );
   let flag = TestFlag::register(&loader).unwrap();
   assert_eq!(*flag.read(), 1);
 
-  assert!(!setup.protobuf_file.exists());
+  assert!(!setup.protobuf_file().exists());
 }

--- a/bd-server-stats/src/stats.rs
+++ b/bd-server-stats/src/stats.rs
@@ -350,7 +350,7 @@ impl bd_stats_common::Counter for CounterWrapper {
 // Named metrics scope used to create metrics.
 #[derive(Clone)]
 pub struct Scope {
-  scope: String,
+  name: String,
   collector: Collector,
   labels: HashMap<String, String>,
 }
@@ -374,14 +374,14 @@ impl Scope {
   // Create a sub-scope with a set of fixed labels.
   #[must_use]
   pub fn scope_with_labels(&self, extend: &str, labels: HashMap<String, String>) -> Self {
-    let scope_name = if extend.is_empty() {
-      self.scope.clone()
+    let name = if extend.is_empty() {
+      self.name.clone()
     } else {
       self.metric_name(extend)
     };
 
     Self {
-      scope: scope_name,
+      name,
       collector: self.collector.clone(),
       labels: self.final_labels(labels),
     }
@@ -518,10 +518,10 @@ impl Scope {
 
   // Build the final metric name from the current scope.
   fn metric_name(&self, name: &str) -> String {
-    if self.scope.is_empty() {
+    if self.name.is_empty() {
       name.to_string()
     } else {
-      format!("{}{SEP}{name}", self.scope)
+      format!("{}{SEP}{name}", self.name)
     }
   }
 }
@@ -587,7 +587,7 @@ impl Collector {
   #[must_use]
   pub fn scope(&self, name: &str) -> Scope {
     Scope {
-      scope: name.to_string(),
+      name: name.to_string(),
       collector: self.clone(),
       labels: HashMap::new(),
     }

--- a/bd-test-helpers/src/metadata.rs
+++ b/bd-test-helpers/src/metadata.rs
@@ -32,7 +32,6 @@ impl Metadata for EmptyMetadata {
     String::new()
   }
 
-  #[must_use]
   fn collect_inner(&self) -> HashMap<String, String> {
     HashMap::new()
   }

--- a/bd-time/src/lib.rs
+++ b/bd-time/src/lib.rs
@@ -63,12 +63,10 @@ impl OffsetDateTimeExt for OffsetDateTime {
     .into()
   }
 
-  #[must_use]
   fn unix_timestamp_ms(&self) -> i64 {
     self.unix_timestamp() * 1_000 + i64::from(self.nanosecond() / 1_000_000)
   }
 
-  #[must_use]
   fn unix_timestamp_micros(&self) -> i64 {
     self.unix_timestamp() * 1_000_000 + i64::from(self.nanosecond() / 1_000)
   }

--- a/bd-workflows/benches/matcher.rs
+++ b/bd-workflows/benches/matcher.rs
@@ -14,7 +14,7 @@ use bd_runtime::runtime::ConfigLoader;
 use bd_test_helpers::{action, declare_transition, log_matches, rule, state, workflow_proto};
 use bd_workflows::config::WorkflowsConfiguration;
 use bd_workflows::engine::{WorkflowsEngine, WorkflowsEngineConfig};
-use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use std::collections::BTreeSet;
 use std::future::Future;
 use time::OffsetDateTime;
@@ -122,7 +122,7 @@ fn run_runtime_bench<T: Future<Output = WorkflowsEngine>>(
       let mut engine = engine().await;
       bencher.iter(|| {
         engine.process_log(
-          black_box(&LogRef {
+          std::hint::black_box(&LogRef {
             log_type: LogType::Normal,
             log_level: log_level::DEBUG,
             message: &"foo".into(),

--- a/bd-workflows/src/engine.rs
+++ b/bd-workflows/src/engine.rs
@@ -967,8 +967,10 @@ impl StateStore {
   fn new(sdk_directory: &Path, scope: &Scope, runtime: &ConfigLoader) -> Self {
     let stats = StateStoreStats::new(scope);
 
-    let description =
-      format!("failed to deserialize workflows: invalid sdk dir: {sdk_directory:?}");
+    let description = format!(
+      "failed to deserialize workflows: invalid sdk dir: {}",
+      sdk_directory.display()
+    );
     bd_client_common::error::handle_unexpected::<(), anyhow::Error>(
       if sdk_directory.is_dir() {
         Ok(())

--- a/bd-workflows/src/engine_test.rs
+++ b/bd-workflows/src/engine_test.rs
@@ -1053,10 +1053,13 @@ async fn traversals_count_limit_prevents_creation_of_new_workflows() {
   ];
 
   let setup = Setup::new();
-  setup.runtime.update_snapshot(&make_simple_update(vec![(
-    bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
-    ValueKind::Int(2),
-  )]));
+  setup
+    .runtime
+    .update_snapshot(&make_simple_update(vec![(
+      bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
+      ValueKind::Int(2),
+    )]))
+    .await;
 
   // We try to create 4 workflows (each with 1 run that has 1 traversal) but
   // the configured traversals count limit is 2. For this reason, we succeed
@@ -1129,10 +1132,13 @@ async fn traversals_count_limit_prevents_creation_of_new_workflow_runs() {
   let workflows = vec![workflow!(parallel with a, b)];
 
   let setup = Setup::new();
-  setup.runtime.update_snapshot(&make_simple_update(vec![(
-    bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
-    ValueKind::Int(2),
-  )]));
+  setup
+    .runtime
+    .update_snapshot(&make_simple_update(vec![(
+      bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
+      ValueKind::Int(2),
+    )]))
+    .await;
 
   let mut workflows_engine = setup
     .make_workflows_engine(WorkflowsEngineConfig::new_with_workflow_configurations(
@@ -1197,10 +1203,13 @@ async fn traversals_count_limit_causes_run_removal_after_forking() {
 
   let setup = Setup::new();
 
-  setup.runtime.update_snapshot(&make_simple_update(vec![(
-    bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
-    ValueKind::Int(2),
-  )]));
+  setup
+    .runtime
+    .update_snapshot(&make_simple_update(vec![(
+      bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
+      ValueKind::Int(2),
+    )]))
+    .await;
 
   let mut workflows_engine = setup
     .make_workflows_engine(WorkflowsEngineConfig::new_with_workflow_configurations(
@@ -1616,10 +1625,13 @@ async fn persists_state_on_periodic_basis() {
 
   // Speed up periodic persistance so that the test can complete in a shorter
   // amount of time.
-  setup.runtime.update_snapshot(&make_simple_update(vec![(
-    bd_runtime::runtime::workflows::StatePeriodicWriteIntervalFlag::path(),
-    ValueKind::Int(10),
-  )]));
+  setup
+    .runtime
+    .update_snapshot(&make_simple_update(vec![(
+      bd_runtime::runtime::workflows::StatePeriodicWriteIntervalFlag::path(),
+      ValueKind::Int(10),
+    )]))
+    .await;
 
   // Engine creation should still succeed but with a default state
   let mut workflows_engine = setup
@@ -2594,10 +2606,13 @@ async fn creating_new_runs_after_first_log_processing() {
   );
 
   let setup = Setup::new();
-  setup.runtime.update_snapshot(&make_simple_update(vec![(
-    bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
-    ValueKind::Int(3),
-  )]));
+  setup
+    .runtime
+    .update_snapshot(&make_simple_update(vec![(
+      bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
+      ValueKind::Int(3),
+    )]))
+    .await;
 
   // This test assumes that internally `workflows_engine` iterates
   // over the list of its workflows in order.

--- a/profiling/src/main.rs
+++ b/profiling/src/main.rs
@@ -400,15 +400,18 @@ fn run_profiling<T: Fn(&mut AnnotatedWorkflowsEngine) + std::marker::Send + 'sta
       .build()
       .unwrap()
       .block_on(async {
-        setup.runtime_loader.update_snapshot(&RuntimeUpdate {
-          version_nonce: "123".to_string(),
-          runtime: Some(bd_test_helpers::runtime::make_proto(vec![(
-            bd_runtime::runtime::stats::DirectStatFlushIntervalFlag::path(),
-            bd_test_helpers::runtime::ValueKind::Int(900),
-          )]))
-          .into(),
-          ..Default::default()
-        });
+        setup
+          .runtime_loader
+          .update_snapshot(&RuntimeUpdate {
+            version_nonce: "123".to_string(),
+            runtime: Some(bd_test_helpers::runtime::make_proto(vec![(
+              bd_runtime::runtime::stats::DirectStatFlushIntervalFlag::path(),
+              bd_test_helpers::runtime::ValueKind::Int(900),
+            )]))
+            .into(),
+            ..Default::default()
+          })
+          .await;
 
         // Given the runtime configuration update time to propagate.
         1.seconds().sleep().await;


### PR DESCRIPTION
This change is the first part of improving cached config handling for workflows. This PR factors out the existing runtime crash loop detection code into a shared helper, and uses that helper for workflow config as well. A follow up change will improve this mechanism by marking configs safe after a certain amount of process lifetime, when the handshake indicates configs are up to date, when a config is updated, or after the process has been up for some number of seconds to better handle fully offline scenarios.

This PR has a bunch of tangentially related changes like clippy fixes, converting some code using sync fs to async fs, and removing opaque config.