### PR TITLE
add memory-backed feature flags implementation

### DIFF
--- a/bd-runtime-config/src/feature_flags.rs
+++ b/bd-runtime-config/src/feature_flags.rs
@@ -159,6 +159,7 @@ pub fn new_memory_feature_flags_loader(
   )
 }
 
+#[must_use]
 pub fn new_feature_flags_loader_for_test(
   feature_flags: ConfigPtr<dyn FeatureFlags>,
 ) -> Arc<dyn Loader<dyn FeatureFlags>> {

--- a/bd-runtime-config/src/feature_flags.rs
+++ b/bd-runtime-config/src/feature_flags.rs
@@ -5,7 +5,14 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::loader::{ConfigPtr, Loader, LoaderError, StatsCallbacks, WatchedFileLoader};
+use crate::loader::{
+  ConfigPtr,
+  Loader,
+  LoaderError,
+  MemoryLoader,
+  StatsCallbacks,
+  WatchedFileLoader,
+};
 use rand::Rng;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -69,7 +76,7 @@ enum FeatureFlagValue {
 
 // Contains a hashmap of string name to value.
 #[derive(Deserialize, Debug)]
-struct MemoryFeatureFlags {
+pub struct MemoryFeatureFlags {
   values: HashMap<String, FeatureFlagValue>,
 }
 
@@ -150,6 +157,12 @@ pub fn new_memory_feature_flags_loader(
     },
     stats,
   )
+}
+
+pub fn new_feature_flags_loader_for_test(
+  feature_flags: ConfigPtr<dyn FeatureFlags>,
+) -> Arc<dyn Loader<dyn FeatureFlags>> {
+  MemoryLoader::new_loader(feature_flags)
 }
 
 #[test]

--- a/bd-runtime-config/src/loader.rs
+++ b/bd-runtime-config/src/loader.rs
@@ -165,6 +165,7 @@ impl<ConfigType: ?Sized + Send + Sync> Loader<ConfigType> for MemoryLoader<Confi
 }
 
 impl<ConfigType: ?Sized + Send + Sync + 'static> MemoryLoader<ConfigType> {
+  #[must_use]
   pub fn new_loader(config: ConfigPtr<ConfigType>) -> Arc<dyn Loader<ConfigType>> {
     let (snapshot_sender, snapshot_receiver) = watch::channel(config);
     Arc::new(Self {


### PR DESCRIPTION
Adds a test only version that avoids having to establish file watches, useful for test