### PR TITLE
increment app_open at logger init

### DIFF
--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -199,10 +199,6 @@ impl LoggerHandle {
     });
   }
 
-  pub fn record_app_open(&self) {
-    self.stats.app_open.inc();
-  }
-
   pub fn log_resource_utilization(&self, mut fields: AnnotatedLogFields, duration: time::Duration) {
     fields.insert(
       "_duration_ms".into(),


### PR DESCRIPTION
consider the creation of the stat to be concurrent with app open. confirmed the behavior by checking the metric increment counts against app launches