### PR TITLE
workflows: cleanup 2 runtime flags

### DIFF
--- a/bd-runtime/src/runtime.rs
+++ b/bd-runtime/src/runtime.rs
@@ -789,20 +789,6 @@ pub mod workflows {
     "workflows.persistence_write_interval_ms",
     1.seconds()
   );
-
-  // The maximum number of workflow traversals that may be active.
-  int_feature_flag!(
-    TraversalsCountLimitFlag,
-    "workflows.traversals_global_count_limit",
-    200
-  );
-
-  // The interval at which workflows state persistence attempts to disk are made.
-  duration_feature_flag!(
-    StatePeriodicWriteIntervalFlag,
-    "workflows.state_periodic_write_interval_ms",
-    5.seconds()
-  );
 }
 
 pub mod platform_events {

--- a/bd-workflows/src/engine_test.rs
+++ b/bd-workflows/src/engine_test.rs
@@ -25,9 +25,8 @@ use bd_proto::protos::client::api::{
   SankeyPathUploadRequest,
   log_upload_intent_request,
 };
-use bd_runtime::runtime::{ConfigLoader, FeatureFlag};
+use bd_runtime::runtime::ConfigLoader;
 use bd_stats_common::labels;
-use bd_test_helpers::runtime::{ValueKind, make_simple_update};
 use bd_test_helpers::workflow::macros::{
   action,
   any,
@@ -59,7 +58,6 @@ use time::ext::NumericalDuration;
 use time::macros::datetime;
 use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
-use tokio::time::timeout;
 
 /// A macro that creates a workflow config using provided states.
 /// See `workflow_proto` macro for more details.
@@ -275,8 +273,8 @@ impl AnnotatedWorkflowsEngine {
     }
   }
 
-  async fn run_once_for_test(&mut self, persist_periodically: bool) {
-    self.engine.run_once(persist_periodically).await;
+  async fn run_once_for_test(&mut self) {
+    self.engine.run_once().await;
     // Give the task started inside of `run_for_test()` method chance to run before proceeding.
     1.milliseconds().sleep().await;
   }
@@ -541,42 +539,6 @@ async fn engine_initialization_and_update() {
     "workflows:workflows_total",
     labels! {"operation" => "stop"},
   );
-  setup
-    .collector
-    .assert_counter_eq(0, "workflows:runs_total", labels! {"operation" => "start"});
-  setup.collector.assert_counter_eq(
-    0,
-    "workflows:runs_total",
-    labels! {"operation" => "advance"},
-  );
-  setup.collector.assert_counter_eq(
-    0,
-    "workflows:runs_total",
-    labels! {"operation" => "completion"},
-  );
-  setup
-    .collector
-    .assert_counter_eq(0, "workflows:runs_total", labels! {"operation" => "stop"});
-  setup.collector.assert_counter_eq(
-    0,
-    "workflows:traversals_total",
-    labels! {"operation" => "start"},
-  );
-  setup.collector.assert_counter_eq(
-    0,
-    "workflows:traversals_total",
-    labels! {"operation" => "advance"},
-  );
-  setup.collector.assert_counter_eq(
-    0,
-    "workflows:traversals_total",
-    labels! {"operation" => "completion"},
-  );
-  setup.collector.assert_counter_eq(
-    0,
-    "workflows:traversals_total",
-    labels! {"operation" => "stop"},
-  );
 }
 
 #[tokio::test]
@@ -820,16 +782,6 @@ async fn persistence_skipped_if_workflow_stays_in_an_initial_state() {
   setup
     .collector
     .assert_counter_eq(1, "workflows:matched_logs_total", labels! {});
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:runs_total",
-    labels! { "operation" => "advance" },
-  );
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:runs_total",
-    labels! { "operation" => "completion" },
-  );
   assert!(!workflows_engine.needs_state_persistence);
 }
 
@@ -867,16 +819,6 @@ async fn persist_workflows_with_at_least_one_non_initial_state_run_only() {
   setup
     .collector
     .assert_counter_eq(1, "workflows:matched_logs_total", labels! {});
-  setup.collector.assert_counter_eq(
-    0,
-    "workflows:runs_total",
-    labels! { "operation" => "advance" },
-  );
-  setup.collector.assert_counter_eq(
-    0,
-    "workflows:runs_total",
-    labels! { "operation" => "completion" },
-  );
   assert!(workflows_engine.needs_state_persistence);
   workflows_engine.maybe_persist(false).await;
 
@@ -917,11 +859,6 @@ async fn needs_persistence_if_workflow_moves_to_an_initial_state() {
   setup
     .collector
     .assert_counter_eq(1, "workflows:matched_logs_total", labels! {});
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:runs_total",
-    labels! { "operation" => "advance" },
-  );
   assert!(workflows_engine.needs_state_persistence);
 
   // Persist state
@@ -932,11 +869,6 @@ async fn needs_persistence_if_workflow_moves_to_an_initial_state() {
   engine_process_log!(workflows_engine; "bar");
   // Workflow needs persistence as its state changed.
   assert!(workflows_engine.needs_state_persistence);
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:runs_total",
-    labels! { "operation" => "completion" },
-  );
 }
 
 #[tokio::test]
@@ -1036,208 +968,6 @@ async fn persistence_performed_if_match_is_found_without_advancing() {
     setup.workflows_state_path().exists(),
     "Workflows State Snapshot file should have been created"
   );
-}
-
-#[tokio::test]
-async fn traversals_count_limit_prevents_creation_of_new_workflows() {
-  let mut a = state("A");
-  let b = state("B");
-
-  declare_transition!(
-    &mut a => &b;
-    when rule!(log_matches!(message == "foo"); times 100)
-  );
-
-  let workflows = vec![
-    workflow!("1"; exclusive with a, b),
-    workflow!("2"; exclusive with a, b),
-    workflow!("3"; exclusive with a, b),
-    workflow!("4"; exclusive with a, b),
-  ];
-
-  let setup = Setup::new();
-  setup
-    .runtime
-    .update_snapshot(&make_simple_update(vec![(
-      bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
-      ValueKind::Int(2),
-    )]))
-    .await;
-
-  // We try to create 4 workflows (each with 1 run that has 1 traversal) but
-  // the configured traversals count limit is 2. For this reason, we succeed
-  // hit the traversals limit twice.
-  let mut workflows_engine = setup
-    .make_workflows_engine(WorkflowsEngineConfig::new_with_workflow_configurations(
-      workflows,
-    ))
-    .await;
-
-  // All workflows are added to the engine but some of them have no runs
-  // to keep the engine below the configured traversals count limit.
-  assert_eq!(4, workflows_engine.state.workflows.len());
-  assert!(workflows_engine.state.workflows[2].runs().is_empty());
-  assert!(workflows_engine.state.workflows[3].runs().is_empty());
-
-  // Process a log to force the engine to create initial runs for all workflows.
-  engine_process_log!(workflows_engine; "foo");
-
-  setup
-    .collector
-    .assert_counter_eq(2, "workflows:traversals_count_limit_hit_total", labels! {});
-  setup.collector.assert_counter_eq(
-    4,
-    "workflows:workflows_total",
-    labels! {"operation" => "start"},
-  );
-
-  let workflows = vec![
-    workflow!("11"; exclusive with a, b),
-    workflow!("22"; exclusive with a, b),
-    workflow!("33"; exclusive with a, b),
-  ];
-
-  // We replace 2 of the existing workflows (each with 1 run that has 1 traversal)
-  // with 3 new ones (each with 1 run that has 1 traversal -> we process a log to force
-  // the engine to create initial state runs).
-  // We start with 2 traversals, substract 2 and try to add 3. Addition of the third one
-  // fails as we hit traversals count limit.
-  workflows_engine.update(WorkflowsEngineConfig::new_with_workflow_configurations(
-    workflows,
-  ));
-  engine_process_log!(workflows_engine; "foo");
-
-  // All workflows are added to the engine but some of them have no runs
-  // to keep the engine below the configured traversals count limit.
-  assert_eq!(3, workflows_engine.state.workflows.len());
-  assert!(workflows_engine.state.workflows[2].runs().is_empty());
-
-  setup
-    .collector
-    .assert_counter_eq(3, "workflows:traversals_count_limit_hit_total", labels! {});
-  setup.collector.assert_counter_eq(
-    7,
-    "workflows:workflows_total",
-    labels! {"operation" => "start"},
-  );
-}
-
-#[tokio::test]
-async fn traversals_count_limit_prevents_creation_of_new_workflow_runs() {
-  let mut a = state("A");
-  let b = state("B");
-
-  declare_transition!(
-    &mut a => &b;
-    when rule!(log_matches!(message == "foo"); times 100)
-  );
-
-  let workflows = vec![workflow!(exclusive with a, b)];
-
-  let setup = Setup::new();
-  setup
-    .runtime
-    .update_snapshot(&make_simple_update(vec![(
-      bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
-      ValueKind::Int(2),
-    )]))
-    .await;
-
-  let mut workflows_engine = setup
-    .make_workflows_engine(WorkflowsEngineConfig::new_with_workflow_configurations(
-      workflows,
-    ))
-    .await;
-
-  // In exclusive mode we will only ever have 1 run with a single traversal attempting to hit the
-  // total count.
-  engine_process_log!(workflows_engine; "foo");
-  engine_process_log!(workflows_engine; "foo");
-  engine_process_log!(workflows_engine; "foo");
-  engine_process_log!(workflows_engine; "foo");
-  engine_process_log!(workflows_engine; "foo");
-
-  setup
-    .collector
-    .assert_counter_eq(0, "workflows:traversals_count_limit_hit_total", labels! {});
-}
-
-#[tokio::test]
-#[allow(clippy::many_single_char_names)]
-async fn traversals_count_limit_causes_run_removal_after_forking() {
-  let mut a = state("A");
-  let mut b = state("B");
-  let mut c = state("C");
-  let mut d = state("D");
-  let e = state("E");
-  let f = state("F");
-
-  declare_transition!(
-    &mut a => &b;
-    when rule!(log_matches!(message == "foo"))
-  );
-  declare_transition!(
-    &mut b => &c;
-    when rule!(log_matches!(message == "bar"))
-  );
-  declare_transition!(
-    &mut b => &d;
-    when rule!(log_matches!(message == "bar"))
-  );
-  declare_transition!(
-    &mut c => &e;
-    when rule!(log_matches!(message == "zar"))
-  );
-  declare_transition!(
-    &mut d => &f;
-    when rule!(log_matches!(message == "zar"))
-  );
-
-  let workflows = vec![workflow!(exclusive with a, b, c, d, e, f)];
-
-  let setup = Setup::new();
-
-  setup
-    .runtime
-    .update_snapshot(&make_simple_update(vec![(
-      bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
-      ValueKind::Int(2),
-    )]))
-    .await;
-
-  let mut workflows_engine = setup
-    .make_workflows_engine(WorkflowsEngineConfig::new_with_workflow_configurations(
-      workflows,
-    ))
-    .await;
-  assert!(workflows_engine.state.workflows[0].runs().is_empty());
-
-  // * A new run is created as workflows has no runs in an initial state.
-  // * The existing run "A" matches "foo" and moves to B.
-  // * Workflow has 2 traversals total (one run "B" trasversal and one run "A" traversal).
-  engine_process_log!(workflows_engine; "foo");
-  engine_assert_active_runs!(workflows_engine; 0; "B");
-
-  // * A second run is created so that a workflow has a run in an initial state.
-  // * Two outgoing transitions of the run "B" traversal match log "bar".
-  // * We have 2 traversals and attempt to create 2 more which gives us 4 traversals total.
-  // * We hit the configured limit of traversals (2).
-  // * In order to stay below the limit we remove the run that caused us to hit the limit.
-  // * We are left with run "A".
-  engine_process_log!(workflows_engine; "bar");
-  engine_assert_active_run_traversals!(workflows_engine; 0 => 0; "A");
-
-  setup
-    .collector
-    .assert_counter_eq(1, "workflows:runs_total", labels! {"operation" => "stop"});
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:traversals_total",
-    labels! {"operation" => "stop"},
-  );
-  setup
-    .collector
-    .assert_counter_eq(1, "workflows:traversals_count_limit_hit_total", labels! {});
 }
 
 #[tokio::test(start_paused = true)]
@@ -1378,11 +1108,6 @@ async fn runs_in_initial_state_are_not_persisted() {
   // * Workflow #2: No runs exists as no runs were stored on disk.
   engine_assert_active_runs!(workflows_engine; 0; "A");
   assert!(workflows_engine.state.workflows[1].runs().is_empty());
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:runs_total",
-    labels! { "operation" => "start" },
-  );
 
   engine_process_log!(workflows_engine; "bar");
   // * Workflow #1: A new run in an initial state is created as workflow has a parallel execution
@@ -1390,11 +1115,6 @@ async fn runs_in_initial_state_are_not_persisted() {
   // * Workflow #2: A new run in an initial state is created as workflow had not runs.
   engine_assert_active_runs!(workflows_engine; 0; "A", "A");
   engine_assert_active_runs!(workflows_engine; 1; "B");
-  setup.collector.assert_counter_eq(
-    3,
-    "workflows:runs_total",
-    labels! { "operation" => "start" },
-  );
 }
 
 #[tokio::test]
@@ -1600,58 +1320,6 @@ async fn ignore_persisted_state_if_invalid_dir() {
 }
 
 #[tokio::test]
-async fn persists_state_on_periodic_basis() {
-  let mut a = state("A");
-  let mut b = state("B");
-  let c = state("C");
-
-  declare_transition!(
-    &mut a => &b;
-    when rule!(log_matches!(message == "foo"); times 100)
-  );
-  declare_transition!(
-    &mut b => &c;
-    when rule!(log_matches!(message == "bar"))
-  );
-
-  let workflows = vec![workflow!(exclusive with a, b, c)];
-
-  let setup = Setup::new();
-
-  // Speed up periodic persistance so that the test can complete in a shorter
-  // amount of time.
-  setup
-    .runtime
-    .update_snapshot(&make_simple_update(vec![(
-      bd_runtime::runtime::workflows::StatePeriodicWriteIntervalFlag::path(),
-      ValueKind::Int(10),
-    )]))
-    .await;
-
-  // Engine creation should still succeed but with a default state
-  let mut workflows_engine = setup
-    .make_workflows_engine(WorkflowsEngineConfig::new_with_workflow_configurations(
-      workflows,
-    ))
-    .await;
-
-  engine_process_log!(workflows_engine; "foo");
-  // Log made the state dirty.
-  assert!(workflows_engine.needs_state_persistence);
-  // One of run loop's responsibilities is periodic persistance of state.
-  // Given enough time it should persist the state to disk and mark
-  // state as being "clean".
-  _ = timeout(Duration::from_millis(100), workflows_engine.run()).await;
-  assert!(!workflows_engine.needs_state_persistence);
-
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:state_persistences_total",
-    labels! {"result" => "success"},
-  );
-}
-
-#[tokio::test]
 async fn engine_processing_log() {
   let mut a = state("A");
   let b = state("B");
@@ -1717,54 +1385,10 @@ async fn engine_processing_log() {
   );
   setup
     .collector
-    .assert_counter_eq(2, "workflows:runs_total", labels! {"operation" => "start"});
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:runs_total",
-    labels! {"operation" => "advance"},
-  );
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:runs_total",
-    labels! {"operation" => "completion"},
-  );
-  setup
-    .collector
-    .assert_counter_eq(0, "workflows:runs_total", labels! {"operation" => "stop"});
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:traversals_total",
-    labels! {"operation" => "start"},
-  );
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:traversals_total",
-    labels! {"operation" => "advance"},
-  );
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:traversals_total",
-    labels! {"operation" => "completion"},
-  );
-  setup.collector.assert_counter_eq(
-    0,
-    "workflows:traversals_total",
-    labels! {"operation" => "stop"},
-  );
-  setup
-    .collector
     .assert_counter_eq(2, "workflows:matched_logs_total", labels! {});
 
   // Two new runs are created to ensure that each workflow has one run in an initial state.
   engine_process_log!(workflows_engine; "not matching");
-  setup
-    .collector
-    .assert_counter_eq(4, "workflows:runs_total", labels! {"operation" => "start"});
-  setup.collector.assert_counter_eq(
-    4,
-    "workflows:traversals_total",
-    labels! {"operation" => "start"},
-  );
 }
 
 #[tokio::test]
@@ -1801,20 +1425,10 @@ async fn exclusive_workflow_duration_limit() {
   // * The newly created run doesn't match a log.
   engine_process_log!(workflows_engine; "bar"; with labels!{}; time now);
   engine_assert_active_runs!(workflows_engine; 0; "A");
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:runs_total",
-    labels! { "operation" => "start" },
-  );
 
   // * The run matches a log and advances. It leaves its initial state.
   engine_process_log!(workflows_engine; "foo"; with labels!{}; time now + Duration::from_secs(2));
   engine_assert_active_runs!(workflows_engine; 0; "B");
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:runs_total",
-    labels! { "operation" => "advance" },
-  );
 
   // * A run in an initial state is created and added to the beginning of runs list.
   // * The run is not an initial state and has exceeded the maximum duration.
@@ -1822,24 +1436,11 @@ async fn exclusive_workflow_duration_limit() {
   engine_process_log!(workflows_engine; "not matching"; with labels!{}; time now + Duration::from_secs(4));
   assert_eq!(workflows_engine.state.workflows[0].runs().len(), 1);
   engine_assert_active_runs!(workflows_engine; 0; "A");
-  setup
-    .collector
-    .assert_counter_eq(1, "workflows:runs_total", labels! { "operation" => "stop" });
 
   // * A new run in an initial state is created.
   // * The new run matches a log and advances.
   engine_process_log!(workflows_engine; "foo"; with labels!{}; time now + Duration::from_secs(4));
   engine_assert_active_runs!(workflows_engine; 0; "B");
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:runs_total",
-    labels! { "operation" => "start" },
-  );
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:runs_total",
-    labels! { "operation" => "advance" },
-  );
 }
 
 #[tokio::test]
@@ -1989,7 +1590,7 @@ async fn logs_streaming() {
 
   // Allow the engine to perform logs upload intent and process the response to it (upload
   // immediately).
-  workflows_engine.run_once_for_test(false).await;
+  workflows_engine.run_once_for_test().await;
 
   assert_eq!(
     vec![log_upload_intent_request::WorkflowActionUpload {
@@ -2020,7 +1621,7 @@ async fn logs_streaming() {
 
   // Allow the engine to perform logs upload intent and process the response to it (upload
   // immediately).
-  workflows_engine.run_once_for_test(false).await;
+  workflows_engine.run_once_for_test().await;
 
   assert_eq!(
     vec![
@@ -2061,7 +1662,7 @@ async fn logs_streaming() {
 
   // Allow the engine to perform logs upload intent and process the response to it (upload
   // immediately).
-  workflows_engine.run_once_for_test(false).await;
+  workflows_engine.run_once_for_test().await;
 
   assert_eq!(
     vec![
@@ -2164,7 +1765,7 @@ async fn logs_streaming() {
 
   // Allow the engine to perform logs upload intent and process the response to it (upload
   // immediately).
-  workflows_engine.run_once_for_test(false).await;
+  workflows_engine.run_once_for_test().await;
 
   assert_eq!(
     vec![
@@ -2198,7 +1799,7 @@ async fn logs_streaming() {
 
   // Allow the engine to perform logs upload intent and process the response to it (upload
   // immediately).
-  workflows_engine.run_once_for_test(false).await;
+  workflows_engine.run_once_for_test().await;
 
   assert_eq!(
     vec![
@@ -2379,7 +1980,7 @@ async fn engine_does_not_purge_pending_actions_on_session_id_change() {
   workflows_engine
     .set_awaiting_logs_upload_intent_decisions(vec![IntentDecision::UploadImmediately]);
 
-  workflows_engine.run_once_for_test(false).await;
+  workflows_engine.run_once_for_test().await;
 
   assert_eq!(
     vec![log_upload_intent_request::WorkflowActionUpload {
@@ -2462,7 +2063,7 @@ async fn engine_continues_to_stream_upload_not_complete() {
   );
 
   log::info!("Running the engine for the first time.");
-  workflows_engine.run_once_for_test(false).await;
+  workflows_engine.run_once_for_test().await;
   log::info!("after Running the engine for the first time.");
 
   assert_eq!(
@@ -2548,13 +2149,6 @@ async fn creating_new_runs_after_first_log_processing() {
   );
 
   let setup = Setup::new();
-  setup
-    .runtime
-    .update_snapshot(&make_simple_update(vec![(
-      bd_runtime::runtime::workflows::TraversalsCountLimitFlag::path(),
-      ValueKind::Int(3),
-    )]))
-    .await;
 
   // This test assumes that internally `workflows_engine` iterates
   // over the list of its workflows in order.
@@ -2572,22 +2166,11 @@ async fn creating_new_runs_after_first_log_processing() {
   engine_process_log!(workflows_engine; "bar");
   engine_assert_active_runs!(workflows_engine; 0; "D");
   engine_assert_active_runs!(workflows_engine; 1; "A");
-  setup
-    .collector
-    .assert_counter_eq(2, "workflows:runs_total", labels! {"operation" => "start"});
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:runs_total",
-    labels! {"operation" => "advance"},
-  );
 
   // * State "A" matches log but does not advance as its transition requires 100 matches.
   engine_process_log!(workflows_engine; "foo");
   engine_assert_active_runs!(workflows_engine; 0; "C", "D");
   engine_assert_active_runs!(workflows_engine; 1; "A");
-  setup
-    .collector
-    .assert_counter_eq(0, "workflows:traversals_count_limit_hit_total", labels! {});
 
   // * States "D" (workflow #1) and "A" (workflow #2) match a log with (key => value) tag.
   // * State "D" advances to a final state "E" and the run is completed. The number of traversals
@@ -2600,18 +2183,12 @@ async fn creating_new_runs_after_first_log_processing() {
   engine_process_log!(workflows_engine; "not matching message"; with labels! { "key" => "value" });
   engine_assert_active_runs!(workflows_engine; 0; "C");
   engine_assert_active_runs!(workflows_engine; 1; "A", "A");
-  setup
-    .collector
-    .assert_counter_eq(0, "workflows:traversals_count_limit_hit_total", labels! {});
 
   // In exclusive mode we will not make any new runs because both workflows have runs in the
   // initial state. With no matches and no traversals we stay under the limit.
   engine_process_log!(workflows_engine; "not matching message");
   engine_assert_active_runs!(workflows_engine; 0; "C");
   engine_assert_active_runs!(workflows_engine; 1; "A", "A");
-  setup
-    .collector
-    .assert_counter_eq(0, "workflows:traversals_count_limit_hit_total", labels! {});
 }
 
 #[tokio::test]
@@ -2638,8 +2215,6 @@ async fn workflows_state_is_purged_when_session_id_changes() {
 
   // Session ID is empty on first engine initialization.
   assert!(workflows_engine.state.session_id.is_empty());
-  // No traversals as no log has been processed yet.
-  assert_eq!(0, workflows_engine.current_traversals_count);
 
   workflows_engine.process_log(
     &LogRef {
@@ -2671,8 +2246,6 @@ async fn workflows_state_is_purged_when_session_id_changes() {
   assert_eq!("foo_session", workflows_engine.state.session_id);
   // Read saved workflow state from disk.
   engine_assert_active_runs!(workflows_engine; 0; "A");
-  // One traversal trad from disk.
-  assert_eq!(1, workflows_engine.current_traversals_count);
 
   // Process a log with a new session ID.
   workflows_engine.process_log(
@@ -2693,7 +2266,6 @@ async fn workflows_state_is_purged_when_session_id_changes() {
 
   // Session ID changed.
   assert_eq!("bar_session", workflows_engine.state.session_id);
-  assert_eq!(1, workflows_engine.current_traversals_count);
 
   assert!(workflows_engine.needs_state_persistence);
   workflows_engine.maybe_persist(false).await;
@@ -2763,93 +2335,77 @@ async fn test_traversals_count_tracking() {
   engine_process_log!(engine; "foo");
   assert_eq!(1, engine.state.workflows[0].runs().len());
   engine_assert_active_runs!(engine; 0; "B");
-  assert_eq!(1, engine.current_traversals_count);
 
   // Log is matched and workflow moves to state "B".
   engine_process_log!(engine; "foo");
   assert_eq!(1, engine.state.workflows[0].runs().len());
   engine_assert_active_runs!(engine; 0; "B");
-  assert_eq!(1, engine.current_traversals_count);
 
   // * A new initial state run is created and added to the beginning of runs list.
   // * Log is matched and workflow moves to state "C".
   engine_process_log!(engine; "bar");
   assert_eq!(2, engine.state.workflows[0].runs().len());
   engine_assert_active_runs!(engine; 0; "A", "C");
-  assert_eq!(2, engine.current_traversals_count);
 
   // Log is not matched.
   engine_process_log!(engine; "dar");
   assert_eq!(2, engine.state.workflows[0].runs().len());
   engine_assert_active_runs!(engine; 0; "A", "C");
-  assert_eq!(2, engine.current_traversals_count);
 
   // Log is matched and workflow is reset to its initial state.
   engine_process_log!(engine; "foo");
   assert_eq!(1, engine.state.workflows[0].runs().len());
   engine_assert_active_runs!(engine; 0; "B");
-  assert_eq!(1, engine.current_traversals_count);
 
   // * A new initial state run is created and added to the beginning of runs list.
   // * Log is matched by the run that's not in an initial state and the run advances to state `C`.
   engine_process_log!(engine; "bar");
   assert_eq!(2, engine.state.workflows[0].runs().len());
   engine_assert_active_runs!(engine; 0; "A", "C");
-  assert_eq!(2, engine.current_traversals_count);
 
   // Log is matched and the more advanced run moves to final state "D" and completes.
   engine_process_log!(engine; "car");
   engine_assert_active_runs!(engine; 0; "A");
-  assert_eq!(1, engine.current_traversals_count);
 
   // Log is not matched.
   engine_process_log!(engine; "foo");
   assert_eq!(1, engine.state.workflows[0].runs().len());
   engine_assert_active_runs!(engine; 0; "B");
-  assert_eq!(1, engine.current_traversals_count);
 
   // Log is matched and workflow moves to state "B".
   engine_process_log!(engine; "foo");
   assert_eq!(1, engine.state.workflows[0].runs().len());
   engine_assert_active_runs!(engine; 0; "B");
-  assert_eq!(1, engine.current_traversals_count);
 
   // * A new initial state run is created and added to the beginning of runs list.
   // * Log is matched and workflow moves to "E" state.
   engine_process_log!(engine; "dar");
   assert_eq!(2, engine.state.workflows[0].runs().len());
   engine_assert_active_runs!(engine; 0; "A", "E");
-  assert_eq!(2, engine.current_traversals_count);
 
   // Log is matched and workflow moves to final state "F" and completes.
   engine_process_log!(engine; "far");
   engine_assert_active_runs!(engine; 0; "A");
-  assert_eq!(1, engine.current_traversals_count);
 
   // Log is not matched.
   engine_process_log!(engine; "no match");
   engine_assert_active_runs!(engine; 0; "A");
-  assert_eq!(1, engine.current_traversals_count);
 
   // Checks that the traversal count does not change if we get update
   // with the same workflow.
   engine.update(engine_config.clone());
-  assert_eq!(1, engine.current_traversals_count);
 
   // Check that traversals count goes to 0 if empty update happens.
   engine.update(WorkflowsEngineConfig::new_with_workflow_configurations(
     vec![],
   ));
-  assert_eq!(0, engine.current_traversals_count);
 
   // Check that traversals stay at since no log has been processed yet.
   engine.update(engine_config);
-  assert_eq!(0, engine.current_traversals_count);
 
   // A traversal is created to process an incoming log that's not matched.
   engine_process_log!(engine; "no match");
   engine_assert_active_runs!(engine; 0; "A");
-  assert_eq!(1, engine.current_traversals_count);
 }
 
 #[tokio::test]
@@ -2886,19 +2442,6 @@ async fn test_exclusive_workflow_state_reset() {
   // state `B`.
   engine_process_log!(engine; "foo");
   engine_assert_active_runs!(engine; 0; "B");
-  setup
-    .collector
-    .assert_counter_eq(0, "workflows:workflow_resets_total", labels! {});
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:runs_total",
-    labels! { "operation" => "start" },
-  );
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:traversals_total",
-    labels! { "operation" => "start" },
-  );
 
   // * A new initial state run is created and added to the beginning of runs list so that the
   //   workflow has a run that's in an initial state.
@@ -2906,63 +2449,16 @@ async fn test_exclusive_workflow_state_reset() {
   //   state `C`.
   engine_process_log!(engine; "bar");
   engine_assert_active_runs!(engine; 0; "A", "C");
-  setup
-    .collector
-    .assert_counter_eq(0, "workflows:workflow_resets_total", labels! {});
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:runs_total",
-    labels! { "operation" => "start" },
-  );
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:traversals_total",
-    labels! { "operation" => "start" },
-  );
 
   // The log is not matched by any of the runs.
   engine_process_log!(engine; "not matching");
   engine_assert_active_runs!(engine; 0;  "A", "C");
-  setup
-    .collector
-    .assert_counter_eq(0, "workflows:workflow_resets_total", labels! {});
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:runs_total",
-    labels! { "operation" => "start" },
-  );
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:traversals_total",
-    labels! { "operation" => "start" },
-  );
 
   // * The log is not matched by the run that's not in an initial state.
   // * The log is matched by the run that's in an initial state. That causes the state advancement
   //   of the run and the removal of the other run.
   engine_process_log!(engine; "foo");
   engine_assert_active_runs!(engine; 0; "B");
-  setup
-    .collector
-    .assert_counter_eq(1, "workflows:workflow_resets_total", labels! {});
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:runs_total",
-    labels! { "operation" => "start" },
-  );
-  setup
-    .collector
-    .assert_counter_eq(1, "workflows:runs_total", labels! { "operation" => "stop" });
-  setup.collector.assert_counter_eq(
-    2,
-    "workflows:traversals_total",
-    labels! { "operation" => "start" },
-  );
-  setup.collector.assert_counter_eq(
-    1,
-    "workflows:traversals_total",
-    labels! { "operation" => "stop" },
-  );
 }
 
 #[tokio::test]

--- a/bd-workflows/src/workflow.rs
+++ b/bd-workflows/src/workflow.rs
@@ -100,9 +100,6 @@ impl Workflow {
       let run_result_did_make_progress = run_result.did_make_progress();
 
       match run_result.state {
-        // If after processing a given log by a workflow run we notice that we end up
-        // over the limit of allowed traversals we remove the `run` which caused the
-        // overflow.
         RunState::Stopped => {
           self.runs.remove(index);
         },

--- a/bd-workflows/src/workflow.rs
+++ b/bd-workflows/src/workflow.rs
@@ -79,21 +79,13 @@ impl Workflow {
     &mut self,
     config: &'a Config,
     log: &LogRef<'_>,
-    current_traversals_count: &mut u32,
-    traversals_count_limit: u32,
   ) -> WorkflowResult<'a> {
     let mut result = WorkflowResult::default();
 
     if self.needs_new_run() {
       let run = Run::new(config);
-      if self.maybe_add_run(
-        run,
-        current_traversals_count,
-        traversals_count_limit,
-        &mut result,
-      ) {
-        log::trace!("added a new run for workflow {}", self.id);
-      }
+      self.add_run(run);
+      log::trace!("added a new run for workflow {}", self.id);
     }
 
     let mut did_make_progress = false;
@@ -105,43 +97,16 @@ impl Workflow {
 
       result.incorporate_run_result(&mut run_result);
 
-      *current_traversals_count += run_result.created_traversals_count;
-      // TODO(Augustyniak): a 'standard' subtracting operation should be sufficient here for
-      // production code but it's no enough for tests due to the way they track
-      // `current_traversals_count` (in tests, the processing of any given always starts with
-      // `current_traversals_count == 0` even if it was != 0 as the result of processing
-      // previous logs). Rework tests to make it possible to replace `saturating_sub` with `-`
-      // operator in here.
-      *current_traversals_count =
-        current_traversals_count.saturating_sub(run_result.completed_traversals_count);
-
-      let is_over_traversals_count_limit = *current_traversals_count > traversals_count_limit;
       let run_result_did_make_progress = run_result.did_make_progress();
 
-      match (run_result.state, is_over_traversals_count_limit) {
+      match run_result.state {
         // If after processing a given log by a workflow run we notice that we end up
         // over the limit of allowed traversals we remove the `run` which caused the
         // overflow.
-        (RunState::Stopped, _) | (_, true) => {
-          result.stats.stopped_runs_count += 1;
-
-          if is_over_traversals_count_limit {
-            result.stats.traversals_count_limit_hit_count += 1;
-            log::debug!(
-              "traversals count ({}) is over the limit ({}); stopping run",
-              *current_traversals_count,
-              traversals_count_limit
-            );
-          }
-
-          let stopped_traversals_count = run.traversals_count();
-          result.stats.stopped_traversals_count += stopped_traversals_count;
-          *current_traversals_count =
-            current_traversals_count.saturating_sub(stopped_traversals_count);
-
+        RunState::Stopped => {
           self.runs.remove(index);
         },
-        (RunState::Completed, _) => {
+        RunState::Completed => {
           debug_assert!(
             self.runs[index].traversals.is_empty(),
             "completing a run with active traversals"
@@ -151,21 +116,11 @@ impl Workflow {
 
           log::trace!("completed run, workflow id={:?}", self.id);
 
-          result.stats.advanced_runs_count += 1;
-          result.stats.completed_runs_count += 1;
-
           self.runs.remove(index);
         },
-        (RunState::Running, _) => {
+        RunState::Running => {
           if run_result_did_make_progress {
             did_make_progress = true;
-          }
-
-          // The run is still running.
-          if run_result.advanced_traversals_count > 0 {
-            // Since at least one traversal was advanced we
-            // consider the enclosing run to be advanced too.
-            result.stats.advanced_runs_count += 1;
           }
         },
       }
@@ -209,15 +164,7 @@ impl Workflow {
         // This is safe as `has_active_run == true means that there are at least two runs and
         // `is_initial_run == true`` means that we are processing run with index == 0.
         log::trace!("resetting workflow due to initial state transition");
-        let run = self.runs.remove(index + 1);
-
-        let removed_traversals_count = run.traversals_count();
-        result.stats.stopped_runs_count += 1;
-        result.stats.stopped_traversals_count += removed_traversals_count;
-        *current_traversals_count =
-          current_traversals_count.saturating_sub(removed_traversals_count);
-
-        result.stats.reset_exclusive_workflows_count += 1;
+        self.runs.remove(index + 1);
       } else {
         // The active state run made progress and the next run to be processed (if there is any)
         // is an initial state run that we do not want to expose to the log.
@@ -229,39 +176,9 @@ impl Workflow {
     result
   }
 
-  fn maybe_add_run(
-    &mut self,
-    run: Run,
-    current_traversals_count: &mut u32,
-    traversals_count_limit: u32,
-    result: &mut WorkflowResult<'_>,
-  ) -> bool {
-    if run.traversals_count() + *current_traversals_count <= traversals_count_limit {
-      log::trace!("workflow={}: creating a new run", self.id);
-
-      result.stats.created_runs_count += 1;
-      result.stats.created_traversals_count += run.traversals_count();
-
-      *current_traversals_count += run.traversals_count();
-      self.runs.insert(0, run);
-
-      true
-    } else {
-      result.stats.traversals_count_limit_hit_count += 1;
-      log::debug!(
-        "workflow={}: traversals count ({}) is over the limit ({}); preventing a new run from \
-         being added",
-        self.id,
-        *current_traversals_count,
-        traversals_count_limit
-      );
-
-      false
-    }
-  }
-
-  pub(crate) fn traversals_count(&self) -> u32 {
-    self.runs.iter().map(Run::traversals_count).sum()
+  fn add_run(&mut self, run: Run) {
+    log::trace!("workflow={}: creating a new run", self.id);
+    self.runs.insert(0, run);
   }
 
   pub(crate) fn needs_new_run(&self) -> bool {
@@ -315,10 +232,6 @@ impl Workflow {
     );
 
     is_in_initial_state
-  }
-
-  pub(crate) fn remove_run(&mut self, index: usize) {
-    self.runs.remove(index);
   }
 
   /// Remove all workflow runs.
@@ -380,9 +293,6 @@ impl<'a> WorkflowResult<'a> {
       .triggered_actions
       .append(&mut run_result.triggered_actions);
     self.logs_to_inject.append(&mut run_result.logs_to_inject);
-    self.stats.created_traversals_count += run_result.created_traversals_count;
-    self.stats.advanced_traversals_count += run_result.advanced_traversals_count;
-    self.stats.completed_traversals_count += run_result.completed_traversals_count;
     self.stats.matched_logs_count += run_result.matched_logs_count;
   }
 }
@@ -396,37 +306,12 @@ impl<'a> WorkflowResult<'a> {
 #[derive(Debug, Default, PartialEq, Eq)]
 #[allow(clippy::struct_field_names)]
 pub(crate) struct WorkflowResultStats {
-  pub(crate) created_runs_count: u32,
-  pub(crate) advanced_runs_count: u32,
-  pub(crate) stopped_runs_count: u32,
-  pub(crate) completed_runs_count: u32,
-
-  pub(crate) created_traversals_count: u32,
-  pub(crate) advanced_traversals_count: u32,
-  pub(crate) stopped_traversals_count: u32,
-  pub(crate) completed_traversals_count: u32,
-
-  /// The number of times the engine prevented a run and/or traversal from being
-  /// created due to a configured traversals count limit.
-  pub(crate) traversals_count_limit_hit_count: u32,
-
-  pub(crate) reset_exclusive_workflows_count: u32,
-
   pub(crate) matched_logs_count: u32,
 }
 
 impl WorkflowResultStats {
   pub(crate) const fn did_make_progress(&self) -> bool {
-    self.created_runs_count > 0
-      || self.advanced_runs_count > 0
-      || self.stopped_runs_count > 0
-      || self.completed_runs_count > 0
-      || self.created_traversals_count > 0
-      || self.advanced_traversals_count > 0
-      || self.stopped_traversals_count > 0
-      || self.completed_traversals_count > 0
-      || self.matched_logs_count > 0
-      || self.reset_exclusive_workflows_count > 0
+    self.matched_logs_count > 0
   }
 }
 
@@ -550,10 +435,6 @@ impl Run {
 
     let mut run_triggered_actions = Vec::<TriggeredAction<'_>>::new();
     let mut run_logs_to_inject = BTreeMap::<&'a str, Log>::new();
-
-    let mut created_traversals_count = 0;
-    let mut advanced_traversals_count = 0;
-    let mut completed_traversals_count = 0;
     let mut run_matched_logs_count = 0;
 
     // Process traversals in reversed order as we may end up modifying the array
@@ -583,9 +464,6 @@ impl Run {
           return RunResult {
             state: RunState::Stopped,
             triggered_actions: vec![],
-            created_traversals_count: 0,
-            advanced_traversals_count: 0,
-            completed_traversals_count: 0,
             matched_logs_count: run_matched_logs_count,
             logs_to_inject: BTreeMap::new(),
           };
@@ -606,9 +484,6 @@ impl Run {
                 return RunResult {
                   state: RunState::Stopped,
                   triggered_actions: vec![],
-                  created_traversals_count: 0,
-                  advanced_traversals_count: 0,
-                  completed_traversals_count: 0,
                   matched_logs_count: run_matched_logs_count,
                   logs_to_inject: BTreeMap::new(),
                 };
@@ -638,20 +513,6 @@ impl Run {
         continue;
       }
 
-      // The currently processed traversal is about to advance.
-      advanced_traversals_count += 1;
-
-      if traversal_result.output_traversals.is_empty() {
-        // Traversal has no successors so it's been completed.
-        completed_traversals_count += 1;
-      } else {
-        #[allow(clippy::cast_possible_truncation)]
-        let output_traversals_count = traversal_result.output_traversals.len() as u32;
-        // The number of created traversals is the number of output traversals
-        // minus the input traversal.
-        created_traversals_count += output_traversals_count - 1;
-      }
-
       // Replace advanced traversals with their successors.
       // Each advanced traversal may have 0 or more successors.
       // Notes:
@@ -675,9 +536,6 @@ impl Run {
     RunResult {
       state,
       triggered_actions: run_triggered_actions,
-      created_traversals_count,
-      advanced_traversals_count,
-      completed_traversals_count,
       matched_logs_count: run_matched_logs_count,
       logs_to_inject: run_logs_to_inject,
     }
@@ -707,12 +565,6 @@ impl Run {
         <= 1
     );
     self.traversals.iter().all(Traversal::is_in_initial_state)
-  }
-
-  pub(crate) fn traversals_count(&self) -> u32 {
-    #[allow(clippy::cast_possible_truncation)]
-    let traversals_count = self.traversals.len() as u32;
-    traversals_count
   }
 }
 
@@ -744,13 +596,6 @@ pub(crate) struct RunResult<'a> {
   state: RunState,
   /// The list of triggered actions.
   triggered_actions: Vec<TriggeredAction<'a>>,
-  /// The number of newly created traversals.
-  created_traversals_count: u32,
-  /// The number of advanced traversals. The traversal is considered
-  /// to be advanced when it transitions to the next state.
-  advanced_traversals_count: u32,
-  /// The number of completed traversals.
-  completed_traversals_count: u32,
   /// The number of matched logs. A single log can be matched multiple times
   matched_logs_count: u32,
   // Logs to be injected back into the workflow engine after field attachment and other processing.

--- a/bd-workflows/src/workflow_test.rs
+++ b/bd-workflows/src/workflow_test.rs
@@ -62,8 +62,6 @@ macro_rules! workflow_process_log {
         occurred_at: time::OffsetDateTime::now_utc(),
         capture_session: None,
       },
-      &mut 0,
-      1000,
     )
   };
   ($annotated_workflow:expr; $message:expr,with $tags:expr) => {
@@ -81,8 +79,6 @@ macro_rules! workflow_process_log {
         occurred_at: time::OffsetDateTime::now_utc(),
         capture_session: None,
       },
-      &mut 0,
-      1000,
     )
   };
 }
@@ -283,16 +279,6 @@ fn multiple_start_nodes_initial_fork() {
       triggered_actions: vec![],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 0,
-        stopped_runs_count: 0,
-        created_traversals_count: 2,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 2,
       },
     }
@@ -306,16 +292,6 @@ fn multiple_start_nodes_initial_fork() {
       triggered_actions: vec![],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 1,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 0,
-        stopped_runs_count: 1,
-        created_traversals_count: 2,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 2,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 2,
       },
     }
@@ -333,16 +309,6 @@ fn multiple_start_nodes_initial_fork() {
       })],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 0,
-        stopped_runs_count: 0,
-        created_traversals_count: 1,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 1,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -391,16 +357,6 @@ fn multiple_start_nodes_initial_branching() {
       triggered_actions: vec![],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 0,
-        stopped_runs_count: 0,
-        created_traversals_count: 1,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -415,16 +371,6 @@ fn multiple_start_nodes_initial_branching() {
       triggered_actions: vec![],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 1,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 0,
-        stopped_runs_count: 1,
-        created_traversals_count: 1,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 1,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -442,16 +388,6 @@ fn multiple_start_nodes_initial_branching() {
       })],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 1,
-        stopped_runs_count: 0,
-        created_traversals_count: 1,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 1,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -508,16 +444,6 @@ fn basic_exclusive_workflow() {
       ],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 0,
-        stopped_runs_count: 0,
-        created_traversals_count: 1,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -538,16 +464,6 @@ fn basic_exclusive_workflow() {
       })],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 1,
-        stopped_runs_count: 0,
-        created_traversals_count: 1,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 1,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -606,16 +522,6 @@ fn exclusive_workflow_matched_logs_count_limit() {
       triggered_actions: vec![],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 0,
-        stopped_runs_count: 0,
-        created_traversals_count: 2,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 2,
       },
     }
@@ -634,16 +540,6 @@ fn exclusive_workflow_matched_logs_count_limit() {
       triggered_actions: vec![],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 0,
-        completed_runs_count: 0,
-        stopped_runs_count: 0,
-        created_traversals_count: 1,
-        advanced_traversals_count: 0,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -663,16 +559,6 @@ fn exclusive_workflow_matched_logs_count_limit() {
       triggered_actions: vec![],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 0,
-        advanced_runs_count: 0,
-        completed_runs_count: 0,
-        stopped_runs_count: 1,
-        created_traversals_count: 0,
-        advanced_traversals_count: 0,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 2,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -714,16 +600,6 @@ fn exclusive_workflow_log_rule_count() {
       triggered_actions: vec![],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 0,
-        completed_runs_count: 0,
-        stopped_runs_count: 0,
-        created_traversals_count: 1,
-        advanced_traversals_count: 0,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -744,16 +620,6 @@ fn exclusive_workflow_log_rule_count() {
       })],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 0,
-        stopped_runs_count: 0,
-        created_traversals_count: 1,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -780,16 +646,6 @@ fn exclusive_workflow_log_rule_count() {
       })],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 0,
-        advanced_runs_count: 1,
-        completed_runs_count: 1,
-        stopped_runs_count: 0,
-        created_traversals_count: 0,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 1,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -850,16 +706,6 @@ fn branching_exclusive_workflow() {
       })],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 1,
-        advanced_runs_count: 1,
-        completed_runs_count: 0,
-        stopped_runs_count: 0,
-        created_traversals_count: 1,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -875,16 +721,6 @@ fn branching_exclusive_workflow() {
   assert!(result.triggered_actions.is_empty());
   assert_eq!(
     WorkflowResultStats {
-      reset_exclusive_workflows_count: 0,
-      created_runs_count: 1,
-      advanced_runs_count: 0,
-      completed_runs_count: 0,
-      stopped_runs_count: 0,
-      created_traversals_count: 1,
-      advanced_traversals_count: 0,
-      completed_traversals_count: 0,
-      stopped_traversals_count: 0,
-      traversals_count_limit_hit_count: 0,
       matched_logs_count: 0,
     },
     result.stats
@@ -904,16 +740,6 @@ fn branching_exclusive_workflow() {
       })],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 0,
-        advanced_runs_count: 1,
-        completed_runs_count: 1,
-        stopped_runs_count: 0,
-        created_traversals_count: 0,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 1,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 1,
       },
     }
@@ -941,16 +767,6 @@ fn branching_exclusive_workflow() {
       ],
       logs_to_inject: BTreeMap::new(),
       stats: WorkflowResultStats {
-        reset_exclusive_workflows_count: 0,
-        created_runs_count: 0,
-        advanced_runs_count: 1,
-        completed_runs_count: 0,
-        stopped_runs_count: 0,
-        created_traversals_count: 1,
-        advanced_traversals_count: 1,
-        completed_traversals_count: 0,
-        stopped_traversals_count: 0,
-        traversals_count_limit_hit_count: 0,
         matched_logs_count: 2,
       },
     }


### PR DESCRIPTION
1) "workflows.state_periodic_write_interval_ms": This flag is redundant
   as we do periodic persistence processing on every log processed and
   logs are received frequently.
2) "workflows.traversals_global_count_limit": With the removal of
   parallel execution mode this flag doesn't provide a lot of value and
   removing it cleans up a lot of complexity.

Also clean up some metrics that I don't think provide any real operational value.