### PR TITLE
fix(crash-handler): load state fields from reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ dependencies = [
  "bd-key-value",
  "bd-log-primitives",
  "bd-proto",
+ "bd-proto-util",
  "bd-runtime",
  "bd-shutdown",
  "bd-test-helpers",

--- a/bd-crash-handler/Cargo.toml
+++ b/bd-crash-handler/Cargo.toml
@@ -35,6 +35,7 @@ uuid.workspace          = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+bd-proto-util.path       = "../bd-proto-util"
 bd-test-helpers          = { path = "../bd-test-helpers", default-features = false }
 ctor.workspace           = true
 futures-util.workspace   = true


### PR DESCRIPTION
load changeable fields like timestamp, OS version, and app version from report contents where available, which should reduce the possibility of old reports on disk causing the appearance of errors in new app versions.

part of BIT-5724