### PR TITLE
Adding blocking_recv_with_timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "log",
+ "thiserror 2.0.12",
  "tokio",
 ]
 

--- a/bd-completion/Cargo.toml
+++ b/bd-completion/Cargo.toml
@@ -11,4 +11,5 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 log.workspace    = true
+thiserror.workspace = true
 tokio.workspace  = true

--- a/bd-completion/src/lib.rs
+++ b/bd-completion/src/lib.rs
@@ -6,6 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use std::fmt::Debug;
+use std::time::{Duration, Instant};
 
 //
 // Sender
@@ -41,6 +42,12 @@ pub struct Receiver<T: Debug> {
 }
 
 impl<T: Debug> Receiver<T> {
+  /// Create a [`bd_completion`] `Receiver<T>` from a raw `tokio::sync::oneshot::Receiver<T>`
+  #[must_use]
+  pub fn to_bd_completion_rx(rx: tokio::sync::oneshot::Receiver<T>) -> Self {
+    Self { rx }
+  }
+
   pub async fn recv(self) -> anyhow::Result<T> {
     match self.rx.await {
       Ok(value) => Ok(value),
@@ -51,4 +58,43 @@ impl<T: Debug> Receiver<T> {
   pub fn blocking_recv(self) -> anyhow::Result<T> {
     Ok(self.rx.blocking_recv()?)
   }
+
+  pub fn blocking_recv_with_timeout(mut self, timeout: Duration) -> Result<T, WaitError> {
+    let deadline = Instant::now() + timeout;
+
+    loop {
+      if Instant::now() > deadline {
+        return Err(WaitError::Timeout);
+      }
+
+      match self.rx.try_recv() {
+        Ok(value) => return Ok(value),
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+          return Err(WaitError::ChannelClosed)
+        },
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+          std::thread::sleep(Duration::from_millis(5));
+        },
+      }
+    }
+  }
 }
+
+#[derive(Debug)]
+pub enum WaitError {
+  Timeout,
+  ChannelClosed,
+}
+
+impl std::fmt::Display for WaitError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let message = match self {
+      Self::Timeout => "timeout duration reached",
+      Self::ChannelClosed => "the oneshot channel was closed",
+    };
+
+    write!(f, "{message}")
+  }
+}
+
+impl std::error::Error for WaitError {}


### PR DESCRIPTION
## What

Resolves BIT-4913

This follow similar approach from @snowp in https://github.com/bitdriftlabs/shared-core/pull/125 and moves the time out logic as part of bd_completion

To avoid potentially blocking permanently on no network situations upon logger blocking calls adding timeout to those calls

[See related doc](https://docs.google.com/document/d/1weR9GFGcvX-RLJd47KRMmhfg2ZknJc7mpUiCEaJvdM8/edit?tab=t.0)

## Verification

Steps

0. Run Android gradle test app
1. Set app in airplane mode
2. Trigger artificial crash
3. App will continue crashing after the defined thresholds (4seconds) to avoid ANRs on android. Before will be deadlocked an leading to ANR dialog

### Temporary logs with airplane mode 

See demo here https://drive.google.com/file/d/12ui3gyApvHdl37YGi4V6-36K-ZL41MQ0/view?usp=drive_link

```
06-17 15:46:10.449  9324  9324 D bd_logger::async_log_buffer: ANDROID_ANR: "enqueue_log entry"
06-17 15:46:10.449  9324  9324 D bd_logger::async_log_buffer: ANDROID_ANR: "about to call tokio::sync::oneshot::channel::<()>()"
06-17 15:46:11.454  9324  9324 D bd_logger::async_log_buffer: ANDROID_ANR: "enqueue_log: error waiting for completion: Timeout"
06-17 15:46:11.455  9324  9324 D bd_logger::async_log_buffer: ANDROID_ANR: "enqueue_log: OK report success 333"
06-17 15:46:11.455  9324  9324 D bd_logger::async_log_buffer: ANDROID_ANR: "flush_state: entering flush blocking portion"
06-17 15:46:11.455  9324  9324 D bd_logger::async_log_buffer: ANDROID_ANR: "flush_state: about to call blocking_recv_with_timeout. 386"
06-17 15:46:12.456  9324  9324 D bd_logger::async_log_buffer: ANDROID_ANR: "flush_state: error waiting for completion: Timeout"
06-17 15:46:12.456  9324  9324 D bd_logger::async_log_buffer: ANDROID_ANR: "flush_state: Success flush_state. 398"

```
###  Temporary logs with valid connection 

See demo here https://drive.google.com/file/d/13ViBmsQDUjLb59iIqZjb3thWFMDuzi1O/view?usp=drive_link

```
06-17 15:48:04.940  9603  9603 D bd_logger::async_log_buffer: ANDROID_ANR: "enqueue_log entry"
06-17 15:48:04.940  9603  9603 D bd_logger::async_log_buffer: ANDROID_ANR: "about to call tokio::sync::oneshot::channel::<()>()"
06-17 15:48:04.951  9603  9603 D bd_logger::async_log_buffer: ANDROID_ANR: "enqueue_log: OK within blocking_wait_with_timeout 305"
06-17 15:48:04.951  9603  9603 D bd_logger::async_log_buffer: ANDROID_ANR: "enqueue_log: OK report success 333"
06-17 15:48:04.951  9603  9603 D bd_logger::async_log_buffer: ANDROID_ANR: "flush_state: entering flush blocking portion"
06-17 15:48:04.951  9603  9603 D bd_logger::async_log_buffer: ANDROID_ANR: "flush_state: about to call blocking_recv_with_timeout. 386"
06-17 15:48:04.961  9603  9603 D bd_logger::async_log_buffer: ANDROID_ANR: "flush_state: completion received. 389"
06-17 15:48:04.961  9603  9603 D bd_logger::async_log_buffer: ANDROID_ANR: "flush_state: Success flush_state. 398"
```