### PR TITLE
rework session strategy stats

### DIFF
--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -15,7 +15,7 @@ use crate::log_replay::LoggerReplay;
 use crate::{app_version, MetadataProvider};
 use bd_api::Metadata;
 use bd_bounded_buffer::{self, Sender as MemoryBoundSender};
-use bd_client_stats_store::{Counter, Scope};
+use bd_client_stats_store::{Collector, Counter, Scope};
 use bd_log::warn_every;
 use bd_log_primitives::{
   log_level,
@@ -411,7 +411,7 @@ impl LoggerHandle {
 pub struct InitParams {
   pub sdk_directory: PathBuf,
   pub api_key: String,
-  pub session_strategy: Arc<bd_session::Strategy>,
+  pub session_strategy: bd_session::Strategy,
 
   pub store: Arc<bd_key_value::Store>,
 
@@ -428,6 +428,9 @@ pub struct InitParams {
 
   // Static metadata used to identify the client when communicating with the backend.
   pub static_metadata: Arc<dyn Metadata + Send + Sync>,
+
+  // The collector to be used for collecting client stats.
+  pub collector: Collector,
 
   // Whether the logger should start in sleep mode. It can then be transitioned using the provided
   // transition APIs.

--- a/bd-logger/src/logger_test.rs
+++ b/bd-logger/src/logger_test.rs
@@ -29,10 +29,10 @@ async fn thread_local_logger_guard() {
   let handle = LoggerHandle {
     tx,
     stats: Stats::new(&Collector::default().scope("")),
-    session_strategy: Arc::new(Strategy::new_fixed(
-      fixed::Strategy::new(store.clone(), Arc::new(UUIDCallbacks)),
-      &Collector::default().scope("session"),
-    )),
+    session_strategy: Arc::new(Strategy::new_fixed(fixed::Strategy::new(
+      store.clone(),
+      Arc::new(UUIDCallbacks),
+    ))),
     device: Arc::new(bd_device::Device::new(store.clone())),
     sdk_version: "1.0.0".into(),
     app_version_repo: Repository::new(store),

--- a/bd-logger/src/test/embedded_logger_integration.rs
+++ b/bd-logger/src/test/embedded_logger_integration.rs
@@ -70,9 +70,9 @@ impl Setup {
     let (logger, _, future, _) = crate::LoggerBuilder::new(InitParams {
       sdk_directory: sdk_directory.path().to_owned(),
       network: Box::new(handle),
-      session_strategy: Arc::new(Strategy::new_fixed(
-        fixed::Strategy::new(store.clone(), Arc::new(UUIDCallbacks)),
-        &Collector::default().scope("session"),
+      session_strategy: Strategy::new_fixed(fixed::Strategy::new(
+        store.clone(),
+        Arc::new(UUIDCallbacks),
       )),
       metadata_provider: Arc::new(TestMetadataProvider),
       store,
@@ -80,6 +80,7 @@ impl Setup {
       session_replay_target: Box::new(bd_test_helpers::session_replay::NoOpTarget),
       events_listener_target: Box::new(bd_test_helpers::events::NoOpListenerTarget),
       device,
+      collector: Collector::default(),
       static_metadata: Arc::new(EmptyMetadata),
       api_key: "apikey".to_string(),
       start_in_sleep_mode: false,

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -1968,9 +1968,9 @@ fn runtime_caching() {
     let logger = crate::LoggerBuilder::new(InitParams {
       api_key: "foo-api-key".to_string(),
       network,
-      session_strategy: Arc::new(Strategy::new_fixed(
-        fixed::Strategy::new(store.clone(), Arc::new(UUIDCallbacks)),
-        &Collector::default().scope("session"),
+      session_strategy: Strategy::new_fixed(fixed::Strategy::new(
+        store.clone(),
+        Arc::new(UUIDCallbacks),
       )),
       static_metadata: Arc::new(EmptyMetadata),
       store,
@@ -1979,6 +1979,7 @@ fn runtime_caching() {
       events_listener_target: Box::new(bd_test_helpers::events::NoOpListenerTarget),
       sdk_directory: sdk_directory.path().into(),
       metadata_provider: Arc::new(LogMetadata::default()),
+      collector: Collector::default(),
       device,
       start_in_sleep_mode: false,
     })

--- a/bd-logger/src/test/setup.rs
+++ b/bd-logger/src/test/setup.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use bd_client_stats::test::TestTicker;
 use bd_client_stats::FlushTrigger;
+use bd_client_stats_store::Collector;
 use bd_device::Store;
 use bd_proto::protos::client::api::configuration_update::StateOfTheWorld;
 use bd_proto::protos::client::api::configuration_update_ack::Nack;
@@ -155,9 +156,9 @@ impl Setup {
     let (logger, _, flush_trigger) = crate::LoggerBuilder::new(InitParams {
       sdk_directory: options.sdk_directory.path().into(),
       api_key: "foo-api-key".to_string(),
-      session_strategy: Arc::new(Strategy::new_fixed(
-        fixed::Strategy::new(store.clone(), Arc::new(UUIDCallbacks)),
-        &bd_client_stats_store::Collector::default().scope("session"),
+      session_strategy: Strategy::new_fixed(fixed::Strategy::new(
+        store.clone(),
+        Arc::new(UUIDCallbacks),
       )),
       metadata_provider: options.metadata_provider,
       resource_utilization_target: Box::new(EmptyTarget),
@@ -165,6 +166,7 @@ impl Setup {
       events_listener_target: Box::new(bd_test_helpers::events::NoOpListenerTarget),
       device,
       store: store.clone(),
+      collector: Collector::default(),
       network: Box::new(Self::run_network(server.port, shutdown.make_shutdown())),
       static_metadata: Arc::new(EmptyMetadata),
       start_in_sleep_mode: options.start_in_sleep_mode,

--- a/bd-session/src/activity_based_test.rs
+++ b/bd-session/src/activity_based_test.rs
@@ -414,7 +414,9 @@ fn new_session_metric() {
   );
 
   let collector = Collector::default();
-  let strategy = crate::Strategy::new_activity_based(strategy, &collector.scope("session"));
+  let mut strategy = crate::Strategy::new_activity_based(strategy);
+  strategy.initialize_stats(&collector);
+
 
   // This should create the first session.
   strategy.session_id();

--- a/bd-session/src/fixed_test.rs
+++ b/bd-session/src/fixed_test.rs
@@ -184,7 +184,8 @@ fn new_session_metric() {
   let callbacks = Arc::new(MockCallbacks::default());
   let strategy = fixed::Strategy::new(store, callbacks.clone());
 
-  let strategy = crate::Strategy::new_fixed(strategy, &collector.scope("session"));
+  let mut strategy = crate::Strategy::new_fixed(strategy);
+  strategy.initialize_stats(&collector);
 
   // This should create the session ID for the first time.
   strategy.session_id();


### PR DESCRIPTION
Turns out the LoggerBuilder interface means that we don't have access to the Collector until after build() is called, but the SessionStrategy handle is created before then.

Change up the way stats are propagated by adding delayed initialization that can be called on the session strategy within the Logger build step after the Collector has been created