### PR TITLE
load runtime config from disk as early as possible

### DIFF
--- a/bd-api/src/api.rs
+++ b/bd-api/src/api.rs
@@ -741,7 +741,7 @@ impl Api {
   /// Handles any number of non-handshake responses. Receiving a handshake response at this point
   /// is considered a protocol error.
   async fn handle_responses(
-    &mut self,
+    &self,
     responses: Vec<ApiResponse>,
     stream_state: &mut StreamState,
   ) -> anyhow::Result<()> {
@@ -855,7 +855,7 @@ impl Api {
         None => {
           debug_assert!(false, "not handled");
         },
-      };
+      }
     }
 
     Ok(())

--- a/bd-client-common/src/payload_conversion.rs
+++ b/bd-client-common/src/payload_conversion.rs
@@ -61,7 +61,8 @@ pub enum ResponseKind<'a> {
   SankeyPathUploadIntent(&'a SankeyIntentResponse),
   ArtifactUploadIntent(&'a UploadArtifactIntentResponse),
   ArtifactUpload(&'a UploadArtifactResponse),
-  Untyped,
+  ConfigurationUpdate(&'a ConfigurationUpdate),
+  RuntimeUpdate(&'a RuntimeUpdate),
 }
 
 //
@@ -173,7 +174,10 @@ impl MuxResponse for ApiResponse {
       Response_type::FlushBuffers(f) => Some(ResponseKind::FlushBuffers(f)),
       Response_type::SankeyDiagramUpload(s) => Some(ResponseKind::SankeyPathUpload(s)),
       Response_type::SankeyIntentResponse(s) => Some(ResponseKind::SankeyPathUploadIntent(s)),
-      _ => Some(ResponseKind::Untyped),
+      Response_type::ConfigurationUpdate(u) => Some(ResponseKind::ConfigurationUpdate(u)),
+      Response_type::RuntimeUpdate(r) => Some(ResponseKind::RuntimeUpdate(r)),
+      Response_type::ArtifactUpload(u) => Some(ResponseKind::ArtifactUpload(u)),
+      Response_type::ArtifactIntent(u) => Some(ResponseKind::ArtifactUploadIntent(u)),
     }
   }
 }

--- a/bd-logger/src/client_config.rs
+++ b/bd-logger/src/client_config.rs
@@ -81,7 +81,7 @@ pub struct Config<A: ApplyConfig> {
 impl<A: ApplyConfig> Config<A> {
   pub fn new(sdk_directory: &Path, apply_config: A) -> Self {
     Self {
-      file_cache: SafeFileCache::new(sdk_directory, "config"),
+      file_cache: SafeFileCache::new("config", sdk_directory),
       configuration_version_id: Mutex::default(),
       apply_config,
     }

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -1646,7 +1646,7 @@ fn continuous_buffer_resume_with_full_buffer() {
     [].into(),
   );
 
-  // Shut down the logger. The bufer should now be "full" and only have a single log in place.
+  // Shut down the logger. The buffer should now be "full" and only have a single log in place.
 
   let sdk_directory = setup.sdk_directory.clone();
   std::mem::drop(setup);

--- a/bd-logger/src/test/setup.rs
+++ b/bd-logger/src/test/setup.rs
@@ -198,7 +198,7 @@ impl Setup {
     server: &mut bd_test_helpers::test_api_server::ServerHandle,
   ) -> StreamHandle {
     let stream = server.blocking_next_stream().unwrap();
-    assert!(stream.await_event_with_timeout(ExpectedStreamEvent::Handshake(None), 1.seconds(),));
+    assert!(stream.await_event_with_timeout(ExpectedStreamEvent::Handshake(None), 2.seconds(),));
 
     stream.blocking_stream_action(StreamAction::SendRuntime(make_update(
       Self::get_default_runtime_values(),

--- a/bd-runtime/src/runtime.rs
+++ b/bd-runtime/src/runtime.rs
@@ -94,6 +94,8 @@ struct LoaderState {
 
   /// Tracks watches for each runtime key.
   watches: HashMap<&'static str, InternalWatchKind>,
+
+  initialized: bool,
 }
 
 impl LoaderState {
@@ -101,6 +103,7 @@ impl LoaderState {
     Self {
       snapshot: Arc::new(Snapshot::new(runtime, version_nonce)),
       watches: HashMap::new(),
+      initialized: false,
     }
   }
 }
@@ -153,7 +156,7 @@ impl ConfigLoader {
   pub fn new(sdk_directory: &Path) -> Arc<Self> {
     Arc::new(Self {
       state: Mutex::new(LoaderState::new(Runtime::default(), None)),
-      file_cache: SafeFileCache::new(sdk_directory, "runtime"),
+      file_cache: SafeFileCache::new("runtime", sdk_directory),
     })
   }
 
@@ -220,7 +223,13 @@ impl ConfigLoader {
   async fn handle_cached_config(&self) {
     if let Some(runtime) = self.file_cache.handle_cached_config().await {
       self.update_snapshot_inner(&runtime);
+    } else {
+      self.state.lock().initialized = true;
     }
+  }
+
+  pub fn expect_initialized(&self) {
+    debug_assert!(self.state.lock().initialized);
   }
 
   pub async fn update_snapshot(&self, runtime_update: &RuntimeUpdate) {
@@ -231,6 +240,7 @@ impl ConfigLoader {
   /// Updates the current runtime snapshot, updating all registered watchers as appropriate.
   fn update_snapshot_inner(&self, runtime_update: &RuntimeUpdate) {
     let mut l = self.state.lock();
+    l.initialized = true;
 
     let snapshot = Arc::new(Snapshot::new(
       runtime_update.runtime.clone().unwrap_or_default(),


### PR DESCRIPTION
This moves runtime config loading to the very beginning of the future exectued on the tokio thread. This should allow us to read runtime flags super early on without having to worry about racing with the api task that would previously handle initialization.

Also cleans up some of the tech debt around configuration pipelines that remained from a previous attempt at supporting multiple configuration pipelines

Fixes BIT-5408