### PR TITLE
grpc: make sure bad request errors are returned as connect errors

### DIFF
--- a/bd-grpc/Cargo.toml
+++ b/bd-grpc/Cargo.toml
@@ -23,11 +23,11 @@ bd-stats-common.path        = "../bd-stats-common"
 bd-time.path                = "../bd-time"
 bytes.workspace             = true
 futures.workspace           = true
-http-body-util.workspace    = true
-http-body.workspace         = true
 http.workspace              = true
-hyper-util.workspace        = true
+http-body.workspace         = true
+http-body-util.workspace    = true
 hyper.workspace             = true
+hyper-util.workspace        = true
 log.workspace               = true
 mockall                     = { workspace = true, optional = true }
 prometheus.workspace        = true
@@ -37,15 +37,16 @@ serde_json.workspace        = true
 snap.workspace              = true
 thiserror.workspace         = true
 time.workspace              = true
-tokio-stream.workspace      = true
 tokio.workspace             = true
-tower-http.workspace        = true
+tokio-stream.workspace      = true
 tower.workspace             = true
+tower-http.workspace        = true
 unwrap-infallible.workspace = true
 urlencoding.workspace       = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+bd-pgv.path              = "../bd-pgv"
 bd-test-helpers.path     = "../bd-test-helpers"
 bd-time.path             = "../bd-time"
 ctor.workspace           = true

--- a/bd-grpc/build.rs
+++ b/bd-grpc/build.rs
@@ -18,7 +18,7 @@ fn main() {
   protobuf_codegen::Codegen::new()
     .protoc()
     .customize(Customize::default().gen_mod_rs(false))
-    .includes(["src/proto"])
+    .includes(["src/proto", "../api/protoc-gen-validate"])
     .inputs(["src/proto/test.proto"])
     .out_dir("src/generated/proto/")
     .capture_stderr()

--- a/bd-grpc/src/error.rs
+++ b/bd-grpc/src/error.rs
@@ -5,10 +5,10 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::connect_protocol::ErrorResponse;
+use crate::connect_protocol::{ConnectProtocolType, ErrorResponse};
 use crate::status::{Code, Status};
 use crate::CONTENT_TYPE_JSON;
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
 use axum::BoxError;
 use http::header::CONTENT_TYPE;
 
@@ -39,12 +39,6 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
-
-impl IntoResponse for Error {
-  fn into_response(self) -> Response {
-    self.into_status().into_response()
-  }
-}
 
 impl Error {
   fn into_status(self) -> Status {
@@ -92,5 +86,14 @@ impl Error {
           .into(),
       )
       .unwrap()
+  }
+
+  #[must_use]
+  pub fn to_response(self, connect_protocol: Option<ConnectProtocolType>) -> Response {
+    if connect_protocol.is_some() {
+      self.to_connect_error_response()
+    } else {
+      self.into_status().into_response()
+    }
   }
 }

--- a/bd-grpc/src/generated/proto/mod.rs
+++ b/bd-grpc/src/generated/proto/mod.rs
@@ -6,3 +6,5 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 pub mod test;
+
+use bd_pgv::generated::protos::validate;

--- a/bd-grpc/src/generated/proto/test.rs
+++ b/bd-grpc/src/generated/proto/test.rs
@@ -269,10 +269,11 @@ impl ::protobuf::reflect::ProtobufValue for EchoResponse {
 }
 
 static file_descriptor_proto_data: &'static [u8] = b"\
-    \n\ntest.proto\x12\x04test\"!\n\x0bEchoRequest\x12\x12\n\x04echo\x18\x01\
-    \x20\x01(\tR\x04echo\"\"\n\x0cEchoResponse\x12\x12\n\x04echo\x18\x01\x20\
-    \x01(\tR\x04echo25\n\x04Test\x12-\n\x04Echo\x12\x11.test.EchoRequest\x1a\
-    \x12.test.EchoResponseb\x06proto3\
+    \n\ntest.proto\x12\x04test\x1a\x17validate/validate.proto\"*\n\x0bEchoRe\
+    quest\x12\x1b\n\x04echo\x18\x01\x20\x01(\tR\x04echoB\x07\xfaB\x04r\x02\
+    \x10\x01\"\"\n\x0cEchoResponse\x12\x12\n\x04echo\x18\x01\x20\x01(\tR\x04\
+    echo25\n\x04Test\x12-\n\x04Echo\x12\x11.test.EchoRequest\x1a\x12.test.Ec\
+    hoResponseb\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file
@@ -289,7 +290,8 @@ pub fn file_descriptor() -> &'static ::protobuf::reflect::FileDescriptor {
     static file_descriptor: ::protobuf::rt::Lazy<::protobuf::reflect::FileDescriptor> = ::protobuf::rt::Lazy::new();
     file_descriptor.get(|| {
         let generated_file_descriptor = generated_file_descriptor_lazy.get(|| {
-            let mut deps = ::std::vec::Vec::with_capacity(0);
+            let mut deps = ::std::vec::Vec::with_capacity(1);
+            deps.push(super::validate::file_descriptor().clone());
             let mut messages = ::std::vec::Vec::with_capacity(2);
             messages.push(EchoRequest::generated_message_descriptor_data());
             messages.push(EchoResponse::generated_message_descriptor_data());

--- a/bd-grpc/src/proto/test.proto
+++ b/bd-grpc/src/proto/test.proto
@@ -1,9 +1,11 @@
 syntax = "proto3";
 
+import "validate/validate.proto";
+
 package test;
 
 message EchoRequest {
-  string echo = 1;
+  string echo = 1 [(validate.rules).string = {min_len: 1}];
 }
 message EchoResponse {
   string echo = 1;


### PR DESCRIPTION
Previously these errors were always returned as gRPC errors.

Fixes BIT-5344