### PR TITLE
[FatalIssueReporter] Update FatalIssue log depending on mechanism

### DIFF
--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -338,6 +338,10 @@ impl Monitor {
 
         fields.extend(
           [
+            (
+              "_app_exit_reason".into(),
+              fatal_issue_metadata.report_type_value,
+            ),
             ("_crash_artifact".into(), contents.into()),
             (
               fatal_issue_metadata.reason_key.clone(),
@@ -352,10 +356,6 @@ impl Monitor {
             (
               "_fatal_issue_mechanism".into(),
               fatal_issue_metadata.mechanism_type_value.into(),
-            ),
-            (
-              "_fatal_issue_report_type".into(),
-              fatal_issue_metadata.report_type_value,
             ),
           ]
           .into_iter(),
@@ -423,11 +423,11 @@ fn get_fatal_issue_metadata(path: &Path) -> anyhow::Result<FatalIssueMetadata> {
   let report_type = if file_name.contains("_anr") {
     "ANR"
   } else if file_name.contains("_native_crash") {
-    "NATIVE_CRASH"
+    "Native Crash"
   } else if file_name.contains("_crash") {
-    "CRASH"
+    "Crash"
   } else {
-    "UNKNOWN"
+    "Unknown"
   };
 
   match ext {

--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -449,6 +449,9 @@ fn get_fatal_issue_metadata(path: &Path) -> Result<FatalIssueMetadata, String> {
       reason_key: "_app_exit_info".into(),
       report_type_value: report_type.into(),
     }),
-    _ => Err(format!("Unknown file extension for path: {:?}", path)),
+    _ => Err(format!(
+      "Unknown file extension for path: {}",
+      path.display()
+    )),
   }
 }

--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -338,7 +338,7 @@ impl Monitor {
         };
 
         let mut fields = global_state_fields.clone();
-        let message = fatal_issue_metadata.message_value.into();
+        let message = fatal_issue_metadata.message_value;
 
         fields.extend(
           [
@@ -359,7 +359,7 @@ impl Monitor {
             ),
             (
               "_fatal_issue_report_type".into(),
-              fatal_issue_metadata.report_type_value.into(),
+              fatal_issue_metadata.report_type_value,
             ),
           ]
           .into_iter(),
@@ -435,7 +435,7 @@ fn get_fatal_issue_metadata(path: &Path) -> Result<FatalIssueMetadata, String> {
   };
 
   match ext {
-    Some("envelope") | Some("json") => Ok(FatalIssueMetadata {
+    Some("envelope" | "json") => Ok(FatalIssueMetadata {
       mechanism_type_value: "INTEGRATION",
       message_value: "App crashed".into(),
       details_key: "_crash_details".into(),

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -265,5 +265,7 @@ fn get_fatal_issue_mechanism_without_extension_must_return_error() {
 
   let metadata = get_fatal_issue_metadata(file_without_extension);
   assert!(metadata.is_err());
-  assert!(metadata.unwrap_err().contains("Unknown file extension"));
+
+  let error_message = metadata.unwrap_err().to_string();
+  assert!(error_message.contains("Unknown file extension"));
 }

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -246,17 +246,27 @@ fn get_fatal_issue_mechanism_from_json_must_return_integration() {
   assert_eq!(metadata.reason_key, "_crash_reason");
   assert_eq!(metadata.message_value, "App crashed".into());
   assert_eq!(metadata.mechanism_type_value, "INTEGRATION");
+  assert_eq!(metadata.report_type_value, "Unknown".into());
 }
 
 #[test]
 fn get_fatal_issue_mechanism_from_cap_must_return_built_in() {
-  let cap_file = Path::new("foo.cap");
+  let cap_file = Path::new("foo_crash.cap");
 
-  let metadata = get_fatal_issue_metadata(cap_file).unwrap();
-  assert_eq!(metadata.details_key, "_app_exit_details");
-  assert_eq!(metadata.reason_key, "_app_exit_info");
-  assert_eq!(metadata.message_value, "AppExit".into());
-  assert_eq!(metadata.mechanism_type_value, "BUILT_IN");
+  let crash_metadata = get_fatal_issue_metadata(cap_file).unwrap();
+  assert_eq!(crash_metadata.details_key, "_app_exit_details");
+  assert_eq!(crash_metadata.reason_key, "_app_exit_info");
+  assert_eq!(crash_metadata.message_value, "AppExit".into());
+  assert_eq!(crash_metadata.mechanism_type_value, "BUILT_IN");
+  assert_eq!(crash_metadata.report_type_value, "Crash".into());
+
+  let cap_file = Path::new("foo_anr.cap");
+  let anr_metadata = get_fatal_issue_metadata(cap_file).unwrap();
+  assert_eq!(anr_metadata.report_type_value, "ANR".into());
+
+  let cap_file = Path::new("foo_native_crash.cap");
+  let anr_metadata = get_fatal_issue_metadata(cap_file).unwrap();
+  assert_eq!(anr_metadata.report_type_value, "Native Crash".into());
 }
 
 #[test]

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -6,8 +6,10 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use crate::{
+  get_fatal_issue_metadata,
   global_state,
   Monitor,
+  Path,
   DETAILS_INFERENCE_CONFIG_FILE,
   INGESTION_CONFIG_FILE,
   REASON_INFERENCE_CONFIG_FILE,
@@ -139,9 +141,9 @@ async fn crash_reason_inference() {
   let artifact1 = b"{\"reason\":\"foo\",\"details\": [{\"cause\": \"kaboom\"}]}";
   let artifact2 = b"{\"crash\":{\"reason\": \"bar\"}}";
   let artifact3 = b"{}\n{\"crash\":{\"reason\": \"bar\"}}\n{\"crash\":{\"reason\": \"bar\"}}";
-  setup.make_crash("crash1", artifact1);
-  setup.make_crash("crash2", artifact2);
-  setup.make_crash("crash3", artifact3);
+  setup.make_crash("crash1.envelope", artifact1);
+  setup.make_crash("crash2.envelope", artifact2);
+  setup.make_crash("crash3.envelope", artifact3);
 
   let logs = setup.process_new_reports().await;
   assert_eq!(3, logs.len());
@@ -178,9 +180,9 @@ async fn crash_handling_missing_reason() {
     .write_config_file(DETAILS_INFERENCE_CONFIG_FILE, "details[0].cause")
     .await;
 
-  setup.make_crash("crash1", b"crash1");
-  setup.make_crash("crash2", b"crash2");
-  setup.make_crash("crash3", b"{\"crash\":{\"reason\": \"bar\"}}");
+  setup.make_crash("crash1.envelope", b"crash1");
+  setup.make_crash("crash2.envelope", b"crash2");
+  setup.make_crash("crash3.envelope", b"{\"crash\":{\"reason\": \"bar\"}}");
 
   let logs = setup.process_new_reports().await;
   assert_eq!(1, logs.len());
@@ -222,4 +224,46 @@ fn crash_reason_from_empty_errors_vector() {
   let (reason, detail) = Monitor::guess_crash_details(data, &[], &[]);
   assert_eq!(None, reason);
   assert_eq!(None, detail);
+}
+
+#[test]
+fn get_fatal_issue_mechanism_from_envelope_must_return_integration() {
+  let envelope_file = Path::new("foo.envelope");
+
+  let metadata = get_fatal_issue_metadata(envelope_file).unwrap();
+  assert_eq!(metadata.details_key, "_crash_details");
+  assert_eq!(metadata.reason_key, "_crash_reason");
+  assert_eq!(metadata.message_value, "App crashed".into());
+  assert_eq!(metadata.mechanism_type_value, "INTEGRATION");
+}
+
+#[test]
+fn get_fatal_issue_mechanism_from_json_must_return_integration() {
+  let json_file = Path::new("foo.json");
+
+  let metadata = get_fatal_issue_metadata(json_file).unwrap();
+  assert_eq!(metadata.details_key, "_crash_details");
+  assert_eq!(metadata.reason_key, "_crash_reason");
+  assert_eq!(metadata.message_value, "App crashed".into());
+  assert_eq!(metadata.mechanism_type_value, "INTEGRATION");
+}
+
+#[test]
+fn get_fatal_issue_mechanism_from_cap_must_return_built_in() {
+  let cap_file = Path::new("foo.cap");
+
+  let metadata = get_fatal_issue_metadata(cap_file).unwrap();
+  assert_eq!(metadata.details_key, "_app_exit_details");
+  assert_eq!(metadata.reason_key, "_app_exit_info");
+  assert_eq!(metadata.message_value, "AppExit".into());
+  assert_eq!(metadata.mechanism_type_value, "BUILT_IN");
+}
+
+#[test]
+fn get_fatal_issue_mechanism_without_extension_must_return_error() {
+  let file_without_extension = Path::new("no_extension");
+
+  let metadata = get_fatal_issue_metadata(file_without_extension);
+  assert!(metadata.is_err());
+  assert!(metadata.unwrap_err().contains("Unknown file extension"));
 }

--- a/bd-log-primitives/src/lib.rs
+++ b/bd-log-primitives/src/lib.rs
@@ -113,6 +113,12 @@ pub type LogFieldKey = Cow<'static, str>;
 pub type LogFieldValue = StringOrBytes<String, Vec<u8>>;
 
 //
+// LogMessageValue
+//
+
+pub type LogMessageValue = StringOrBytes<String, Vec<u8>>;
+
+//
 // AnnotatedLogFields
 //
 

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -287,7 +287,7 @@ impl LoggerBuilder {
         .map(|crash_log| Log {
           log_level: log_level::ERROR,
           log_type: LogType::Lifecycle,
-          message: "App crashed".into(),
+          message: crash_log.message,
           fields: crash_log.fields,
           matching_fields: [].into(),
           session_id: session_strategy

--- a/bd-logger/src/test/crash_handler_integration.rs
+++ b/bd-logger/src/test/crash_handler_integration.rs
@@ -45,14 +45,14 @@ fn crash_reports() {
     .unwrap();
 
     std::fs::write(
-      setup.sdk_directory.path().join("reports/new/crash1.txt"),
+      setup.sdk_directory.path().join("reports/new/crash1.json"),
       "{\"crash\": \"crash1\"}",
     )
     .unwrap();
 
     std::fs::write(
       setup.sdk_directory.path().join(format!(
-        "reports/new/{}_crash2.txt",
+        "reports/new/{}_crash2.json",
         timestamp.unix_timestamp_nanos() / 1_000_000
       )),
       "{\"crash\": \"crash2\"}",


### PR DESCRIPTION
Updating FatalIssue Log contents depending on mechanism type

Frontend changes added in https://github.com/bitdriftlabs/bitdrift-frontend/pull/2298

More details in https://docs.google.com/document/d/1JTlIW2rB_3crYArBB6wHeF0JGdTPA6DrAnFCw3Jo8DM/edit?tab=t.p3ma0bg1t9cz#heading=h.odruallazj53 

| Field/Value change | Integration | BuiltIn |
| --------------------| -----------| ---------|
| **details_key** | _crash_details | _app_exit_details |
| **reason_key** | _crash_reason | _app_exit_info |
| **message_value** | App crashed | AppExit |

For matching with existing `Fatal Issue -JVM` workflows we are relying on '_app_exit_reason = Crash'

NOTE: This requires to also update frontend and update iOS client to append the report type to file name

# Verification

https://timeline.bitdrift.dev/session/74a492e7-05d8-487a-923a-fa5ac8af1bf7?utm_source=sdk&pages=1&utilization=0&expanded=-5582004108022113377

# Worflow verification

Verify with this workflow matching on a new custom error only on the local build

See the generated output from this worfklow https://explorations.bitdrift.dev/exploration/fran-s-explorations-DGBY/fatal-issue-jvm-builtin-mechanism-K60A

```
log_matcher:
          and_matcher:
            log_matchers:
            - base_matcher:
                tag_match:
                  string_value_match:
                    match_value: Android
                    operator: OPERATOR_EQUALS
                  tag_key: os
            - and_matcher:
                log_matchers:
                - base_matcher:
                    tag_match:
                      int_value_match:
                        match_value: 2
                        operator: OPERATOR_EQUALS
                      tag_key: log_type
                - base_matcher:
                    message_match:
                      string_value_match:
                        match_value: AppExit
                        operator: OPERATOR_EQUALS
                - base_matcher:
                    tag_match:
                      string_value_match:
                        match_value: Crash
                        operator: OPERATOR_EQUALS
                      tag_key: _app_exit_reason
            - base_matcher:
                tag_match:
                  string_value_match:
                    match_value: Dispatchers.IO coroutine crash
                    operator: OPERATOR_EQUALS
                  tag_key: _app_exit_details
```

<img width="1618" alt="image" src="https://github.com/user-attachments/assets/966349a5-d008-4797-99bf-b49c643e9b5b" />

https://timeline.bitdrift.review/v/4030457849317637990/session/0b230f26-5a4c-4375-9a31-b1fb789d35ce?pages=1&utilization=0&expanded=-2014054000533534313

<img width="1722" alt="image" src="https://github.com/user-attachments/assets/ac6313c9-241c-4521-993d-65a3111d6c45" />

<img width="1614" alt="image" src="https://github.com/user-attachments/assets/65d0392c-d067-40a1-8281-bea489f9280a" />