### PR TITLE
feat(report-convert): support reading conversion input from stdin

### DIFF
--- a/bd-report-convert/src/glue.cpp
+++ b/bd-report-convert/src/glue.cpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
-#include <iostream>
 #include <string>
 
 #include <flatbuffers/idl.h>
@@ -27,15 +26,12 @@ enum BDReaderErr {
 using namespace bitdrift_public::fbs::issue_reporting::v1;
 extern "C" {
 char *bdrc_alloc_json(char *bin_data_path) {
-  std::ifstream data_file;
-  data_file.open(bin_data_path, std::ios::binary | std::ios::in);
-  data_file.seekg(0,std::ios::end);
-
-  int length = data_file.tellg();
-  data_file.seekg(0,std::ios::beg);
-  char *bin_data = new char[length];
-  data_file.read(bin_data, length);
-  data_file.close();
+  std::ifstream data_file(bin_data_path);
+  std::string contents(
+    (std::istreambuf_iterator<char>(data_file)),
+    (std::istreambuf_iterator<char>())
+  );
+  char *bin_data = (char *)contents.c_str();
 
   auto output = flatbuffers::FlatBufferToString(
       reinterpret_cast<uint8_t *>(bin_data),

--- a/bd-report-convert/src/main.rs
+++ b/bd-report-convert/src/main.rs
@@ -28,13 +28,18 @@ pub fn main() -> Result<ExitCode, std::io::Error> {
   }
 
   let (action, input_path) = (&args[1], &args[2]);
-  if !Path::new(input_path).exists() {
-    eprintln!("Input file not found: {input_path}");
-    return Ok(ExitCode::from(74));
-  }
+  let input_path = if input_path == "-" {
+    "/dev/stdin"
+  } else {
+    if !Path::new(input_path).exists() {
+      eprintln!("Input file not found: {input_path}");
+      return Ok(ExitCode::from(74));
+    }
+    input_path
+  };
   match (args.len(), action.as_str()) {
-    (3, "to-json") => Ok(print_json(input_path.as_str())),
-    (4, "to-bin") => write_bin(input_path.as_str(), &args[3]),
+    (3, "to-json") => Ok(print_json(input_path)),
+    (4, "to-bin") => write_bin(input_path, &args[3]),
     _ => Ok(print_usage(&args[0])),
   }
 }


### PR DESCRIPTION
Adds the option of specifying `-` for the input file to `bd-report-convert` to read the input contents from standard input.

Examples:

```sh
# creating synthetic uploadable artifacts
generate-report-json [...] \
    | cargo run --bin bd-report-convert -- to-bin - new-report.cap
```

```sh
# parsing downloaded reports
download-client-report [artifact_id] \
    | cargo run --bin bd-report-convert -- to-json - | jq
```