### PR TITLE
Add a BONJSON encoder and harmonize the general API

### DIFF
--- a/bd-bonjson-tests/src/ffi_tests.rs
+++ b/bd-bonjson-tests/src/ffi_tests.rs
@@ -6,7 +6,8 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use assert_no_alloc::*;
-use bd_bonjson::decoder::{Decoder, Value};
+use bd_bonjson::Value;
+use bd_bonjson::decoder::Decoder;
 use bd_bonjson::ffi::BDCrashWriterHandle;
 use std::ptr::null;
 use tempfile::NamedTempFile;

--- a/bd-bonjson-tests/src/ffi_tests.rs
+++ b/bd-bonjson-tests/src/ffi_tests.rs
@@ -7,7 +7,6 @@
 
 use assert_no_alloc::*;
 use bd_bonjson::Value;
-use bd_bonjson::decoder::Decoder;
 use bd_bonjson::ffi::BDCrashWriterHandle;
 use std::ptr::null;
 use tempfile::NamedTempFile;
@@ -99,8 +98,7 @@ fn test_write_boolean() {
   }
 
   let bytes = std::fs::read(temp_file_path).unwrap();
-  let mut decoder = Decoder::new(&bytes);
-  let value = decoder.decode().unwrap();
+  let value = bd_bonjson::decoder::decode(&bytes).unwrap();
   assert_eq!(value, Value::Bool(expected));
 }
 
@@ -122,8 +120,7 @@ fn test_write_null() {
     assert!(handle.is_null());
   }
   let bytes = std::fs::read(temp_file_path).unwrap();
-  let mut decoder = Decoder::new(&bytes);
-  let value = decoder.decode().unwrap();
+  let value = bd_bonjson::decoder::decode(&bytes).unwrap();
   assert_eq!(value, Value::Null);
 }
 
@@ -146,8 +143,7 @@ fn test_write_signed() {
     assert!(handle.is_null());
   }
   let bytes = std::fs::read(temp_file_path).unwrap();
-  let mut decoder = Decoder::new(&bytes);
-  let value = decoder.decode().unwrap();
+  let value = bd_bonjson::decoder::decode(&bytes).unwrap();
   assert_eq!(value, Value::Signed(expected));
 }
 
@@ -170,8 +166,7 @@ fn test_write_unsigned() {
     assert!(handle.is_null());
   }
   let bytes = std::fs::read(temp_file_path).unwrap();
-  let mut decoder = Decoder::new(&bytes);
-  let value = decoder.decode().unwrap();
+  let value = bd_bonjson::decoder::decode(&bytes).unwrap();
   assert_eq!(value, Value::Unsigned(expected));
 }
 
@@ -194,8 +189,7 @@ fn test_write_float() {
     assert!(handle.is_null());
   }
   let bytes = std::fs::read(temp_file_path).unwrap();
-  let mut decoder = Decoder::new(&bytes);
-  let value = decoder.decode().unwrap();
+  let value = bd_bonjson::decoder::decode(&bytes).unwrap();
   assert_eq!(value, Value::Float(expected));
 }
 
@@ -219,8 +213,7 @@ fn test_write_str() {
     assert!(handle.is_null());
   }
   let bytes = std::fs::read(temp_file_path).unwrap();
-  let mut decoder = Decoder::new(&bytes);
-  let value = decoder.decode().unwrap();
+  let value = bd_bonjson::decoder::decode(&bytes).unwrap();
   assert_eq!(value, Value::String(expected.to_string()));
 }
 
@@ -246,8 +239,7 @@ fn test_write_array() {
     assert!(handle.is_null());
   }
   let bytes = std::fs::read(temp_file_path).unwrap();
-  let mut decoder = Decoder::new(&bytes);
-  let value = decoder.decode().unwrap();
+  let value = bd_bonjson::decoder::decode(&bytes).unwrap();
   assert_eq!(
     value,
     Value::Array(vec![Value::Signed(1), Value::Signed(2), Value::Signed(3),])
@@ -279,8 +271,7 @@ fn test_write_map() {
     assert!(handle.is_null());
   }
   let bytes = std::fs::read(temp_file_path).unwrap();
-  let mut decoder = Decoder::new(&bytes);
-  let value = decoder.decode().unwrap();
+  let value = bd_bonjson::decoder::decode(&bytes).unwrap();
   let mut expected = std::collections::HashMap::new();
   expected.insert("foo".to_string(), Value::Signed(42));
   expected.insert("bar".to_string(), Value::Bool(false));
@@ -323,8 +314,7 @@ fn test_write_deeply_nested_structure() {
     assert!(handle.is_null());
   }
   let bytes = std::fs::read(temp_file_path).unwrap();
-  let mut decoder = Decoder::new(&bytes);
-  let value = decoder.decode().unwrap();
+  let value = bd_bonjson::decoder::decode(&bytes).unwrap();
 
   // Build expected value
   let mut inner_map = std::collections::HashMap::new();

--- a/bd-bonjson/src/decoder.rs
+++ b/bd-bonjson/src/decoder.rs
@@ -98,6 +98,9 @@ impl<'a> Decoder<'a> {
 
   /// Decode the entire buffer and return the resulting value.
   /// On error, it returns the value decoded so far and the error.
+  ///
+  /// # Errors
+  /// Returns `DecodeError` if the buffer contains invalid BONJSON data.
   pub fn decode(&mut self) -> Result<Value> {
     self.decode_value()
   }
@@ -311,6 +314,9 @@ impl<'a> Decoder<'a> {
 
 /// Decode a buffer and return the resulting value.
 /// On error, it returns the value decoded so far and the error.
+///
+/// # Errors
+/// Returns `DecodeError` if the buffer contains invalid BONJSON data.
 pub fn decode_value(data: &[u8]) -> Result<Value> {
   let mut decoder = Decoder::new(data);
   decoder.decode()

--- a/bd-bonjson/src/decoder.rs
+++ b/bd-bonjson/src/decoder.rs
@@ -25,6 +25,16 @@ use crate::type_codes::TypeCode;
 use crate::{Value, deserialize_primitives};
 use std::collections::HashMap;
 
+/// Decode a buffer and return the resulting value.
+/// On error, it returns the value decoded so far and the error.
+///
+/// # Errors
+/// Returns `DecodeError` if the buffer contains invalid BONJSON data.
+pub fn decode(data: &[u8]) -> Result<Value> {
+  let mut context = DecoderContext::new(data);
+  context.decode_value()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeserializationErrorWithOffset {
   // An error that occurred during deserialization, with the byte offset in the data where it
@@ -298,14 +308,4 @@ impl<'a> DecoderContext<'a> {
 
     Ok(Value::Object(object))
   }
-}
-
-/// Decode a buffer and return the resulting value.
-/// On error, it returns the value decoded so far and the error.
-///
-/// # Errors
-/// Returns `DecodeError` if the buffer contains invalid BONJSON data.
-pub fn decode_value(data: &[u8]) -> Result<Value> {
-  let mut context = DecoderContext::new(data);
-  context.decode_value()
 }

--- a/bd-bonjson/src/decoder.rs
+++ b/bd-bonjson/src/decoder.rs
@@ -9,7 +9,6 @@
 #[path = "./decoder_test.rs"]
 mod decoder_test;
 
-use crate::deserialize_primitives;
 use crate::deserialize_primitives::{
   DeserializationError,
   deserialize_f16_after_type_code,
@@ -23,6 +22,7 @@ use crate::deserialize_primitives::{
   peek_type_code,
 };
 use crate::type_codes::TypeCode;
+use crate::{Value, deserialize_primitives};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,27 +31,45 @@ pub enum DeserializationErrorWithOffset {
   // occurred.
   Error(DeserializationError, usize),
 }
-pub type Result<T> = std::result::Result<T, PartialDecodeResult>;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct PartialDecodeResult {
-  pub partial_value: Value, // The value decoded so far, which will be incomplete or possibly None.
-  pub error: DeserializationErrorWithOffset,
+pub enum DecodeError {
+  /// Fatal error - no partial value could be decoded
+  Fatal(DeserializationErrorWithOffset),
+  /// Partial decode - some value was decoded before the error occurred
+  Partial {
+    partial_value: Value,
+    error: DeserializationErrorWithOffset,
+  },
 }
 
-/// BONJSON has the same value types and structure as JSON.
-#[derive(Debug, Clone, PartialEq)]
-pub enum Value {
-  None, // Can only be returned when an error occurs.
-  Null,
-  Bool(bool),
-  Float(f64),
-  Signed(i64),
-  Unsigned(u64),
-  String(String),
-  Array(Vec<Value>),
-  Object(HashMap<String, Value>),
+impl DecodeError {
+  /// Check if this is a fatal error (no partial data available)
+  #[must_use]
+  pub fn is_fatal(&self) -> bool {
+    matches!(self, Self::Fatal(_))
+  }
+
+  /// Get the error information
+  #[must_use]
+  pub fn error(&self) -> &DeserializationErrorWithOffset {
+    match self {
+      Self::Fatal(e) => e,
+      Self::Partial { error, .. } => error,
+    }
+  }
+
+  /// Get the partial value if available
+  #[must_use]
+  pub fn partial_value(&self) -> Option<&Value> {
+    match self {
+      Self::Fatal(_) => None,
+      Self::Partial { partial_value, .. } => Some(partial_value),
+    }
+  }
 }
+
+pub type Result<T> = std::result::Result<T, DecodeError>;
 
 /// Decoder decodes a buffer containing a BONJSON-encoded data into a `Value`.
 pub struct Decoder<'a> {
@@ -59,10 +77,16 @@ pub struct Decoder<'a> {
   position: usize,
 }
 
-fn propagate_error(error: &PartialDecodeResult, value: Value) -> PartialDecodeResult {
-  PartialDecodeResult {
-    partial_value: value,
-    error: error.error,
+fn propagate_partial_decode(error: &DecodeError, value: Value) -> DecodeError {
+  match error {
+    DecodeError::Fatal(e) => DecodeError::Partial {
+      partial_value: value,
+      error: *e,
+    },
+    DecodeError::Partial { error, .. } => DecodeError::Partial {
+      partial_value: value,
+      error: *error,
+    },
   }
 }
 
@@ -86,12 +110,16 @@ impl<'a> Decoder<'a> {
     self.position += bytes;
   }
 
-  fn map_err<T>(&self, result: deserialize_primitives::Result<T>, value: Value) -> Result<T> {
-    result.map_err(|e| self.error_here(e, value))
+  fn map_err<T>(&self, result: deserialize_primitives::Result<T>) -> Result<T> {
+    result.map_err(|e| self.fatal_error_here(e))
   }
 
-  fn error_here(&self, error: DeserializationError, value: Value) -> PartialDecodeResult {
-    PartialDecodeResult {
+  fn fatal_error_here(&self, error: DeserializationError) -> DecodeError {
+    DecodeError::Fatal(DeserializationErrorWithOffset::Error(error, self.position))
+  }
+
+  fn partial_error_here(&self, error: DeserializationError, value: Value) -> DecodeError {
+    DecodeError::Partial {
       partial_value: value,
       error: DeserializationErrorWithOffset::Error(error, self.position),
     }
@@ -101,7 +129,7 @@ impl<'a> Decoder<'a> {
   fn decode_value(&mut self) -> Result<Value> {
     let remaining = self.remaining_data();
 
-    let (size, type_code) = self.map_err(deserialize_type_code(remaining), Value::None)?;
+    let (size, type_code) = self.map_err(deserialize_type_code(remaining))?;
     self.advance(size);
 
     match type_code {
@@ -126,29 +154,29 @@ impl<'a> Decoder<'a> {
         self.decode_signed_integer(code)
       },
       code if code == TypeCode::LongNumber as u8 => {
-        Err(self.error_here(DeserializationError::LongNumberNotSupported, Value::None))
+        Err(self.fatal_error_here(DeserializationError::LongNumberNotSupported))
       },
-      _ => Err(self.error_here(DeserializationError::UnexpectedTypeCode, Value::None)),
+      _ => Err(self.fatal_error_here(DeserializationError::UnexpectedTypeCode)),
     }
   }
 
   fn decode_f16(&mut self) -> Result<Value> {
     let remaining = self.remaining_data();
-    let (size, value) = self.map_err(deserialize_f16_after_type_code(remaining), Value::None)?;
+    let (size, value) = self.map_err(deserialize_f16_after_type_code(remaining))?;
     self.advance(size);
     Ok(Value::Float(f64::from(value)))
   }
 
   fn decode_f32(&mut self) -> Result<Value> {
     let remaining = self.remaining_data();
-    let (size, value) = self.map_err(deserialize_f32_after_type_code(remaining), Value::None)?;
+    let (size, value) = self.map_err(deserialize_f32_after_type_code(remaining))?;
     self.advance(size);
     Ok(Value::Float(f64::from(value)))
   }
 
   fn decode_f64(&mut self) -> Result<Value> {
     let remaining = self.remaining_data();
-    let (size, value) = self.map_err(deserialize_f64_after_type_code(remaining), Value::None)?;
+    let (size, value) = self.map_err(deserialize_f64_after_type_code(remaining))?;
     self.advance(size);
     Ok(Value::Float(value))
   }
@@ -156,10 +184,7 @@ impl<'a> Decoder<'a> {
   fn decode_long_string(&mut self) -> Result<Value> {
     let remaining = &self.data[self.position ..];
     // let remaining = self.remaining_data();
-    let (size, str_slice) = self.map_err(
-      deserialize_long_string_after_type_code(remaining),
-      Value::None,
-    )?;
+    let (size, str_slice) = self.map_err(deserialize_long_string_after_type_code(remaining))?;
     self.advance(size);
     Ok(Value::String(str_slice.to_string()))
   }
@@ -167,10 +192,9 @@ impl<'a> Decoder<'a> {
   fn decode_short_string(&mut self, type_code: u8) -> Result<Value> {
     let remaining = &self.data[self.position ..];
     // let remaining = self.remaining_data();
-    let (size, str_slice) = self.map_err(
-      deserialize_short_string_after_type_code(remaining, type_code),
-      Value::None,
-    )?;
+    let (size, str_slice) = self.map_err(deserialize_short_string_after_type_code(
+      remaining, type_code,
+    ))?;
     self.advance(size);
     Ok(Value::String(str_slice.to_string()))
   }
@@ -178,10 +202,7 @@ impl<'a> Decoder<'a> {
   #[allow(clippy::cast_possible_wrap)]
   fn decode_unsigned_integer(&mut self, type_code: u8) -> Result<Value> {
     let remaining = self.remaining_data();
-    let (size, value) = self.map_err(
-      deserialize_unsigned_after_type_code(remaining, type_code),
-      Value::None,
-    )?;
+    let (size, value) = self.map_err(deserialize_unsigned_after_type_code(remaining, type_code))?;
     self.advance(size);
     if i64::try_from(value).is_ok() {
       Ok(Value::Signed(value as i64))
@@ -192,10 +213,7 @@ impl<'a> Decoder<'a> {
 
   fn decode_signed_integer(&mut self, type_code: u8) -> Result<Value> {
     let remaining = self.remaining_data();
-    let (size, value) = self.map_err(
-      deserialize_signed_after_type_code(remaining, type_code),
-      Value::None,
-    )?;
+    let (size, value) = self.map_err(deserialize_signed_after_type_code(remaining, type_code))?;
     self.advance(size);
     Ok(Value::Signed(value))
   }
@@ -205,18 +223,28 @@ impl<'a> Decoder<'a> {
 
     loop {
       let remaining = self.remaining_data();
-      let type_code = self.map_err(peek_type_code(remaining), Value::Array(elements.clone()))?;
+      let type_code = match peek_type_code(remaining) {
+        Ok(code) => code,
+        Err(e) => return Err(self.partial_error_here(e, Value::Array(elements))),
+      };
 
       if type_code == TypeCode::ContainerEnd as u8 {
         self.advance(1);
         break;
       }
 
-      let value = self.decode_value().map_err(|e| {
-        if e.partial_value != Value::None {
-          elements.push(e.partial_value.clone());
-        }
-        propagate_error(&e, Value::Array(elements.clone()))
+      let value = self.decode_value().map_err(|e| match e {
+        DecodeError::Fatal(_) => propagate_partial_decode(&e, Value::Array(elements.clone())),
+        DecodeError::Partial {
+          partial_value,
+          error,
+        } => {
+          elements.push(partial_value);
+          DecodeError::Partial {
+            partial_value: Value::Array(elements.clone()),
+            error,
+          }
+        },
       })?;
 
       elements.push(value);
@@ -230,7 +258,10 @@ impl<'a> Decoder<'a> {
 
     loop {
       let remaining = self.remaining_data();
-      let type_code = self.map_err(peek_type_code(remaining), Value::Object(object.clone()))?;
+      let type_code = match peek_type_code(remaining) {
+        Ok(code) => code,
+        Err(e) => return Err(self.partial_error_here(e, Value::Object(object))),
+      };
 
       if type_code == TypeCode::ContainerEnd as u8 {
         self.advance(1);
@@ -241,19 +272,26 @@ impl<'a> Decoder<'a> {
       let key = match self.decode_value() {
         Ok(Value::String(key)) => key,
         Ok(_) => {
-          return Err(self.error_here(
+          return Err(self.partial_error_here(
             DeserializationError::NonStringKeyInMap,
-            Value::Object(object.clone()),
+            Value::Object(object),
           ));
         },
-        Err(e) => return Err(propagate_error(&e, Value::Object(object.clone()))),
+        Err(e) => return Err(propagate_partial_decode(&e, Value::Object(object))),
       };
 
-      let value = self.decode_value().map_err(|e| {
-        if e.partial_value != Value::None {
-          object.insert(key.clone(), e.partial_value.clone());
-        }
-        propagate_error(&e, Value::Object(object.clone()))
+      let value = self.decode_value().map_err(|e| match e {
+        DecodeError::Fatal(_) => propagate_partial_decode(&e, Value::Object(object.clone())),
+        DecodeError::Partial {
+          partial_value,
+          error,
+        } => {
+          object.insert(key.clone(), partial_value);
+          DecodeError::Partial {
+            partial_value: Value::Object(object.clone()),
+            error,
+          }
+        },
       })?;
 
       object.insert(key, value);
@@ -268,120 +306,4 @@ impl<'a> Decoder<'a> {
 pub fn decode_value(data: &[u8]) -> Result<Value> {
   let mut decoder = Decoder::new(data);
   decoder.decode()
-}
-
-// Helper methods for Value
-impl Value {
-  pub fn as_null(&self) -> deserialize_primitives::Result<()> {
-    match self {
-      Self::Null => Ok(()),
-      _ => Err(DeserializationError::ExpectedNull),
-    }
-  }
-
-  pub fn as_bool(&self) -> deserialize_primitives::Result<bool> {
-    match self {
-      Self::Bool(b) => Ok(*b),
-      _ => Err(DeserializationError::ExpectedBoolean),
-    }
-  }
-
-  pub fn as_integer(&self) -> deserialize_primitives::Result<i64> {
-    match self {
-      Self::Signed(n) => Ok(*n),
-      _ => Err(DeserializationError::ExpectedSignedInteger),
-    }
-  }
-
-  pub fn as_unsigned(&self) -> deserialize_primitives::Result<u64> {
-    match self {
-      Self::Unsigned(n) => Ok(*n),
-      _ => Err(DeserializationError::ExpectedUnsignedInteger),
-    }
-  }
-
-  pub fn as_float(&self) -> deserialize_primitives::Result<f64> {
-    match self {
-      Self::Float(n) => Ok(*n),
-      _ => Err(DeserializationError::ExpectedFloat),
-    }
-  }
-
-  pub fn as_string(&self) -> deserialize_primitives::Result<&str> {
-    match self {
-      Self::String(s) => Ok(s),
-      _ => Err(DeserializationError::ExpectedString),
-    }
-  }
-
-  pub fn as_array(&self) -> deserialize_primitives::Result<&Vec<Self>> {
-    match self {
-      Self::Array(arr) => Ok(arr),
-      _ => Err(DeserializationError::ExpectedArray),
-    }
-  }
-
-  pub fn as_object(&self) -> deserialize_primitives::Result<&HashMap<String, Self>> {
-    match self {
-      Self::Object(obj) => Ok(obj),
-      _ => Err(DeserializationError::ExpectedMap),
-    }
-  }
-
-  // JSON-like accessor methods
-  #[must_use]
-  pub fn get(&self, key: &str) -> Option<&Self> {
-    match self {
-      Self::Object(obj) => obj.get(key),
-      _ => None,
-    }
-  }
-
-  #[must_use]
-  pub fn get_index(&self, index: usize) -> Option<&Self> {
-    match self {
-      Self::Array(arr) => arr.get(index),
-      _ => None,
-    }
-  }
-
-  #[must_use]
-  pub fn is_null(&self) -> bool {
-    matches!(self, Self::Null)
-  }
-
-  #[must_use]
-  pub fn is_bool(&self) -> bool {
-    matches!(self, Self::Bool(_))
-  }
-
-  #[must_use]
-  pub fn is_integer(&self) -> bool {
-    matches!(self, Self::Signed(_))
-  }
-
-  #[must_use]
-  pub fn is_unsigned(&self) -> bool {
-    matches!(self, Self::Unsigned(_))
-  }
-
-  #[must_use]
-  pub fn is_float(&self) -> bool {
-    matches!(self, Self::Float(_))
-  }
-
-  #[must_use]
-  pub fn is_string(&self) -> bool {
-    matches!(self, Self::String(_))
-  }
-
-  #[must_use]
-  pub fn is_array(&self) -> bool {
-    matches!(self, Self::Array(_))
-  }
-
-  #[must_use]
-  pub fn is_object(&self) -> bool {
-    matches!(self, Self::Object(_))
-  }
 }

--- a/bd-bonjson/src/decoder_test.rs
+++ b/bd-bonjson/src/decoder_test.rs
@@ -1025,8 +1025,8 @@ fn test_value_none_removed_successful_decode() {
   let valid_data = [0x85, 0x48, 0x65, 0x6c, 0x6c, 0x6f]; // "Hello"
   match decode_value(&valid_data) {
     Ok(Value::String(s)) => assert_eq!(s, "Hello"),
-    Ok(other) => panic!("Expected string, got: {:?}", other),
-    Err(e) => panic!("Unexpected error: {:?}", e),
+    Ok(other) => panic!("Expected string, got: {other:?}"),
+    Err(e) => panic!("Unexpected error: {e:?}"),
   }
 }
 
@@ -1035,9 +1035,9 @@ fn test_value_none_removed_fatal_errors() {
   // Test that invalid data returns fatal errors (no partial value)
   let invalid_data = [0x65]; // Invalid type code
   match decode_value(&invalid_data) {
-    Ok(value) => panic!("Expected error, got: {:?}", value),
+    Ok(value) => panic!("Expected error, got: {value:?}"),
     Err(err) => {
-      assert!(err.is_fatal(), "Expected fatal error, got: {:?}", err);
+      assert!(err.is_fatal(), "Expected fatal error, got: {err:?}");
       assert!(err.partial_value().is_none(), "Expected no partial value");
     },
   }
@@ -1048,12 +1048,11 @@ fn test_value_none_removed_partial_errors() {
   // Test that truncated data returns partial results
   let truncated_array = [0x9a, 0x6d, 0x85, 0x48, 0x65, 0x6c, 0x6c, 0x6f]; // Start of array with null and "Hello", but no end
   match decode_value(&truncated_array) {
-    Ok(value) => panic!("Expected error, got: {:?}", value),
+    Ok(value) => panic!("Expected error, got: {value:?}"),
     Err(err) => {
       assert!(
         !err.is_fatal(),
-        "Expected partial error, got fatal: {:?}",
-        err
+        "Expected partial error, got fatal: {err:?}"
       );
       assert!(err.partial_value().is_some(), "Expected partial value");
     },
@@ -1067,7 +1066,7 @@ fn test_all_variants() {
   let all_value_types = vec![
     Value::Null,
     Value::Bool(true),
-    Value::Float(3.14),
+    Value::Float(std::f64::consts::PI),
     Value::Signed(-42),
     Value::Unsigned(42),
     Value::String("test".to_string()),

--- a/bd-bonjson/src/decoder_test.rs
+++ b/bd-bonjson/src/decoder_test.rs
@@ -25,8 +25,8 @@ fn test_decode_null() {
   };
   writer.write_null().unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Null);
 }
 
@@ -40,8 +40,8 @@ fn test_decode_booleans() {
   };
   writer.write_boolean(true).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Bool(true));
 
   // Test false
@@ -52,8 +52,8 @@ fn test_decode_booleans() {
   };
   writer.write_boolean(false).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Bool(false));
 }
 
@@ -67,8 +67,8 @@ fn test_decode_integers() {
   };
   writer.write_signed(42).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Signed(42));
 
   // Small negative integer
@@ -79,8 +79,8 @@ fn test_decode_integers() {
   };
   writer.write_signed(-42).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Signed(-42));
 
   // Large positive integer
@@ -92,8 +92,8 @@ fn test_decode_integers() {
   let large_val = 1_000_000_000;
   writer.write_signed(large_val).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Signed(large_val));
 }
 
@@ -108,8 +108,8 @@ fn test_decode_unsigned() {
   };
   writer.write_unsigned(42).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Signed(42));
 
   // Large unsigned
@@ -121,8 +121,8 @@ fn test_decode_unsigned() {
   let large_val = 4_000_000_000;
   writer.write_unsigned(large_val).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Signed(large_val as i64));
 
   // Huge unsigned
@@ -134,8 +134,8 @@ fn test_decode_unsigned() {
   let huge_val = i64::MAX as u64 + 1;
   writer.write_unsigned(huge_val).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Unsigned(huge_val));
 }
 
@@ -149,8 +149,8 @@ fn test_decode_floats() {
   };
   writer.write_float(f64::consts::PI).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Float(f64::consts::PI));
 
   // Negative float
@@ -161,8 +161,8 @@ fn test_decode_floats() {
   };
   writer.write_float(-f64::consts::E).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Float(-f64::consts::E));
 
   // Float with conversion from f32
@@ -173,8 +173,8 @@ fn test_decode_floats() {
   };
   writer.write_f32(1.5f32).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::Float(1.5));
 }
 
@@ -188,8 +188,8 @@ fn test_decode_strings() {
   };
   writer.write_str("hello").unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::String("hello".to_string()));
 
   // Empty string
@@ -200,8 +200,8 @@ fn test_decode_strings() {
   };
   writer.write_str("").unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::String(String::new()));
 
   // Long string
@@ -214,8 +214,8 @@ fn test_decode_strings() {
   };
   writer.write_str(long_str).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::String(long_str.to_string()));
 }
 
@@ -236,8 +236,8 @@ fn test_decode_array() {
   writer.write_container_end().unwrap();
 
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
 
   if let Value::Array(items) = value {
     assert_eq!(items.len(), 4);
@@ -260,8 +260,8 @@ fn test_decode_array() {
   writer.write_container_end().unwrap();
 
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
 
   if let Value::Array(items) = value {
     assert_eq!(items.len(), 0);
@@ -289,8 +289,8 @@ fn test_decode_object() {
   writer.write_container_end().unwrap();
 
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
 
   if let Value::Object(map) = value {
     assert_eq!(map.len(), 3);
@@ -312,8 +312,8 @@ fn test_decode_object() {
   writer.write_container_end().unwrap();
 
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
 
   if let Value::Object(map) = value {
     assert_eq!(map.len(), 0);
@@ -356,8 +356,8 @@ fn test_nested_structures() {
   writer.write_container_end().unwrap(); // End object
 
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
 
   // Verify structure
   if let Value::Object(map) = &value {
@@ -403,8 +403,8 @@ fn test_error_handling() {
   // Missing container end
 
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let result = decoder.decode();
+  let data_slice = &buf[.. pos];
+  let result = decode_value(data_slice);
   assert!(result.is_err());
 
   // Invalid map key (not a string)
@@ -420,8 +420,8 @@ fn test_error_handling() {
   writer.write_container_end().unwrap();
 
   let pos = usize::try_from(cursor.position()).unwrap();
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let result = decoder.decode();
+  let data_slice = &buf[.. pos];
+  let result = decode_value(data_slice);
   assert!(result.is_err());
 }
 
@@ -455,8 +455,8 @@ fn test_boundary_values() {
     writer.write_signed(value).unwrap();
     let pos = usize::try_from(cursor.position()).unwrap();
 
-    let mut decoder = Decoder::new(&buf[.. pos]);
-    let decoded = decoder.decode().unwrap();
+    let data_slice = &buf[.. pos];
+    let decoded = decode_value(data_slice).unwrap();
 
     if u64::try_from(value).is_ok() {
       // Unsigned conversion may happen
@@ -494,8 +494,8 @@ fn test_boundary_values() {
     writer.write_unsigned(value).unwrap();
     let pos = usize::try_from(cursor.position()).unwrap();
 
-    let mut decoder = Decoder::new(&buf[.. pos]);
-    let decoded = decoder.decode().unwrap();
+    let data_slice = &buf[.. pos];
+    let decoded = decode_value(data_slice).unwrap();
 
     if i64::try_from(value).is_ok() {
       // Integer conversion may happen
@@ -796,8 +796,8 @@ fn test_decode_special_strings() {
   writer.write_str("").unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
 
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::String(String::new()));
 
   // Test emoji and multi-byte characters
@@ -810,8 +810,8 @@ fn test_decode_special_strings() {
   writer.write_str(special_str).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
 
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::String(special_str.to_string()));
 
   // Test string with control characters
@@ -824,8 +824,8 @@ fn test_decode_special_strings() {
   writer.write_str(control_str).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
 
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
   assert_eq!(value, Value::String(control_str.to_string()));
 }
 
@@ -833,8 +833,8 @@ fn test_decode_special_strings() {
 fn test_decode_empty_input() {
   // Test with completely empty input
   let buf = [];
-  let mut decoder = Decoder::new(&buf);
-  let result = decoder.decode();
+  let data_slice = &buf;
+  let result = decode_value(data_slice);
   assert!(result.is_err());
 }
 
@@ -872,8 +872,8 @@ fn test_deeply_nested_structures() {
   let pos = usize::try_from(cursor.position()).unwrap();
 
   // Test decoding the deeply nested structure
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
 
   // Verify the structure at each level
   if let Value::Array(level1) = value {
@@ -945,8 +945,8 @@ fn test_mixed_object_and_array_nesting() {
   let pos = usize::try_from(cursor.position()).unwrap();
 
   // Test decoding the mixed nested structure
-  let mut decoder = Decoder::new(&buf[.. pos]);
-  let value = decoder.decode().unwrap();
+  let data_slice = &buf[.. pos];
+  let value = decode_value(data_slice).unwrap();
 
   // Verify the structure
   if let Value::Object(root) = &value {
@@ -978,45 +978,6 @@ fn test_mixed_object_and_array_nesting() {
   } else {
     panic!("Expected object at root");
   }
-}
-
-#[test]
-fn test_decode_position_tracking() {
-  // Test that the decoder properly advances its position
-  let mut buf = vec![0u8; 128];
-  let mut cursor = Cursor::new(&mut buf);
-  let mut writer = Writer {
-    writer: &mut cursor,
-  };
-
-  writer.write_null().unwrap();
-  writer.write_boolean(true).unwrap();
-  writer.write_signed(42).unwrap();
-  writer.write_str("test").unwrap();
-
-  // Should be: [0x6d, 0x6f, 0x2a, 0x84, b't', b'e', b's', b't'];
-
-  let mut decoder = Decoder::new(&buf);
-
-  // First value (null)
-  let value = decoder.decode().unwrap();
-  assert_eq!(value, Value::Null);
-  assert_eq!(decoder.position, 1);
-
-  // Second value (bool)
-  let value = decoder.decode().unwrap();
-  assert_eq!(value, Value::Bool(true));
-  assert_eq!(decoder.position, 2);
-
-  // Third value (int)
-  let value = decoder.decode().unwrap();
-  assert_eq!(value, Value::Signed(42));
-  assert_eq!(decoder.position, 3);
-
-  // Fourth value (string)
-  let value = decoder.decode().unwrap();
-  assert_eq!(value, Value::String("test".to_string()));
-  assert_eq!(decoder.position, 8);
 }
 
 #[test]

--- a/bd-bonjson/src/decoder_test.rs
+++ b/bd-bonjson/src/decoder_test.rs
@@ -26,7 +26,7 @@ fn test_decode_null() {
   writer.write_null().unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Null);
 }
 
@@ -41,7 +41,7 @@ fn test_decode_booleans() {
   writer.write_boolean(true).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Bool(true));
 
   // Test false
@@ -53,7 +53,7 @@ fn test_decode_booleans() {
   writer.write_boolean(false).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Bool(false));
 }
 
@@ -68,7 +68,7 @@ fn test_decode_integers() {
   writer.write_signed(42).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Signed(42));
 
   // Small negative integer
@@ -80,7 +80,7 @@ fn test_decode_integers() {
   writer.write_signed(-42).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Signed(-42));
 
   // Large positive integer
@@ -93,7 +93,7 @@ fn test_decode_integers() {
   writer.write_signed(large_val).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Signed(large_val));
 }
 
@@ -109,7 +109,7 @@ fn test_decode_unsigned() {
   writer.write_unsigned(42).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Signed(42));
 
   // Large unsigned
@@ -122,7 +122,7 @@ fn test_decode_unsigned() {
   writer.write_unsigned(large_val).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Signed(large_val as i64));
 
   // Huge unsigned
@@ -135,7 +135,7 @@ fn test_decode_unsigned() {
   writer.write_unsigned(huge_val).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Unsigned(huge_val));
 }
 
@@ -150,7 +150,7 @@ fn test_decode_floats() {
   writer.write_float(f64::consts::PI).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Float(f64::consts::PI));
 
   // Negative float
@@ -162,7 +162,7 @@ fn test_decode_floats() {
   writer.write_float(-f64::consts::E).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Float(-f64::consts::E));
 
   // Float with conversion from f32
@@ -174,7 +174,7 @@ fn test_decode_floats() {
   writer.write_f32(1.5f32).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::Float(1.5));
 }
 
@@ -189,7 +189,7 @@ fn test_decode_strings() {
   writer.write_str("hello").unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::String("hello".to_string()));
 
   // Empty string
@@ -201,7 +201,7 @@ fn test_decode_strings() {
   writer.write_str("").unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::String(String::new()));
 
   // Long string
@@ -215,7 +215,7 @@ fn test_decode_strings() {
   writer.write_str(long_str).unwrap();
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::String(long_str.to_string()));
 }
 
@@ -237,7 +237,7 @@ fn test_decode_array() {
 
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
 
   if let Value::Array(items) = value {
     assert_eq!(items.len(), 4);
@@ -261,7 +261,7 @@ fn test_decode_array() {
 
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
 
   if let Value::Array(items) = value {
     assert_eq!(items.len(), 0);
@@ -290,7 +290,7 @@ fn test_decode_object() {
 
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
 
   if let Value::Object(map) = value {
     assert_eq!(map.len(), 3);
@@ -313,7 +313,7 @@ fn test_decode_object() {
 
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
 
   if let Value::Object(map) = value {
     assert_eq!(map.len(), 0);
@@ -357,7 +357,7 @@ fn test_nested_structures() {
 
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
 
   // Verify structure
   if let Value::Object(map) = &value {
@@ -404,7 +404,7 @@ fn test_error_handling() {
 
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let result = decode_value(data_slice);
+  let result = decode(data_slice);
   assert!(result.is_err());
 
   // Invalid map key (not a string)
@@ -421,7 +421,7 @@ fn test_error_handling() {
 
   let pos = usize::try_from(cursor.position()).unwrap();
   let data_slice = &buf[.. pos];
-  let result = decode_value(data_slice);
+  let result = decode(data_slice);
   assert!(result.is_err());
 }
 
@@ -456,7 +456,7 @@ fn test_boundary_values() {
     let pos = usize::try_from(cursor.position()).unwrap();
 
     let data_slice = &buf[.. pos];
-    let decoded = decode_value(data_slice).unwrap();
+    let decoded = decode(data_slice).unwrap();
 
     if u64::try_from(value).is_ok() {
       // Unsigned conversion may happen
@@ -495,7 +495,7 @@ fn test_boundary_values() {
     let pos = usize::try_from(cursor.position()).unwrap();
 
     let data_slice = &buf[.. pos];
-    let decoded = decode_value(data_slice).unwrap();
+    let decoded = decode(data_slice).unwrap();
 
     if i64::try_from(value).is_ok() {
       // Integer conversion may happen
@@ -577,7 +577,7 @@ fn test_partial_decode_unterminated_array() {
   let pos = usize::try_from(cursor.position()).unwrap();
 
   // Try to decode - should fail with partial result
-  let result = decode_value(&buf[.. pos]);
+  let result = decode(&buf[.. pos]);
   assert!(result.is_err());
 
   let err = result.err().unwrap();
@@ -617,7 +617,7 @@ fn test_partial_decode_unterminated_object() {
   let pos = usize::try_from(cursor.position()).unwrap();
 
   // Try to decode - should fail with partial result
-  let result = decode_value(&buf[.. pos]);
+  let result = decode(&buf[.. pos]);
   assert!(result.is_err());
 
   let err = result.err().unwrap();
@@ -662,7 +662,7 @@ fn test_partial_decode_nested_containers() {
   let pos = usize::try_from(cursor.position()).unwrap();
 
   // Try to decode - should fail with partial result
-  let result = decode_value(&buf[.. pos]);
+  let result = decode(&buf[.. pos]);
   assert!(result.is_err());
 
   let err = result.err().unwrap();
@@ -692,7 +692,7 @@ fn test_partial_decode_truncated_string() {
   let buf = [0x84, b'a', b'b', b'c'];
 
   // Try to decode - should fail with error but no partial result
-  let result = decode_value(&buf);
+  let result = decode(&buf);
   assert!(result.is_err());
 
   let err = result.err().unwrap();
@@ -720,7 +720,7 @@ fn test_partial_decode_with_invalid_type_code() {
   buf[pos] = 0x65; // Invalid type code
 
   // Try to decode
-  let result = decode_value(&buf[..= pos]);
+  let result = decode(&buf[..= pos]);
   assert!(result.is_err());
 
   let err = result.err().unwrap();
@@ -761,7 +761,7 @@ fn test_partial_decode_object_with_invalid_key() {
   let pos = usize::try_from(cursor.position()).unwrap();
 
   // Try to decode
-  let result = decode_value(&buf[.. pos]);
+  let result = decode(&buf[.. pos]);
   assert!(result.is_err());
 
   let err = result.err().unwrap();
@@ -797,7 +797,7 @@ fn test_decode_special_strings() {
   let pos = usize::try_from(cursor.position()).unwrap();
 
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::String(String::new()));
 
   // Test emoji and multi-byte characters
@@ -811,7 +811,7 @@ fn test_decode_special_strings() {
   let pos = usize::try_from(cursor.position()).unwrap();
 
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::String(special_str.to_string()));
 
   // Test string with control characters
@@ -825,7 +825,7 @@ fn test_decode_special_strings() {
   let pos = usize::try_from(cursor.position()).unwrap();
 
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
   assert_eq!(value, Value::String(control_str.to_string()));
 }
 
@@ -834,7 +834,7 @@ fn test_decode_empty_input() {
   // Test with completely empty input
   let buf = [];
   let data_slice = &buf;
-  let result = decode_value(data_slice);
+  let result = decode(data_slice);
   assert!(result.is_err());
 }
 
@@ -873,7 +873,7 @@ fn test_deeply_nested_structures() {
 
   // Test decoding the deeply nested structure
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
 
   // Verify the structure at each level
   if let Value::Array(level1) = value {
@@ -946,7 +946,7 @@ fn test_mixed_object_and_array_nesting() {
 
   // Test decoding the mixed nested structure
   let data_slice = &buf[.. pos];
-  let value = decode_value(data_slice).unwrap();
+  let value = decode(data_slice).unwrap();
 
   // Verify the structure
   if let Value::Object(root) = &value {
@@ -984,7 +984,7 @@ fn test_mixed_object_and_array_nesting() {
 fn test_value_none_removed_successful_decode() {
   // Test that valid data decodes successfully without Value::None
   let valid_data = [0x85, 0x48, 0x65, 0x6c, 0x6c, 0x6f]; // "Hello"
-  match decode_value(&valid_data) {
+  match decode(&valid_data) {
     Ok(Value::String(s)) => assert_eq!(s, "Hello"),
     Ok(other) => panic!("Expected string, got: {other:?}"),
     Err(e) => panic!("Unexpected error: {e:?}"),
@@ -995,7 +995,7 @@ fn test_value_none_removed_successful_decode() {
 fn test_value_none_removed_fatal_errors() {
   // Test that invalid data returns fatal errors (no partial value)
   let invalid_data = [0x65]; // Invalid type code
-  match decode_value(&invalid_data) {
+  match decode(&invalid_data) {
     Ok(value) => panic!("Expected error, got: {value:?}"),
     Err(err) => {
       assert!(err.is_fatal(), "Expected fatal error, got: {err:?}");
@@ -1008,7 +1008,7 @@ fn test_value_none_removed_fatal_errors() {
 fn test_value_none_removed_partial_errors() {
   // Test that truncated data returns partial results
   let truncated_array = [0x9a, 0x6d, 0x85, 0x48, 0x65, 0x6c, 0x6c, 0x6f]; // Start of array with null and "Hello", but no end
-  match decode_value(&truncated_array) {
+  match decode(&truncated_array) {
     Ok(value) => panic!("Expected error, got: {value:?}"),
     Err(err) => {
       assert!(

--- a/bd-bonjson/src/encoder.rs
+++ b/bd-bonjson/src/encoder.rs
@@ -9,6 +9,7 @@
 #[path = "./encoder_test.rs"]
 mod encoder_test;
 
+use crate::Value;
 use crate::serialize_primitives::{
   SerializationError,
   serialize_array_begin,
@@ -21,7 +22,6 @@ use crate::serialize_primitives::{
   serialize_string_header,
   serialize_u64,
 };
-use crate::Value;
 use std::collections::HashMap;
 
 /// An encoder for converting `Value` instances into BONJSON byte format.
@@ -30,14 +30,10 @@ pub struct Encoder {
 }
 
 impl Encoder {
-  /// Creates a new encoder with an initial buffer capacity.
   pub fn new() -> Self {
-    Self {
-      buffer: Vec::new(),
-    }
+    Self { buffer: Vec::new() }
   }
 
-  /// Creates a new encoder with a specified initial capacity.
   pub fn with_capacity(capacity: usize) -> Self {
     Self {
       buffer: Vec::with_capacity(capacity),
@@ -45,10 +41,10 @@ impl Encoder {
   }
 
   /// Encodes a `Value` into BONJSON format and returns the resulting bytes.
-  /// 
+  ///
   /// # Arguments
   /// * `value` - The value to encode
-  /// 
+  ///
   /// # Returns
   /// * `Ok(Vec<u8>)` - The encoded bytes on success
   /// * `Err(SerializationError)` - If encoding fails
@@ -64,27 +60,27 @@ impl Encoder {
       Value::Null => {
         let mut temp_buffer: [u8; 1] = [0; 1];
         let size = serialize_null(&mut temp_buffer)?;
-        self.buffer.extend_from_slice(&temp_buffer[..size]);
+        self.buffer.extend_from_slice(&temp_buffer[.. size]);
       },
       Value::Bool(b) => {
         let mut temp_buffer: [u8; 1] = [0; 1];
         let size = serialize_boolean(&mut temp_buffer, *b)?;
-        self.buffer.extend_from_slice(&temp_buffer[..size]);
+        self.buffer.extend_from_slice(&temp_buffer[.. size]);
       },
       Value::Float(f) => {
         let mut temp_buffer: [u8; 16] = [0; 16];
         let size = serialize_f64(&mut temp_buffer, *f)?;
-        self.buffer.extend_from_slice(&temp_buffer[..size]);
+        self.buffer.extend_from_slice(&temp_buffer[.. size]);
       },
       Value::Signed(i) => {
         let mut temp_buffer: [u8; 16] = [0; 16];
         let size = serialize_i64(&mut temp_buffer, *i)?;
-        self.buffer.extend_from_slice(&temp_buffer[..size]);
+        self.buffer.extend_from_slice(&temp_buffer[.. size]);
       },
       Value::Unsigned(u) => {
         let mut temp_buffer: [u8; 16] = [0; 16];
         let size = serialize_u64(&mut temp_buffer, *u)?;
-        self.buffer.extend_from_slice(&temp_buffer[..size]);
+        self.buffer.extend_from_slice(&temp_buffer[.. size]);
       },
       Value::String(s) => {
         self.encode_string(s)?;
@@ -104,11 +100,11 @@ impl Encoder {
     // String header
     let mut temp_buffer: [u8; 16] = [0; 16]; // Should be enough for any string header
     let header_size = serialize_string_header(&mut temp_buffer, s)?;
-    self.buffer.extend_from_slice(&temp_buffer[..header_size]);
-    
+    self.buffer.extend_from_slice(&temp_buffer[.. header_size]);
+
     // String content
     self.buffer.extend_from_slice(s.as_bytes());
-    
+
     Ok(())
   }
 
@@ -117,7 +113,7 @@ impl Encoder {
     // Array start marker
     let mut temp_buffer: [u8; 1] = [0; 1];
     let size = serialize_array_begin(&mut temp_buffer)?;
-    self.buffer.extend_from_slice(&temp_buffer[..size]);
+    self.buffer.extend_from_slice(&temp_buffer[.. size]);
 
     // Encode each element
     for item in arr {
@@ -127,7 +123,7 @@ impl Encoder {
     // Array end marker
     let mut temp_buffer: [u8; 1] = [0; 1];
     let size = serialize_container_end(&mut temp_buffer)?;
-    self.buffer.extend_from_slice(&temp_buffer[..size]);
+    self.buffer.extend_from_slice(&temp_buffer[.. size]);
 
     Ok(())
   }
@@ -137,7 +133,7 @@ impl Encoder {
     // Object start marker
     let mut temp_buffer: [u8; 1] = [0; 1];
     let size = serialize_map_begin(&mut temp_buffer)?;
-    self.buffer.extend_from_slice(&temp_buffer[..size]);
+    self.buffer.extend_from_slice(&temp_buffer[.. size]);
 
     // Encode each key-value pair
     for (key, value) in obj {
@@ -150,7 +146,7 @@ impl Encoder {
     // Object end marker
     let mut temp_buffer: [u8; 1] = [0; 1];
     let size = serialize_container_end(&mut temp_buffer)?;
-    self.buffer.extend_from_slice(&temp_buffer[..size]);
+    self.buffer.extend_from_slice(&temp_buffer[.. size]);
 
     Ok(())
   }

--- a/bd-bonjson/src/encoder.rs
+++ b/bd-bonjson/src/encoder.rs
@@ -51,10 +51,10 @@ impl Encoder {
   /// * `Ok(Vec<u8>)` - The encoded bytes on success
   /// * `Err(SerializationError)` - If encoding fails
   pub fn encode(&mut self, value: &Value) -> Result<Vec<u8>, SerializationError> {
-    self.buffer.clear();
-
     // Start with a reasonable initial capacity
     const INITIAL_CAPACITY: usize = 1024;
+    
+    self.buffer.clear();
     if self.buffer.capacity() < INITIAL_CAPACITY {
       self.buffer.reserve(INITIAL_CAPACITY);
     }

--- a/bd-bonjson/src/encoder.rs
+++ b/bd-bonjson/src/encoder.rs
@@ -30,10 +30,12 @@ pub struct Encoder {
 }
 
 impl Encoder {
+  #[must_use]
   pub fn new() -> Self {
     Self { buffer: Vec::new() }
   }
 
+  #[must_use]
   pub fn with_capacity(capacity: usize) -> Self {
     Self {
       buffer: Vec::with_capacity(capacity),
@@ -152,6 +154,7 @@ impl Encoder {
   }
 
   /// Returns the current buffer contents without consuming the encoder.
+  #[must_use]
   pub fn buffer(&self) -> &[u8] {
     &self.buffer
   }
@@ -163,6 +166,153 @@ impl Encoder {
 }
 
 impl Default for Encoder {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+/// An in-place encoder for converting `Value` instances into BONJSON byte format
+/// using a pre-allocated slice.
+pub struct InPlaceEncoder {
+  position: usize,
+}
+
+impl InPlaceEncoder {
+  /// Creates a new in-place encoder.
+  ///
+  /// # Returns
+  /// A new `InPlaceEncoder` instance
+  #[must_use]
+  pub fn new() -> Self {
+    Self { position: 0 }
+  }
+
+  /// Encodes a `Value` into BONJSON format in the provided buffer.
+  ///
+  /// # Arguments
+  /// * `buffer` - The mutable slice to encode into
+  /// * `value` - The value to encode
+  ///
+  /// # Returns
+  /// * `Ok(usize)` - The number of bytes written on success
+  /// * `Err(SerializationError)` - If encoding fails (including buffer full)
+  pub fn encode(&mut self, buffer: &mut [u8], value: &Value) -> Result<usize, SerializationError> {
+    self.position = 0;
+    self.encode_value(buffer, value)?;
+    Ok(self.position)
+  }
+
+  /// Writes bytes to the buffer at the current position.
+  fn write_bytes(&mut self, buffer: &mut [u8], data: &[u8]) -> Result<(), SerializationError> {
+    let bytes_needed = data.len();
+    if self.position + bytes_needed > buffer.len() {
+      return Err(SerializationError::BufferFull);
+    }
+    
+    buffer[self.position..self.position + bytes_needed].copy_from_slice(data);
+    self.position += bytes_needed;
+    Ok(())
+  }
+
+  /// Encodes a value into the buffer at the current position.
+  fn encode_value(&mut self, buffer: &mut [u8], value: &Value) -> Result<(), SerializationError> {
+    match value {
+      Value::Null => {
+        let mut temp_buffer: [u8; 1] = [0; 1];
+        let size = serialize_null(&mut temp_buffer)?;
+        self.write_bytes(buffer, &temp_buffer[..size])?;
+      },
+      Value::Bool(b) => {
+        let mut temp_buffer: [u8; 1] = [0; 1];
+        let size = serialize_boolean(&mut temp_buffer, *b)?;
+        self.write_bytes(buffer, &temp_buffer[..size])?;
+      },
+      Value::Float(f) => {
+        let mut temp_buffer: [u8; 16] = [0; 16];
+        let size = serialize_f64(&mut temp_buffer, *f)?;
+        self.write_bytes(buffer, &temp_buffer[..size])?;
+      },
+      Value::Signed(i) => {
+        let mut temp_buffer: [u8; 16] = [0; 16];
+        let size = serialize_i64(&mut temp_buffer, *i)?;
+        self.write_bytes(buffer, &temp_buffer[..size])?;
+      },
+      Value::Unsigned(u) => {
+        let mut temp_buffer: [u8; 16] = [0; 16];
+        let size = serialize_u64(&mut temp_buffer, *u)?;
+        self.write_bytes(buffer, &temp_buffer[..size])?;
+      },
+      Value::String(s) => {
+        self.encode_string(buffer, s)?;
+      },
+      Value::Array(arr) => {
+        self.encode_array(buffer, arr)?;
+      },
+      Value::Object(obj) => {
+        self.encode_object(buffer, obj)?;
+      },
+    }
+    Ok(())
+  }
+
+  /// Encodes a string value into the buffer.
+  fn encode_string(&mut self, buffer: &mut [u8], s: &str) -> Result<(), SerializationError> {
+    // String header
+    let mut temp_buffer: [u8; 16] = [0; 16]; // Should be enough for any string header
+    let header_size = serialize_string_header(&mut temp_buffer, s)?;
+    self.write_bytes(buffer, &temp_buffer[..header_size])?;
+
+    // String content
+    self.write_bytes(buffer, s.as_bytes())?;
+
+    Ok(())
+  }
+
+  /// Encodes an array value.
+  fn encode_array(&mut self, buffer: &mut [u8], arr: &[Value]) -> Result<(), SerializationError> {
+    // Array start marker
+    let mut temp_buffer: [u8; 1] = [0; 1];
+    let size = serialize_array_begin(&mut temp_buffer)?;
+    self.write_bytes(buffer, &temp_buffer[..size])?;
+
+    // Encode each element
+    for item in arr {
+      self.encode_value(buffer, item)?;
+    }
+
+    // Array end marker
+    let mut temp_buffer: [u8; 1] = [0; 1];
+    let size = serialize_container_end(&mut temp_buffer)?;
+    self.write_bytes(buffer, &temp_buffer[..size])?;
+
+    Ok(())
+  }
+
+  /// Encodes an object value.
+  fn encode_object(&mut self, buffer: &mut [u8], obj: &HashMap<String, Value>) -> Result<(), SerializationError> {
+    // Object start marker
+    let mut temp_buffer: [u8; 1] = [0; 1];
+    let size = serialize_map_begin(&mut temp_buffer)?;
+    self.write_bytes(buffer, &temp_buffer[..size])?;
+
+    // Encode each key-value pair
+    for (key, value) in obj {
+      // Encode key as string
+      self.encode_string(buffer, key)?;
+      // Encode value
+      self.encode_value(buffer, value)?;
+    }
+
+    // Object end marker
+    let mut temp_buffer: [u8; 1] = [0; 1];
+    let size = serialize_container_end(&mut temp_buffer)?;
+    self.write_bytes(buffer, &temp_buffer[..size])?;
+
+    Ok(())
+  }
+}
+
+impl Default for InPlaceEncoder {
   fn default() -> Self {
     Self::new()
   }

--- a/bd-bonjson/src/encoder.rs
+++ b/bd-bonjson/src/encoder.rs
@@ -69,54 +69,6 @@ pub fn encode(buffer: &mut Vec<u8>, value: &Value) -> Result<Vec<u8>, Serializat
   }
 }
 
-/// An encoder for converting `Value` instances into BONJSON byte format.
-pub struct Encoder {
-  buffer: Vec<u8>,
-}
-
-impl Encoder {
-  #[must_use]
-  pub fn new() -> Self {
-    Self { buffer: Vec::new() }
-  }
-
-  #[must_use]
-  pub fn with_capacity(capacity: usize) -> Self {
-    Self {
-      buffer: Vec::with_capacity(capacity),
-    }
-  }
-
-  /// Encodes a `Value` into BONJSON format and returns the resulting bytes.
-  ///
-  /// # Arguments
-  /// * `value` - The value to encode
-  ///
-  /// # Returns
-  /// * `Ok(Vec<u8>)` - The encoded bytes on success
-  /// * `Err(SerializationError)` - If encoding fails
-  pub fn encode(&mut self, value: &Value) -> Result<Vec<u8>, SerializationError> {
-    encode(&mut self.buffer, value)
-  }
-
-  /// Returns the current buffer contents without consuming the encoder.
-  #[must_use]
-  pub fn buffer(&self) -> &[u8] {
-    &self.buffer
-  }
-
-  /// Clears the internal buffer for reuse.
-  pub fn clear(&mut self) {
-    self.buffer.clear();
-  }
-}
-
-impl Default for Encoder {
-  fn default() -> Self {
-    Self::new()
-  }
-}
-
 /// Encodes a `Value` into BONJSON format in the provided buffer.
 ///
 /// This function writes BONJSON data directly to a mutable slice without

--- a/bd-bonjson/src/encoder.rs
+++ b/bd-bonjson/src/encoder.rs
@@ -52,105 +52,35 @@ impl Encoder {
   /// * `Err(SerializationError)` - If encoding fails
   pub fn encode(&mut self, value: &Value) -> Result<Vec<u8>, SerializationError> {
     self.buffer.clear();
-    self.encode_value(value)?;
-    Ok(self.buffer.clone())
-  }
-
-  /// Encodes a value into the internal buffer.
-  fn encode_value(&mut self, value: &Value) -> Result<(), SerializationError> {
-    match value {
-      Value::Null => {
-        let mut temp_buffer: [u8; 1] = [0; 1];
-        let size = serialize_null(&mut temp_buffer)?;
-        self.buffer.extend_from_slice(&temp_buffer[.. size]);
-      },
-      Value::Bool(b) => {
-        let mut temp_buffer: [u8; 1] = [0; 1];
-        let size = serialize_boolean(&mut temp_buffer, *b)?;
-        self.buffer.extend_from_slice(&temp_buffer[.. size]);
-      },
-      Value::Float(f) => {
-        let mut temp_buffer: [u8; 16] = [0; 16];
-        let size = serialize_f64(&mut temp_buffer, *f)?;
-        self.buffer.extend_from_slice(&temp_buffer[.. size]);
-      },
-      Value::Signed(i) => {
-        let mut temp_buffer: [u8; 16] = [0; 16];
-        let size = serialize_i64(&mut temp_buffer, *i)?;
-        self.buffer.extend_from_slice(&temp_buffer[.. size]);
-      },
-      Value::Unsigned(u) => {
-        let mut temp_buffer: [u8; 16] = [0; 16];
-        let size = serialize_u64(&mut temp_buffer, *u)?;
-        self.buffer.extend_from_slice(&temp_buffer[.. size]);
-      },
-      Value::String(s) => {
-        self.encode_string(s)?;
-      },
-      Value::Array(arr) => {
-        self.encode_array(arr)?;
-      },
-      Value::Object(obj) => {
-        self.encode_object(obj)?;
-      },
+    
+    // Start with a reasonable initial capacity
+    const INITIAL_CAPACITY: usize = 1024;
+    if self.buffer.capacity() < INITIAL_CAPACITY {
+      self.buffer.reserve(INITIAL_CAPACITY);
     }
-    Ok(())
-  }
-
-  /// Encodes a string value into the buffer.
-  fn encode_string(&mut self, s: &str) -> Result<(), SerializationError> {
-    // String header
-    let mut temp_buffer: [u8; 16] = [0; 16]; // Should be enough for any string header
-    let header_size = serialize_string_header(&mut temp_buffer, s)?;
-    self.buffer.extend_from_slice(&temp_buffer[.. header_size]);
-
-    // String content
-    self.buffer.extend_from_slice(s.as_bytes());
-
-    Ok(())
-  }
-
-  /// Encodes an array value.
-  fn encode_array(&mut self, arr: &[Value]) -> Result<(), SerializationError> {
-    // Array start marker
-    let mut temp_buffer: [u8; 1] = [0; 1];
-    let size = serialize_array_begin(&mut temp_buffer)?;
-    self.buffer.extend_from_slice(&temp_buffer[.. size]);
-
-    // Encode each element
-    for item in arr {
-      self.encode_value(item)?;
+    
+    loop {
+      // Resize buffer to current capacity
+      self.buffer.resize(self.buffer.capacity(), 0);
+      
+      // Try to encode in place
+      match encode_in_place(&mut self.buffer, value) {
+        Ok(bytes_written) => {
+          // Success! Truncate to actual size and return
+          self.buffer.truncate(bytes_written);
+          return Ok(self.buffer.clone());
+        }
+        Err(SerializationError::BufferFull) => {
+          // Buffer too small, double the capacity and try again
+          let new_capacity = self.buffer.capacity() * 2;
+          self.buffer.reserve(new_capacity - self.buffer.capacity());
+        }
+        Err(e) => {
+          // Other error, propagate it
+          return Err(e);
+        }
+      }
     }
-
-    // Array end marker
-    let mut temp_buffer: [u8; 1] = [0; 1];
-    let size = serialize_container_end(&mut temp_buffer)?;
-    self.buffer.extend_from_slice(&temp_buffer[.. size]);
-
-    Ok(())
-  }
-
-  /// Encodes an object value.
-  fn encode_object(&mut self, obj: &HashMap<String, Value>) -> Result<(), SerializationError> {
-    // Object start marker
-    let mut temp_buffer: [u8; 1] = [0; 1];
-    let size = serialize_map_begin(&mut temp_buffer)?;
-    self.buffer.extend_from_slice(&temp_buffer[.. size]);
-
-    // Encode each key-value pair
-    for (key, value) in obj {
-      // Encode key as string
-      self.encode_string(key)?;
-      // Encode value
-      self.encode_value(value)?;
-    }
-
-    // Object end marker
-    let mut temp_buffer: [u8; 1] = [0; 1];
-    let size = serialize_container_end(&mut temp_buffer)?;
-    self.buffer.extend_from_slice(&temp_buffer[.. size]);
-
-    Ok(())
   }
 
   /// Returns the current buffer contents without consuming the encoder.

--- a/bd-bonjson/src/encoder.rs
+++ b/bd-bonjson/src/encoder.rs
@@ -1,0 +1,173 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+#[cfg(test)]
+#[path = "./encoder_test.rs"]
+mod encoder_test;
+
+use crate::serialize_primitives::{
+  SerializationError,
+  serialize_array_begin,
+  serialize_boolean,
+  serialize_container_end,
+  serialize_f64,
+  serialize_i64,
+  serialize_map_begin,
+  serialize_null,
+  serialize_string_header,
+  serialize_u64,
+};
+use crate::Value;
+use std::collections::HashMap;
+
+/// An encoder for converting `Value` instances into BONJSON byte format.
+pub struct Encoder {
+  buffer: Vec<u8>,
+}
+
+impl Encoder {
+  /// Creates a new encoder with an initial buffer capacity.
+  pub fn new() -> Self {
+    Self {
+      buffer: Vec::new(),
+    }
+  }
+
+  /// Creates a new encoder with a specified initial capacity.
+  pub fn with_capacity(capacity: usize) -> Self {
+    Self {
+      buffer: Vec::with_capacity(capacity),
+    }
+  }
+
+  /// Encodes a `Value` into BONJSON format and returns the resulting bytes.
+  /// 
+  /// # Arguments
+  /// * `value` - The value to encode
+  /// 
+  /// # Returns
+  /// * `Ok(Vec<u8>)` - The encoded bytes on success
+  /// * `Err(SerializationError)` - If encoding fails
+  pub fn encode(&mut self, value: &Value) -> Result<Vec<u8>, SerializationError> {
+    self.buffer.clear();
+    self.encode_value(value)?;
+    Ok(self.buffer.clone())
+  }
+
+  /// Encodes a value into the internal buffer.
+  fn encode_value(&mut self, value: &Value) -> Result<(), SerializationError> {
+    match value {
+      Value::Null => {
+        let mut temp_buffer: [u8; 1] = [0; 1];
+        let size = serialize_null(&mut temp_buffer)?;
+        self.buffer.extend_from_slice(&temp_buffer[..size]);
+      },
+      Value::Bool(b) => {
+        let mut temp_buffer: [u8; 1] = [0; 1];
+        let size = serialize_boolean(&mut temp_buffer, *b)?;
+        self.buffer.extend_from_slice(&temp_buffer[..size]);
+      },
+      Value::Float(f) => {
+        let mut temp_buffer: [u8; 16] = [0; 16];
+        let size = serialize_f64(&mut temp_buffer, *f)?;
+        self.buffer.extend_from_slice(&temp_buffer[..size]);
+      },
+      Value::Signed(i) => {
+        let mut temp_buffer: [u8; 16] = [0; 16];
+        let size = serialize_i64(&mut temp_buffer, *i)?;
+        self.buffer.extend_from_slice(&temp_buffer[..size]);
+      },
+      Value::Unsigned(u) => {
+        let mut temp_buffer: [u8; 16] = [0; 16];
+        let size = serialize_u64(&mut temp_buffer, *u)?;
+        self.buffer.extend_from_slice(&temp_buffer[..size]);
+      },
+      Value::String(s) => {
+        self.encode_string(s)?;
+      },
+      Value::Array(arr) => {
+        self.encode_array(arr)?;
+      },
+      Value::Object(obj) => {
+        self.encode_object(obj)?;
+      },
+    }
+    Ok(())
+  }
+
+  /// Encodes a string value into the buffer.
+  fn encode_string(&mut self, s: &str) -> Result<(), SerializationError> {
+    // String header
+    let mut temp_buffer: [u8; 16] = [0; 16]; // Should be enough for any string header
+    let header_size = serialize_string_header(&mut temp_buffer, s)?;
+    self.buffer.extend_from_slice(&temp_buffer[..header_size]);
+    
+    // String content
+    self.buffer.extend_from_slice(s.as_bytes());
+    
+    Ok(())
+  }
+
+  /// Encodes an array value.
+  fn encode_array(&mut self, arr: &[Value]) -> Result<(), SerializationError> {
+    // Array start marker
+    let mut temp_buffer: [u8; 1] = [0; 1];
+    let size = serialize_array_begin(&mut temp_buffer)?;
+    self.buffer.extend_from_slice(&temp_buffer[..size]);
+
+    // Encode each element
+    for item in arr {
+      self.encode_value(item)?;
+    }
+
+    // Array end marker
+    let mut temp_buffer: [u8; 1] = [0; 1];
+    let size = serialize_container_end(&mut temp_buffer)?;
+    self.buffer.extend_from_slice(&temp_buffer[..size]);
+
+    Ok(())
+  }
+
+  /// Encodes an object value.
+  fn encode_object(&mut self, obj: &HashMap<String, Value>) -> Result<(), SerializationError> {
+    // Object start marker
+    let mut temp_buffer: [u8; 1] = [0; 1];
+    let size = serialize_map_begin(&mut temp_buffer)?;
+    self.buffer.extend_from_slice(&temp_buffer[..size]);
+
+    // Encode each key-value pair
+    for (key, value) in obj {
+      // Encode key as string
+      self.encode_string(key)?;
+      // Encode value
+      self.encode_value(value)?;
+    }
+
+    // Object end marker
+    let mut temp_buffer: [u8; 1] = [0; 1];
+    let size = serialize_container_end(&mut temp_buffer)?;
+    self.buffer.extend_from_slice(&temp_buffer[..size]);
+
+    Ok(())
+  }
+
+  /// Returns the current buffer contents without consuming the encoder.
+  pub fn buffer(&self) -> &[u8] {
+    &self.buffer
+  }
+
+  /// Clears the internal buffer for reuse.
+  pub fn clear(&mut self) {
+    self.buffer.clear();
+  }
+}
+
+impl Default for Encoder {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/bd-bonjson/src/encoder.rs
+++ b/bd-bonjson/src/encoder.rs
@@ -39,7 +39,7 @@ use std::collections::HashMap;
 pub fn encode(buffer: &mut Vec<u8>, value: &Value) -> Result<Vec<u8>, SerializationError> {
   // Start with a reasonable initial capacity
   const INITIAL_CAPACITY: usize = 1024;
-  
+
   buffer.clear();
   if buffer.capacity() < INITIAL_CAPACITY {
     buffer.reserve(INITIAL_CAPACITY);

--- a/bd-bonjson/src/encoder.rs
+++ b/bd-bonjson/src/encoder.rs
@@ -64,7 +64,7 @@ impl Encoder {
       self.buffer.resize(self.buffer.capacity(), 0);
       
       // Try to encode in place
-      match encode_in_place(&mut self.buffer, value) {
+      match encode_into(&mut self.buffer, value) {
         Ok(bytes_written) => {
           // Success! Truncate to actual size and return
           self.buffer.truncate(bytes_written);
@@ -114,14 +114,14 @@ impl Default for Encoder {
 /// # Returns
 /// * `Ok(usize)` - The number of bytes written on success
 /// * `Err(SerializationError)` - If encoding fails (including buffer full)
-pub fn encode_in_place(buffer: &mut [u8], value: &Value) -> Result<usize, SerializationError> {
+pub fn encode_into(buffer: &mut [u8], value: &Value) -> Result<usize, SerializationError> {
   let mut position = 0;
-  encode_value_in_place(buffer, value, &mut position)?;
+  encode_value_into(buffer, value, &mut position)?;
   Ok(position)
 }
 
 /// Writes bytes to the buffer at the current position.
-fn write_bytes_in_place(buffer: &mut [u8], data: &[u8], position: &mut usize) -> Result<(), SerializationError> {
+fn write_bytes_into(buffer: &mut [u8], data: &[u8], position: &mut usize) -> Result<(), SerializationError> {
   let bytes_needed = data.len();
   if *position + bytes_needed > buffer.len() {
     return Err(SerializationError::BufferFull);
@@ -133,97 +133,97 @@ fn write_bytes_in_place(buffer: &mut [u8], data: &[u8], position: &mut usize) ->
 }
 
 /// Encodes a value into the buffer at the current position.
-fn encode_value_in_place(buffer: &mut [u8], value: &Value, position: &mut usize) -> Result<(), SerializationError> {
+fn encode_value_into(buffer: &mut [u8], value: &Value, position: &mut usize) -> Result<(), SerializationError> {
   match value {
     Value::Null => {
       let mut temp_buffer: [u8; 1] = [0; 1];
       let size = serialize_null(&mut temp_buffer)?;
-      write_bytes_in_place(buffer, &temp_buffer[..size], position)?;
+      write_bytes_into(buffer, &temp_buffer[..size], position)?;
     },
     Value::Bool(b) => {
       let mut temp_buffer: [u8; 1] = [0; 1];
       let size = serialize_boolean(&mut temp_buffer, *b)?;
-      write_bytes_in_place(buffer, &temp_buffer[..size], position)?;
+      write_bytes_into(buffer, &temp_buffer[..size], position)?;
     },
     Value::Float(f) => {
       let mut temp_buffer: [u8; 16] = [0; 16];
       let size = serialize_f64(&mut temp_buffer, *f)?;
-      write_bytes_in_place(buffer, &temp_buffer[..size], position)?;
+      write_bytes_into(buffer, &temp_buffer[..size], position)?;
     },
     Value::Signed(i) => {
       let mut temp_buffer: [u8; 16] = [0; 16];
       let size = serialize_i64(&mut temp_buffer, *i)?;
-      write_bytes_in_place(buffer, &temp_buffer[..size], position)?;
+      write_bytes_into(buffer, &temp_buffer[..size], position)?;
     },
     Value::Unsigned(u) => {
       let mut temp_buffer: [u8; 16] = [0; 16];
       let size = serialize_u64(&mut temp_buffer, *u)?;
-      write_bytes_in_place(buffer, &temp_buffer[..size], position)?;
+      write_bytes_into(buffer, &temp_buffer[..size], position)?;
     },
     Value::String(s) => {
-      encode_string_in_place(buffer, s, position)?;
+      encode_string_into(buffer, s, position)?;
     },
     Value::Array(arr) => {
-      encode_array_in_place(buffer, arr, position)?;
+      encode_array_into(buffer, arr, position)?;
     },
     Value::Object(obj) => {
-      encode_object_in_place(buffer, obj, position)?;
+      encode_object_into(buffer, obj, position)?;
     },
   }
   Ok(())
 }
 /// Encodes a string value into the buffer.
-fn encode_string_in_place(buffer: &mut [u8], s: &str, position: &mut usize) -> Result<(), SerializationError> {
+fn encode_string_into(buffer: &mut [u8], s: &str, position: &mut usize) -> Result<(), SerializationError> {
   // String header
   let mut temp_buffer: [u8; 16] = [0; 16]; // Should be enough for any string header
   let header_size = serialize_string_header(&mut temp_buffer, s)?;
-  write_bytes_in_place(buffer, &temp_buffer[..header_size], position)?;
+  write_bytes_into(buffer, &temp_buffer[..header_size], position)?;
 
   // String content
-  write_bytes_in_place(buffer, s.as_bytes(), position)?;
+  write_bytes_into(buffer, s.as_bytes(), position)?;
 
   Ok(())
 }
 
 /// Encodes an array value.
-fn encode_array_in_place(buffer: &mut [u8], arr: &[Value], position: &mut usize) -> Result<(), SerializationError> {
+fn encode_array_into(buffer: &mut [u8], arr: &[Value], position: &mut usize) -> Result<(), SerializationError> {
   // Array start marker
   let mut temp_buffer: [u8; 1] = [0; 1];
   let size = serialize_array_begin(&mut temp_buffer)?;
-  write_bytes_in_place(buffer, &temp_buffer[..size], position)?;
+  write_bytes_into(buffer, &temp_buffer[..size], position)?;
 
   // Encode each element
   for item in arr {
-    encode_value_in_place(buffer, item, position)?;
+    encode_value_into(buffer, item, position)?;
   }
 
   // Array end marker
   let mut temp_buffer: [u8; 1] = [0; 1];
   let size = serialize_container_end(&mut temp_buffer)?;
-  write_bytes_in_place(buffer, &temp_buffer[..size], position)?;
+  write_bytes_into(buffer, &temp_buffer[..size], position)?;
 
   Ok(())
 }
 
 /// Encodes an object value.
-fn encode_object_in_place(buffer: &mut [u8], obj: &HashMap<String, Value>, position: &mut usize) -> Result<(), SerializationError> {
+fn encode_object_into(buffer: &mut [u8], obj: &HashMap<String, Value>, position: &mut usize) -> Result<(), SerializationError> {
   // Object start marker
   let mut temp_buffer: [u8; 1] = [0; 1];
   let size = serialize_map_begin(&mut temp_buffer)?;
-  write_bytes_in_place(buffer, &temp_buffer[..size], position)?;
+  write_bytes_into(buffer, &temp_buffer[..size], position)?;
 
   // Encode each key-value pair
   for (key, value) in obj {
     // Encode key as string
-    encode_string_in_place(buffer, key, position)?;
+    encode_string_into(buffer, key, position)?;
     // Encode value
-    encode_value_in_place(buffer, value, position)?;
+    encode_value_into(buffer, value, position)?;
   }
 
   // Object end marker
   let mut temp_buffer: [u8; 1] = [0; 1];
   let size = serialize_container_end(&mut temp_buffer)?;
-  write_bytes_in_place(buffer, &temp_buffer[..size], position)?;
+  write_bytes_into(buffer, &temp_buffer[..size], position)?;
 
   Ok(())
 }

--- a/bd-bonjson/src/encoder_test.rs
+++ b/bd-bonjson/src/encoder_test.rs
@@ -1,0 +1,414 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use crate::decoder::Decoder;
+use crate::encoder::Encoder;
+use crate::Value;
+use std::collections::HashMap;
+
+#[test]
+fn test_encode_null() {
+  let mut encoder = Encoder::new();
+  let value = Value::Null;
+  
+  let result = encoder.encode(&value).expect("Failed to encode null");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_bool_true() {
+  let mut encoder = Encoder::new();
+  let value = Value::Bool(true);
+  
+  let result = encoder.encode(&value).expect("Failed to encode bool");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_bool_false() {
+  let mut encoder = Encoder::new();
+  let value = Value::Bool(false);
+  
+  let result = encoder.encode(&value).expect("Failed to encode bool");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_float() {
+  let mut encoder = Encoder::new();
+  let value = Value::Float(3.14159);
+  
+  let result = encoder.encode(&value).expect("Failed to encode float");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_signed_positive() {
+  let mut encoder = Encoder::new();
+  let value = Value::Signed(12345);
+  
+  let result = encoder.encode(&value).expect("Failed to encode signed");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_signed_negative() {
+  let mut encoder = Encoder::new();
+  let value = Value::Signed(-6789);
+  
+  let result = encoder.encode(&value).expect("Failed to encode signed");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_unsigned() {
+  let mut encoder = Encoder::new();
+  let value = Value::Unsigned(98765);
+  
+  let result = encoder.encode(&value).expect("Failed to encode unsigned");
+  
+  // Verify we can decode it back
+  // Note: The decoder may convert unsigned values that fit in i64 to Signed
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  
+  // Check if the value was converted to signed (this is expected behavior)
+  match decoded {
+    Value::Signed(v) => assert_eq!(v, 98765),
+    Value::Unsigned(v) => assert_eq!(v, 98765),
+    _ => panic!("Expected integer value, got {:?}", decoded),
+  }
+}
+
+#[test]
+fn test_encode_string() {
+  let mut encoder = Encoder::new();
+  let value = Value::String("Hello, World!".to_string());
+  
+  let result = encoder.encode(&value).expect("Failed to encode string");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_empty_string() {
+  let mut encoder = Encoder::new();
+  let value = Value::String(String::new());
+  
+  let result = encoder.encode(&value).expect("Failed to encode empty string");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_string_with_unicode() {
+  let mut encoder = Encoder::new();
+  let value = Value::String("🦀 Rust is awesome! 🚀".to_string());
+  
+  let result = encoder.encode(&value).expect("Failed to encode unicode string");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_empty_array() {
+  let mut encoder = Encoder::new();
+  let value = Value::Array(Vec::new());
+  
+  let result = encoder.encode(&value).expect("Failed to encode empty array");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_array_with_values() {
+  let mut encoder = Encoder::new();
+  let value = Value::Array(vec![
+    Value::Null,
+    Value::Bool(true),
+    Value::Signed(42),
+    Value::String("test".to_string()),
+  ]);
+  
+  let result = encoder.encode(&value).expect("Failed to encode array");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_nested_arrays() {
+  let mut encoder = Encoder::new();
+  let value = Value::Array(vec![
+    Value::Array(vec![Value::Signed(1), Value::Signed(2)]),
+    Value::Array(vec![Value::String("a".to_string()), Value::String("b".to_string())]),
+  ]);
+  
+  let result = encoder.encode(&value).expect("Failed to encode nested arrays");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_empty_object() {
+  let mut encoder = Encoder::new();
+  let value = Value::Object(HashMap::new());
+  
+  let result = encoder.encode(&value).expect("Failed to encode empty object");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_object_with_values() {
+  let mut encoder = Encoder::new();
+  let mut obj = HashMap::new();
+  obj.insert("null_key".to_string(), Value::Null);
+  obj.insert("bool_key".to_string(), Value::Bool(false));
+  obj.insert("number_key".to_string(), Value::Signed(123));
+  obj.insert("string_key".to_string(), Value::String("value".to_string()));
+  
+  let value = Value::Object(obj);
+  
+  let result = encoder.encode(&value).expect("Failed to encode object");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_nested_objects() {
+  let mut encoder = Encoder::new();
+  
+  let mut inner_obj = HashMap::new();
+  inner_obj.insert("inner_key".to_string(), Value::String("inner_value".to_string()));
+  
+  let mut outer_obj = HashMap::new();
+  outer_obj.insert("outer_key".to_string(), Value::Object(inner_obj));
+  outer_obj.insert("simple_key".to_string(), Value::Signed(42));
+  
+  let value = Value::Object(outer_obj);
+  
+  let result = encoder.encode(&value).expect("Failed to encode nested objects");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encode_mixed_nested_structure() {
+  let mut encoder = Encoder::new();
+  
+  let mut obj = HashMap::new();
+  obj.insert("array".to_string(), Value::Array(vec![
+    Value::Signed(1),
+    Value::Signed(2),
+    Value::Array(vec![Value::String("nested".to_string())]),
+  ]));
+  obj.insert("object".to_string(), {
+    let mut inner = HashMap::new();
+    inner.insert("key".to_string(), Value::Bool(true));
+    Value::Object(inner)
+  });
+  
+  let value = Value::Object(obj);
+  
+  let result = encoder.encode(&value).expect("Failed to encode mixed structure");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encoder_reuse() {
+  let mut encoder = Encoder::new();
+  
+  // Encode first value
+  let value1 = Value::String("first".to_string());
+  let result1 = encoder.encode(&value1).expect("Failed to encode first value");
+  
+  // Encode second value (should reuse the encoder)
+  let value2 = Value::Signed(42);
+  let result2 = encoder.encode(&value2).expect("Failed to encode second value");
+  
+  // Verify both encodings work
+  let mut decoder1 = Decoder::new(&result1);
+  let decoded1 = decoder1.decode().expect("Failed to decode first");
+  assert_eq!(decoded1, value1);
+  
+  let mut decoder2 = Decoder::new(&result2);
+  let decoded2 = decoder2.decode().expect("Failed to decode second");
+  assert_eq!(decoded2, value2);
+}
+
+#[test]
+fn test_encoder_with_capacity() {
+  let mut encoder = Encoder::with_capacity(1024);
+  let value = Value::String("test".to_string());
+  
+  let result = encoder.encode(&value).expect("Failed to encode with capacity");
+  
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value);
+}
+
+#[test]
+fn test_encoder_clear() {
+  let mut encoder = Encoder::new();
+  
+  // Encode a value
+  let value = Value::String("test".to_string());
+  encoder.encode(&value).expect("Failed to encode");
+  
+  // Clear and encode another value
+  encoder.clear();
+  let value2 = Value::Signed(123);
+  let result = encoder.encode(&value2).expect("Failed to encode after clear");
+  
+  // Verify the second encoding works
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value2);
+}
+
+#[test]
+fn test_encoder_buffer_access() {
+  let mut encoder = Encoder::new();
+  let value = Value::String("test".to_string());
+  
+  encoder.encode(&value).expect("Failed to encode");
+  
+  // Access buffer without consuming encoder
+  let buffer = encoder.buffer();
+  assert!(!buffer.is_empty());
+  
+  // Verify we can still use the encoder
+  let value2 = Value::Signed(456);
+  encoder.encode(&value2).expect("Failed to encode again");
+}
+
+#[test]
+fn test_encode_large_numbers() {
+  let mut encoder = Encoder::new();
+  
+  // Test large positive signed
+  let value1 = Value::Signed(i64::MAX);
+  let result1 = encoder.encode(&value1).expect("Failed to encode large positive");
+  let mut decoder1 = Decoder::new(&result1);
+  let decoded1 = decoder1.decode().expect("Failed to decode");
+  assert_eq!(decoded1, value1);
+  
+  // Test large negative signed
+  let value2 = Value::Signed(i64::MIN);
+  let result2 = encoder.encode(&value2).expect("Failed to encode large negative");
+  let mut decoder2 = Decoder::new(&result2);
+  let decoded2 = decoder2.decode().expect("Failed to decode");
+  assert_eq!(decoded2, value2);
+  
+  // Test large unsigned that requires staying unsigned
+  let value3 = Value::Unsigned(u64::MAX);
+  let result3 = encoder.encode(&value3).expect("Failed to encode large unsigned");
+  let mut decoder3 = Decoder::new(&result3);
+  let decoded3 = decoder3.decode().expect("Failed to decode");
+  assert_eq!(decoded3, value3); // u64::MAX cannot fit in i64, so should stay unsigned
+}
+
+#[test]
+fn test_encode_special_floats() {
+  let mut encoder = Encoder::new();
+  
+  // Test zero
+  let value1 = Value::Float(0.0);
+  let result1 = encoder.encode(&value1).expect("Failed to encode zero");
+  let mut decoder1 = Decoder::new(&result1);
+  let decoded1 = decoder1.decode().expect("Failed to decode");
+  assert_eq!(decoded1, value1);
+  
+  // Test negative zero
+  let value2 = Value::Float(-0.0);
+  let result2 = encoder.encode(&value2).expect("Failed to encode negative zero");
+  let mut decoder2 = Decoder::new(&result2);
+  let decoded2 = decoder2.decode().expect("Failed to decode");
+  assert_eq!(decoded2, value2);
+  
+  // Test infinity
+  let value3 = Value::Float(f64::INFINITY);
+  let result3 = encoder.encode(&value3).expect("Failed to encode infinity");
+  let mut decoder3 = Decoder::new(&result3);
+  let decoded3 = decoder3.decode().expect("Failed to decode");
+  assert_eq!(decoded3, value3);
+  
+  // Test negative infinity
+  let value4 = Value::Float(f64::NEG_INFINITY);
+  let result4 = encoder.encode(&value4).expect("Failed to encode negative infinity");
+  let mut decoder4 = Decoder::new(&result4);
+  let decoded4 = decoder4.decode().expect("Failed to decode");
+  assert_eq!(decoded4, value4);
+  
+  // Test NaN (Note: NaN != NaN, so we need special handling)
+  let value5 = Value::Float(f64::NAN);
+  let result5 = encoder.encode(&value5).expect("Failed to encode NaN");
+  let mut decoder5 = Decoder::new(&result5);
+  let decoded5 = decoder5.decode().expect("Failed to decode");
+  if let Value::Float(f) = decoded5 {
+    assert!(f.is_nan());
+  } else {
+    panic!("Expected Float value");
+  }
+}

--- a/bd-bonjson/src/encoder_test.rs
+++ b/bd-bonjson/src/encoder_test.rs
@@ -6,7 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use crate::Value;
-use crate::decoder::decode_value;
+use crate::decoder::decode;
 use crate::encoder::encode;
 use std::collections::HashMap;
 
@@ -19,7 +19,7 @@ fn test_encode_null() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -32,7 +32,7 @@ fn test_encode_bool_true() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -45,7 +45,7 @@ fn test_encode_bool_false() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -58,7 +58,7 @@ fn test_encode_float() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -71,7 +71,7 @@ fn test_encode_signed_positive() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -84,7 +84,7 @@ fn test_encode_signed_negative() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -98,7 +98,7 @@ fn test_encode_unsigned() {
   // Verify we can decode it back
   // Note: The decoder may convert unsigned values that fit in i64 to Signed
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
 
   // Check if the value was converted to signed (this is expected behavior)
   match decoded {
@@ -117,7 +117,7 @@ fn test_encode_string() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -131,7 +131,7 @@ fn test_encode_empty_string() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -145,7 +145,7 @@ fn test_encode_string_with_unicode() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -159,7 +159,7 @@ fn test_encode_empty_array() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -177,7 +177,7 @@ fn test_encode_array_with_values() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -197,7 +197,7 @@ fn test_encode_nested_arrays() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -211,7 +211,7 @@ fn test_encode_empty_object() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -230,7 +230,7 @@ fn test_encode_object_with_values() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -255,7 +255,7 @@ fn test_encode_nested_objects() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -285,7 +285,7 @@ fn test_encode_mixed_nested_structure() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -305,11 +305,11 @@ fn test_encoder_reuse() {
 
   // Verify both encodings work
   let data_slice1 = &result1;
-  let decoded1 = decode_value(data_slice1).expect("Failed to decode first");
+  let decoded1 = decode(data_slice1).expect("Failed to decode first");
   assert_eq!(decoded1, value1);
 
   let data_slice2 = &result2;
-  let decoded2 = decode_value(data_slice2).expect("Failed to decode second");
+  let decoded2 = decode(data_slice2).expect("Failed to decode second");
   assert_eq!(decoded2, value2);
 }
 
@@ -323,7 +323,7 @@ fn test_encoder_with_capacity() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -342,7 +342,7 @@ fn test_encoder_clear() {
 
   // Verify the second encoding works
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value2);
 }
 
@@ -362,7 +362,7 @@ fn test_encoder_buffer_access() {
   
   // The buffer now contains the second encoding result
   let data_slice = &second_result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value2);
 }
 
@@ -375,7 +375,7 @@ fn test_encode_large_numbers() {
   let result1 = encode(&mut buffer, &value1)
     .expect("Failed to encode");
   let data_slice1 = &result1;
-  let decoded1 = decode_value(data_slice1).expect("Failed to decode");
+  let decoded1 = decode(data_slice1).expect("Failed to decode");
   assert_eq!(decoded1, value1);
 
   // Test large negative signed
@@ -383,7 +383,7 @@ fn test_encode_large_numbers() {
   let result2 = encode(&mut buffer, &value2)
     .expect("Failed to encode");
   let data_slice2 = &result2;
-  let decoded2 = decode_value(data_slice2).expect("Failed to decode");
+  let decoded2 = decode(data_slice2).expect("Failed to decode");
   assert_eq!(decoded2, value2);
 
   // Test large unsigned that requires staying unsigned
@@ -391,7 +391,7 @@ fn test_encode_large_numbers() {
   let result3 = encode(&mut buffer, &value3)
     .expect("Failed to encode");
   let data_slice3 = &result3;
-  let decoded3 = decode_value(data_slice3).expect("Failed to decode");
+  let decoded3 = decode(data_slice3).expect("Failed to decode");
   assert_eq!(decoded3, value3); // u64::MAX cannot fit in i64, so should stay unsigned
 }
 
@@ -403,7 +403,7 @@ fn test_encode_special_floats() {
   let value1 = Value::Float(0.0);
   let result1 = encode(&mut buffer, &value1).expect("Failed to encode zero");
   let data_slice1 = &result1;
-  let decoded1 = decode_value(data_slice1).expect("Failed to decode");
+  let decoded1 = decode(data_slice1).expect("Failed to decode");
   assert_eq!(decoded1, value1);
 
   // Test negative zero
@@ -411,14 +411,14 @@ fn test_encode_special_floats() {
   let result2 = encode(&mut buffer, &value2)
     .expect("Failed to encode");
   let data_slice2 = &result2;
-  let decoded2 = decode_value(data_slice2).expect("Failed to decode");
+  let decoded2 = decode(data_slice2).expect("Failed to decode");
   assert_eq!(decoded2, value2);
 
   // Test infinity
   let value3 = Value::Float(f64::INFINITY);
   let result3 = encode(&mut buffer, &value3).expect("Failed to encode infinity");
   let data_slice3 = &result3;
-  let decoded3 = decode_value(data_slice3).expect("Failed to decode");
+  let decoded3 = decode(data_slice3).expect("Failed to decode");
   assert_eq!(decoded3, value3);
 
   // Test negative infinity
@@ -426,14 +426,14 @@ fn test_encode_special_floats() {
   let result4 = encode(&mut buffer, &value4)
     .expect("Failed to encode");
   let data_slice4 = &result4;
-  let decoded4 = decode_value(data_slice4).expect("Failed to decode");
+  let decoded4 = decode(data_slice4).expect("Failed to decode");
   assert_eq!(decoded4, value4);
 
   // Test NaN (Note: NaN != NaN, so we need special handling)
   let value5 = Value::Float(f64::NAN);
   let result5 = encode(&mut buffer, &value5).expect("Failed to encode NaN");
   let data_slice5 = &result5;
-  let decoded5 = decode_value(data_slice5).expect("Failed to decode");
+  let decoded5 = decode(data_slice5).expect("Failed to decode");
   if let Value::Float(f) = decoded5 {
     assert!(f.is_nan());
   } else {
@@ -559,7 +559,7 @@ fn test_encode_deeply_nested_mixed_structures() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice)
+  let decoded = decode(data_slice)
     .expect("Failed to decode deeply nested structure");
 
   // Since HashMap order is not guaranteed, we'll verify the structure piece by piece
@@ -763,7 +763,7 @@ fn test_in_place_encode_null() {
 
   // Verify we can decode it back
   let data_slice = &buffer[.. bytes_written];
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -777,7 +777,7 @@ fn test_in_place_encode_bool() {
 
   // Verify we can decode it back
   let data_slice = &buffer[.. bytes_written];
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -790,7 +790,7 @@ fn test_in_place_encode_string() {
 
   // Verify we can decode it back
   let data_slice = &buffer[.. bytes_written];
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -807,7 +807,7 @@ fn test_in_place_encode_array() {
 
   // Verify we can decode it back
   let data_slice = &buffer[.. bytes_written];
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -824,7 +824,7 @@ fn test_in_place_encode_object() {
 
   // Verify we can decode it back
   let data_slice = &buffer[.. bytes_written];
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
 
   // Since HashMap ordering is not guaranteed, we need to check content differently
   if let Value::Object(decoded_obj) = decoded {
@@ -876,7 +876,7 @@ fn test_in_place_encode_exact_fit() {
 
   // Verify we can decode it back
   let data_slice = &buffer[.. bytes_written];
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -894,7 +894,7 @@ fn test_in_place_encode_reuse() {
 
   // Verify the second value overwrote the first
   let data_slice = &buffer[.. bytes_written2];
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value2);
 }
 
@@ -913,7 +913,7 @@ fn test_in_place_encode_deeply_nested() {
 
   // Verify we can decode it back
   let data_slice = &buffer[.. bytes_written];
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, nested_value);
 }
 
@@ -931,13 +931,13 @@ fn test_standalone_encode_function() {
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode_value(data_slice).expect("Failed to decode");
+  let decoded = decode(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 
   // Verify buffer was reused correctly
   let second_value = Value::String("second test".to_string());
   let second_result = encode(&mut buffer, &second_value).expect("Failed to encode second value");
   
-  let second_decoded = decode_value(&second_result).expect("Failed to decode second value");
+  let second_decoded = decode(&second_result).expect("Failed to decode second value");
   assert_eq!(second_decoded, second_value);
 }

--- a/bd-bonjson/src/encoder_test.rs
+++ b/bd-bonjson/src/encoder_test.rs
@@ -126,8 +126,7 @@ fn test_encode_empty_string() {
   let mut buffer = Vec::new();
   let value = Value::String(String::new());
 
-  let result = encode(&mut buffer, &value)
-    .expect("Failed to encode");
+  let result = encode(&mut buffer, &value).expect("Failed to encode");
 
   // Verify we can decode it back
   let data_slice = &result;
@@ -140,8 +139,7 @@ fn test_encode_string_with_unicode() {
   let mut buffer = Vec::new();
   let value = Value::String("🦀 Rust is awesome! 🚀".to_string());
 
-  let result = encode(&mut buffer, &value)
-    .expect("Failed to encode");
+  let result = encode(&mut buffer, &value).expect("Failed to encode");
 
   // Verify we can decode it back
   let data_slice = &result;
@@ -154,8 +152,7 @@ fn test_encode_empty_array() {
   let mut buffer = Vec::new();
   let value = Value::Array(Vec::new());
 
-  let result = encode(&mut buffer, &value)
-    .expect("Failed to encode");
+  let result = encode(&mut buffer, &value).expect("Failed to encode");
 
   // Verify we can decode it back
   let data_slice = &result;
@@ -192,8 +189,7 @@ fn test_encode_nested_arrays() {
     ]),
   ]);
 
-  let result = encode(&mut buffer, &value)
-    .expect("Failed to encode");
+  let result = encode(&mut buffer, &value).expect("Failed to encode");
 
   // Verify we can decode it back
   let data_slice = &result;
@@ -206,8 +202,7 @@ fn test_encode_empty_object() {
   let mut buffer = Vec::new();
   let value = Value::Object(HashMap::new());
 
-  let result = encode(&mut buffer, &value)
-    .expect("Failed to encode");
+  let result = encode(&mut buffer, &value).expect("Failed to encode");
 
   // Verify we can decode it back
   let data_slice = &result;
@@ -250,8 +245,7 @@ fn test_encode_nested_objects() {
 
   let value = Value::Object(outer_obj);
 
-  let result = encode(&mut buffer, &value)
-    .expect("Failed to encode");
+  let result = encode(&mut buffer, &value).expect("Failed to encode");
 
   // Verify we can decode it back
   let data_slice = &result;
@@ -280,8 +274,7 @@ fn test_encode_mixed_nested_structure() {
 
   let value = Value::Object(obj);
 
-  let result = encode(&mut buffer, &value)
-    .expect("Failed to encode");
+  let result = encode(&mut buffer, &value).expect("Failed to encode");
 
   // Verify we can decode it back
   let data_slice = &result;
@@ -295,13 +288,11 @@ fn test_encoder_reuse() {
 
   // Encode first value
   let value1 = Value::String("first".to_string());
-  let result1 = encode(&mut buffer, &value1)
-    .expect("Failed to encode");
+  let result1 = encode(&mut buffer, &value1).expect("Failed to encode");
 
   // Encode second value (should reuse the encoder)
   let value2 = Value::Signed(42);
-  let result2 = encode(&mut buffer, &value2)
-    .expect("Failed to encode");
+  let result2 = encode(&mut buffer, &value2).expect("Failed to encode");
 
   // Verify both encodings work
   let data_slice1 = &result1;
@@ -318,8 +309,7 @@ fn test_encoder_with_capacity() {
   let mut buffer = Vec::with_capacity(1024);
   let value = Value::String("test".to_string());
 
-  let result = encode(&mut buffer, &value)
-    .expect("Failed to encode");
+  let result = encode(&mut buffer, &value).expect("Failed to encode");
 
   // Verify we can decode it back
   let data_slice = &result;
@@ -359,7 +349,7 @@ fn test_encoder_buffer_access() {
   // Verify we can still use the buffer for more encoding
   let value2 = Value::Signed(456);
   let second_result = encode(&mut buffer, &value2).expect("Failed to encode again");
-  
+
   // The buffer now contains the second encoding result
   let data_slice = &second_result;
   let decoded = decode(data_slice).expect("Failed to decode");
@@ -372,24 +362,21 @@ fn test_encode_large_numbers() {
 
   // Test large positive signed
   let value1 = Value::Signed(i64::MAX);
-  let result1 = encode(&mut buffer, &value1)
-    .expect("Failed to encode");
+  let result1 = encode(&mut buffer, &value1).expect("Failed to encode");
   let data_slice1 = &result1;
   let decoded1 = decode(data_slice1).expect("Failed to decode");
   assert_eq!(decoded1, value1);
 
   // Test large negative signed
   let value2 = Value::Signed(i64::MIN);
-  let result2 = encode(&mut buffer, &value2)
-    .expect("Failed to encode");
+  let result2 = encode(&mut buffer, &value2).expect("Failed to encode");
   let data_slice2 = &result2;
   let decoded2 = decode(data_slice2).expect("Failed to decode");
   assert_eq!(decoded2, value2);
 
   // Test large unsigned that requires staying unsigned
   let value3 = Value::Unsigned(u64::MAX);
-  let result3 = encode(&mut buffer, &value3)
-    .expect("Failed to encode");
+  let result3 = encode(&mut buffer, &value3).expect("Failed to encode");
   let data_slice3 = &result3;
   let decoded3 = decode(data_slice3).expect("Failed to decode");
   assert_eq!(decoded3, value3); // u64::MAX cannot fit in i64, so should stay unsigned
@@ -408,8 +395,7 @@ fn test_encode_special_floats() {
 
   // Test negative zero
   let value2 = Value::Float(-0.0);
-  let result2 = encode(&mut buffer, &value2)
-    .expect("Failed to encode");
+  let result2 = encode(&mut buffer, &value2).expect("Failed to encode");
   let data_slice2 = &result2;
   let decoded2 = decode(data_slice2).expect("Failed to decode");
   assert_eq!(decoded2, value2);
@@ -423,8 +409,7 @@ fn test_encode_special_floats() {
 
   // Test negative infinity
   let value4 = Value::Float(f64::NEG_INFINITY);
-  let result4 = encode(&mut buffer, &value4)
-    .expect("Failed to encode");
+  let result4 = encode(&mut buffer, &value4).expect("Failed to encode");
   let data_slice4 = &result4;
   let decoded4 = decode(data_slice4).expect("Failed to decode");
   assert_eq!(decoded4, value4);
@@ -554,13 +539,12 @@ fn test_encode_deeply_nested_mixed_structures() {
   let complex_value = Value::Object(root_obj);
 
   // Encode the complex structure
-  let result = encode(&mut buffer, &complex_value)
-    .expect("Failed to encode deeply nested structure");
+  let result =
+    encode(&mut buffer, &complex_value).expect("Failed to encode deeply nested structure");
 
   // Verify we can decode it back
   let data_slice = &result;
-  let decoded = decode(data_slice)
-    .expect("Failed to decode deeply nested structure");
+  let decoded = decode(data_slice).expect("Failed to decode deeply nested structure");
 
   // Since HashMap order is not guaranteed, we'll verify the structure piece by piece
   // instead of doing a direct equality check
@@ -937,7 +921,7 @@ fn test_standalone_encode_function() {
   // Verify buffer was reused correctly
   let second_value = Value::String("second test".to_string());
   let second_result = encode(&mut buffer, &second_value).expect("Failed to encode second value");
-  
+
   let second_decoded = decode(&second_result).expect("Failed to decode second value");
   assert_eq!(second_decoded, second_value);
 }

--- a/bd-bonjson/src/encoder_test.rs
+++ b/bd-bonjson/src/encoder_test.rs
@@ -765,7 +765,7 @@ fn test_encode_deeply_nested_mixed_structures() {
 
 // Tests for in-place encoding
 
-use crate::encoder::encode_in_place;
+use crate::encoder::encode_into;
 use crate::serialize_primitives::SerializationError;
 
 #[test]
@@ -773,7 +773,7 @@ fn test_in_place_encode_null() {
   let mut buffer = [0u8; 16];
   let value = Value::Null;
 
-  let bytes_written = encode_in_place(&mut buffer, &value).expect("Failed to encode null");
+  let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode null");
   assert_eq!(bytes_written, 1);
 
   // Verify we can decode it back
@@ -787,7 +787,7 @@ fn test_in_place_encode_bool() {
   let mut buffer = [0u8; 16];
   let value = Value::Bool(true);
 
-  let bytes_written = encode_in_place(&mut buffer, &value).expect("Failed to encode bool");
+  let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode bool");
   assert_eq!(bytes_written, 1);
 
   // Verify we can decode it back
@@ -801,7 +801,7 @@ fn test_in_place_encode_string() {
   let mut buffer = [0u8; 32];
   let value = Value::String("hello".to_string());
 
-  let bytes_written = encode_in_place(&mut buffer, &value).expect("Failed to encode string");
+  let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode string");
   
   // Verify we can decode it back
   let mut decoder = Decoder::new(&buffer[..bytes_written]);
@@ -818,7 +818,7 @@ fn test_in_place_encode_array() {
     Value::String("test".to_string()),
   ]);
 
-  let bytes_written = encode_in_place(&mut buffer, &value).expect("Failed to encode array");
+  let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode array");
   
   // Verify we can decode it back
   let mut decoder = Decoder::new(&buffer[..bytes_written]);
@@ -835,7 +835,7 @@ fn test_in_place_encode_object() {
   obj.insert("age".to_string(), Value::Signed(25));
   let value = Value::Object(obj);
 
-  let bytes_written = encode_in_place(&mut buffer, &value).expect("Failed to encode object");
+  let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode object");
   
   // Verify we can decode it back
   let mut decoder = Decoder::new(&buffer[..bytes_written]);
@@ -856,7 +856,7 @@ fn test_in_place_encode_buffer_full() {
   let mut buffer = [0u8; 2]; // Very small buffer
   let value = Value::String("this is a long string that won't fit".to_string());
 
-  let result = encode_in_place(&mut buffer, &value);
+  let result = encode_into(&mut buffer, &value);
   assert!(result.is_err());
   assert_eq!(result.unwrap_err(), SerializationError::BufferFull);
 }
@@ -866,13 +866,13 @@ fn test_in_place_encode_position_tracking() {
   let mut buffer = [0u8; 16];
   
   let value = Value::Null;
-  let bytes_written = encode_in_place(&mut buffer, &value).expect("Failed to encode null");
+  let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode null");
   
   assert_eq!(bytes_written, 1);
   
   // Second encode should start fresh (functions are stateless)
   let value2 = Value::Bool(true);
-  let bytes_written2 = encode_in_place(&mut buffer, &value2).expect("Failed to encode bool");
+  let bytes_written2 = encode_into(&mut buffer, &value2).expect("Failed to encode bool");
   
   assert_eq!(bytes_written2, 1);
 }
@@ -883,7 +883,7 @@ fn test_in_place_encode_exact_fit() {
   let mut buffer = [0u8; 8]; // Exactly the size needed for a small signed integer
   let value = Value::Signed(42);
 
-  let bytes_written = encode_in_place(&mut buffer, &value).expect("Failed to encode");
+  let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode");
   assert!(bytes_written <= buffer.len());
   
   // Verify we can decode it back
@@ -898,11 +898,11 @@ fn test_in_place_encode_reuse() {
   
   // First encoding
   let value1 = Value::Signed(123);
-  encode_in_place(&mut buffer, &value1).expect("Failed to encode first value");
+  encode_into(&mut buffer, &value1).expect("Failed to encode first value");
   
   // Second encoding (functions are stateless, so each call starts from position 0)
   let value2 = Value::String("hello".to_string());
-  let bytes_written2 = encode_in_place(&mut buffer, &value2).expect("Failed to encode second value");
+  let bytes_written2 = encode_into(&mut buffer, &value2).expect("Failed to encode second value");
   
   // Verify the second value overwrote the first
   let mut decoder = Decoder::new(&buffer[..bytes_written2]);
@@ -924,7 +924,7 @@ fn test_in_place_encode_deeply_nested() {
     ]),
   ]);
 
-  let bytes_written = encode_in_place(&mut buffer, &nested_value).expect("Failed to encode nested structure");
+  let bytes_written = encode_into(&mut buffer, &nested_value).expect("Failed to encode nested structure");
   
   // Verify we can decode it back
   let mut decoder = Decoder::new(&buffer[..bytes_written]);

--- a/bd-bonjson/src/encoder_test.rs
+++ b/bd-bonjson/src/encoder_test.rs
@@ -6,7 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use crate::Value;
-use crate::decoder::Decoder;
+use crate::decoder::decode_value;
 use crate::encoder::encode;
 use std::collections::HashMap;
 
@@ -18,8 +18,8 @@ fn test_encode_null() {
   let result = encode(&mut buffer, &value).expect("Failed to encode null");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -31,8 +31,8 @@ fn test_encode_bool_true() {
   let result = encode(&mut buffer, &value).expect("Failed to encode bool");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -44,8 +44,8 @@ fn test_encode_bool_false() {
   let result = encode(&mut buffer, &value).expect("Failed to encode bool");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -57,8 +57,8 @@ fn test_encode_float() {
   let result = encode(&mut buffer, &value).expect("Failed to encode float");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -70,8 +70,8 @@ fn test_encode_signed_positive() {
   let result = encode(&mut buffer, &value).expect("Failed to encode signed");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -83,8 +83,8 @@ fn test_encode_signed_negative() {
   let result = encode(&mut buffer, &value).expect("Failed to encode signed");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -97,8 +97,8 @@ fn test_encode_unsigned() {
 
   // Verify we can decode it back
   // Note: The decoder may convert unsigned values that fit in i64 to Signed
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
 
   // Check if the value was converted to signed (this is expected behavior)
   match decoded {
@@ -116,8 +116,8 @@ fn test_encode_string() {
   let result = encode(&mut buffer, &value).expect("Failed to encode string");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -130,8 +130,8 @@ fn test_encode_empty_string() {
     .expect("Failed to encode");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -144,8 +144,8 @@ fn test_encode_string_with_unicode() {
     .expect("Failed to encode");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -158,8 +158,8 @@ fn test_encode_empty_array() {
     .expect("Failed to encode");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -176,8 +176,8 @@ fn test_encode_array_with_values() {
   let result = encode(&mut buffer, &value).expect("Failed to encode array");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -196,8 +196,8 @@ fn test_encode_nested_arrays() {
     .expect("Failed to encode");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -210,8 +210,8 @@ fn test_encode_empty_object() {
     .expect("Failed to encode");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -229,8 +229,8 @@ fn test_encode_object_with_values() {
   let result = encode(&mut buffer, &value).expect("Failed to encode object");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -254,8 +254,8 @@ fn test_encode_nested_objects() {
     .expect("Failed to encode");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -284,8 +284,8 @@ fn test_encode_mixed_nested_structure() {
     .expect("Failed to encode");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -304,12 +304,12 @@ fn test_encoder_reuse() {
     .expect("Failed to encode");
 
   // Verify both encodings work
-  let mut decoder1 = Decoder::new(&result1);
-  let decoded1 = decoder1.decode().expect("Failed to decode first");
+  let data_slice1 = &result1;
+  let decoded1 = decode_value(data_slice1).expect("Failed to decode first");
   assert_eq!(decoded1, value1);
 
-  let mut decoder2 = Decoder::new(&result2);
-  let decoded2 = decoder2.decode().expect("Failed to decode second");
+  let data_slice2 = &result2;
+  let decoded2 = decode_value(data_slice2).expect("Failed to decode second");
   assert_eq!(decoded2, value2);
 }
 
@@ -322,8 +322,8 @@ fn test_encoder_with_capacity() {
     .expect("Failed to encode");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -341,8 +341,8 @@ fn test_encoder_clear() {
   let result = encode(&mut buffer, &value2).expect("Failed to encode after clear");
 
   // Verify the second encoding works
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value2);
 }
 
@@ -361,8 +361,8 @@ fn test_encoder_buffer_access() {
   let second_result = encode(&mut buffer, &value2).expect("Failed to encode again");
   
   // The buffer now contains the second encoding result
-  let mut decoder = Decoder::new(&second_result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &second_result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value2);
 }
 
@@ -374,24 +374,24 @@ fn test_encode_large_numbers() {
   let value1 = Value::Signed(i64::MAX);
   let result1 = encode(&mut buffer, &value1)
     .expect("Failed to encode");
-  let mut decoder1 = Decoder::new(&result1);
-  let decoded1 = decoder1.decode().expect("Failed to decode");
+  let data_slice1 = &result1;
+  let decoded1 = decode_value(data_slice1).expect("Failed to decode");
   assert_eq!(decoded1, value1);
 
   // Test large negative signed
   let value2 = Value::Signed(i64::MIN);
   let result2 = encode(&mut buffer, &value2)
     .expect("Failed to encode");
-  let mut decoder2 = Decoder::new(&result2);
-  let decoded2 = decoder2.decode().expect("Failed to decode");
+  let data_slice2 = &result2;
+  let decoded2 = decode_value(data_slice2).expect("Failed to decode");
   assert_eq!(decoded2, value2);
 
   // Test large unsigned that requires staying unsigned
   let value3 = Value::Unsigned(u64::MAX);
   let result3 = encode(&mut buffer, &value3)
     .expect("Failed to encode");
-  let mut decoder3 = Decoder::new(&result3);
-  let decoded3 = decoder3.decode().expect("Failed to decode");
+  let data_slice3 = &result3;
+  let decoded3 = decode_value(data_slice3).expect("Failed to decode");
   assert_eq!(decoded3, value3); // u64::MAX cannot fit in i64, so should stay unsigned
 }
 
@@ -402,38 +402,38 @@ fn test_encode_special_floats() {
   // Test zero
   let value1 = Value::Float(0.0);
   let result1 = encode(&mut buffer, &value1).expect("Failed to encode zero");
-  let mut decoder1 = Decoder::new(&result1);
-  let decoded1 = decoder1.decode().expect("Failed to decode");
+  let data_slice1 = &result1;
+  let decoded1 = decode_value(data_slice1).expect("Failed to decode");
   assert_eq!(decoded1, value1);
 
   // Test negative zero
   let value2 = Value::Float(-0.0);
   let result2 = encode(&mut buffer, &value2)
     .expect("Failed to encode");
-  let mut decoder2 = Decoder::new(&result2);
-  let decoded2 = decoder2.decode().expect("Failed to decode");
+  let data_slice2 = &result2;
+  let decoded2 = decode_value(data_slice2).expect("Failed to decode");
   assert_eq!(decoded2, value2);
 
   // Test infinity
   let value3 = Value::Float(f64::INFINITY);
   let result3 = encode(&mut buffer, &value3).expect("Failed to encode infinity");
-  let mut decoder3 = Decoder::new(&result3);
-  let decoded3 = decoder3.decode().expect("Failed to decode");
+  let data_slice3 = &result3;
+  let decoded3 = decode_value(data_slice3).expect("Failed to decode");
   assert_eq!(decoded3, value3);
 
   // Test negative infinity
   let value4 = Value::Float(f64::NEG_INFINITY);
   let result4 = encode(&mut buffer, &value4)
     .expect("Failed to encode");
-  let mut decoder4 = Decoder::new(&result4);
-  let decoded4 = decoder4.decode().expect("Failed to decode");
+  let data_slice4 = &result4;
+  let decoded4 = decode_value(data_slice4).expect("Failed to decode");
   assert_eq!(decoded4, value4);
 
   // Test NaN (Note: NaN != NaN, so we need special handling)
   let value5 = Value::Float(f64::NAN);
   let result5 = encode(&mut buffer, &value5).expect("Failed to encode NaN");
-  let mut decoder5 = Decoder::new(&result5);
-  let decoded5 = decoder5.decode().expect("Failed to decode");
+  let data_slice5 = &result5;
+  let decoded5 = decode_value(data_slice5).expect("Failed to decode");
   if let Value::Float(f) = decoded5 {
     assert!(f.is_nan());
   } else {
@@ -558,9 +558,8 @@ fn test_encode_deeply_nested_mixed_structures() {
     .expect("Failed to encode deeply nested structure");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder
-    .decode()
+  let data_slice = &result;
+  let decoded = decode_value(data_slice)
     .expect("Failed to decode deeply nested structure");
 
   // Since HashMap order is not guaranteed, we'll verify the structure piece by piece
@@ -763,8 +762,8 @@ fn test_in_place_encode_null() {
   assert_eq!(bytes_written, 1);
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &buffer[.. bytes_written];
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -777,8 +776,8 @@ fn test_in_place_encode_bool() {
   assert_eq!(bytes_written, 1);
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &buffer[.. bytes_written];
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -790,8 +789,8 @@ fn test_in_place_encode_string() {
   let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode string");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &buffer[.. bytes_written];
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -807,8 +806,8 @@ fn test_in_place_encode_array() {
   let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode array");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &buffer[.. bytes_written];
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -824,8 +823,8 @@ fn test_in_place_encode_object() {
   let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode object");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &buffer[.. bytes_written];
+  let decoded = decode_value(data_slice).expect("Failed to decode");
 
   // Since HashMap ordering is not guaranteed, we need to check content differently
   if let Value::Object(decoded_obj) = decoded {
@@ -876,8 +875,8 @@ fn test_in_place_encode_exact_fit() {
   assert!(bytes_written <= buffer.len());
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &buffer[.. bytes_written];
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 }
 
@@ -894,8 +893,8 @@ fn test_in_place_encode_reuse() {
   let bytes_written2 = encode_into(&mut buffer, &value2).expect("Failed to encode second value");
 
   // Verify the second value overwrote the first
-  let mut decoder = Decoder::new(&buffer[.. bytes_written2]);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &buffer[.. bytes_written2];
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value2);
 }
 
@@ -913,8 +912,8 @@ fn test_in_place_encode_deeply_nested() {
     encode_into(&mut buffer, &nested_value).expect("Failed to encode nested structure");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &buffer[.. bytes_written];
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, nested_value);
 }
 
@@ -931,15 +930,14 @@ fn test_standalone_encode_function() {
   let result = encode(&mut buffer, &value).expect("Failed to encode with standalone function");
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&result);
-  let decoded = decoder.decode().expect("Failed to decode");
+  let data_slice = &result;
+  let decoded = decode_value(data_slice).expect("Failed to decode");
   assert_eq!(decoded, value);
 
   // Verify buffer was reused correctly
   let second_value = Value::String("second test".to_string());
   let second_result = encode(&mut buffer, &second_value).expect("Failed to encode second value");
   
-  let mut second_decoder = Decoder::new(&second_result);
-  let second_decoded = second_decoder.decode().expect("Failed to decode second value");
+  let second_decoded = decode_value(&second_result).expect("Failed to decode second value");
   assert_eq!(second_decoded, second_value);
 }

--- a/bd-bonjson/src/encoder_test.rs
+++ b/bd-bonjson/src/encoder_test.rs
@@ -288,19 +288,21 @@ fn test_encoder_reuse() {
 
   // Encode first value
   let value1 = Value::String("first".to_string());
-  let result1 = encode(&mut buffer, &value1).expect("Failed to encode");
+  let result1 = encode(&mut buffer, &value1)
+    .expect("Failed to encode")
+    .to_vec();
 
   // Encode second value (should reuse the encoder)
   let value2 = Value::Signed(42);
-  let result2 = encode(&mut buffer, &value2).expect("Failed to encode");
+  let result2 = encode(&mut buffer, &value2)
+    .expect("Failed to encode")
+    .to_vec();
 
   // Verify both encodings work
-  let data_slice1 = &result1;
-  let decoded1 = decode(data_slice1).expect("Failed to decode first");
+  let decoded1 = decode(&result1).expect("Failed to decode first");
   assert_eq!(decoded1, value1);
 
-  let data_slice2 = &result2;
-  let decoded2 = decode(data_slice2).expect("Failed to decode second");
+  let decoded2 = decode(&result2).expect("Failed to decode second");
   assert_eq!(decoded2, value2);
 }
 

--- a/bd-bonjson/src/encoder_test.rs
+++ b/bd-bonjson/src/encoder_test.rs
@@ -5,18 +5,18 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
+use crate::Value;
 use crate::decoder::Decoder;
 use crate::encoder::Encoder;
-use crate::Value;
 use std::collections::HashMap;
 
 #[test]
 fn test_encode_null() {
   let mut encoder = Encoder::new();
   let value = Value::Null;
-  
+
   let result = encoder.encode(&value).expect("Failed to encode null");
-  
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -27,9 +27,9 @@ fn test_encode_null() {
 fn test_encode_bool_true() {
   let mut encoder = Encoder::new();
   let value = Value::Bool(true);
-  
+
   let result = encoder.encode(&value).expect("Failed to encode bool");
-  
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -40,9 +40,9 @@ fn test_encode_bool_true() {
 fn test_encode_bool_false() {
   let mut encoder = Encoder::new();
   let value = Value::Bool(false);
-  
+
   let result = encoder.encode(&value).expect("Failed to encode bool");
-  
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -53,9 +53,9 @@ fn test_encode_bool_false() {
 fn test_encode_float() {
   let mut encoder = Encoder::new();
   let value = Value::Float(3.14159);
-  
+
   let result = encoder.encode(&value).expect("Failed to encode float");
-  
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -66,9 +66,9 @@ fn test_encode_float() {
 fn test_encode_signed_positive() {
   let mut encoder = Encoder::new();
   let value = Value::Signed(12345);
-  
+
   let result = encoder.encode(&value).expect("Failed to encode signed");
-  
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -79,9 +79,9 @@ fn test_encode_signed_positive() {
 fn test_encode_signed_negative() {
   let mut encoder = Encoder::new();
   let value = Value::Signed(-6789);
-  
+
   let result = encoder.encode(&value).expect("Failed to encode signed");
-  
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -92,14 +92,14 @@ fn test_encode_signed_negative() {
 fn test_encode_unsigned() {
   let mut encoder = Encoder::new();
   let value = Value::Unsigned(98765);
-  
+
   let result = encoder.encode(&value).expect("Failed to encode unsigned");
-  
+
   // Verify we can decode it back
   // Note: The decoder may convert unsigned values that fit in i64 to Signed
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
-  
+
   // Check if the value was converted to signed (this is expected behavior)
   match decoded {
     Value::Signed(v) => assert_eq!(v, 98765),
@@ -112,9 +112,9 @@ fn test_encode_unsigned() {
 fn test_encode_string() {
   let mut encoder = Encoder::new();
   let value = Value::String("Hello, World!".to_string());
-  
+
   let result = encoder.encode(&value).expect("Failed to encode string");
-  
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -125,9 +125,11 @@ fn test_encode_string() {
 fn test_encode_empty_string() {
   let mut encoder = Encoder::new();
   let value = Value::String(String::new());
-  
-  let result = encoder.encode(&value).expect("Failed to encode empty string");
-  
+
+  let result = encoder
+    .encode(&value)
+    .expect("Failed to encode empty string");
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -138,9 +140,11 @@ fn test_encode_empty_string() {
 fn test_encode_string_with_unicode() {
   let mut encoder = Encoder::new();
   let value = Value::String("🦀 Rust is awesome! 🚀".to_string());
-  
-  let result = encoder.encode(&value).expect("Failed to encode unicode string");
-  
+
+  let result = encoder
+    .encode(&value)
+    .expect("Failed to encode unicode string");
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -151,9 +155,11 @@ fn test_encode_string_with_unicode() {
 fn test_encode_empty_array() {
   let mut encoder = Encoder::new();
   let value = Value::Array(Vec::new());
-  
-  let result = encoder.encode(&value).expect("Failed to encode empty array");
-  
+
+  let result = encoder
+    .encode(&value)
+    .expect("Failed to encode empty array");
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -169,9 +175,9 @@ fn test_encode_array_with_values() {
     Value::Signed(42),
     Value::String("test".to_string()),
   ]);
-  
+
   let result = encoder.encode(&value).expect("Failed to encode array");
-  
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -183,11 +189,16 @@ fn test_encode_nested_arrays() {
   let mut encoder = Encoder::new();
   let value = Value::Array(vec![
     Value::Array(vec![Value::Signed(1), Value::Signed(2)]),
-    Value::Array(vec![Value::String("a".to_string()), Value::String("b".to_string())]),
+    Value::Array(vec![
+      Value::String("a".to_string()),
+      Value::String("b".to_string()),
+    ]),
   ]);
-  
-  let result = encoder.encode(&value).expect("Failed to encode nested arrays");
-  
+
+  let result = encoder
+    .encode(&value)
+    .expect("Failed to encode nested arrays");
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -198,9 +209,11 @@ fn test_encode_nested_arrays() {
 fn test_encode_empty_object() {
   let mut encoder = Encoder::new();
   let value = Value::Object(HashMap::new());
-  
-  let result = encoder.encode(&value).expect("Failed to encode empty object");
-  
+
+  let result = encoder
+    .encode(&value)
+    .expect("Failed to encode empty object");
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -215,11 +228,11 @@ fn test_encode_object_with_values() {
   obj.insert("bool_key".to_string(), Value::Bool(false));
   obj.insert("number_key".to_string(), Value::Signed(123));
   obj.insert("string_key".to_string(), Value::String("value".to_string()));
-  
+
   let value = Value::Object(obj);
-  
+
   let result = encoder.encode(&value).expect("Failed to encode object");
-  
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -229,18 +242,23 @@ fn test_encode_object_with_values() {
 #[test]
 fn test_encode_nested_objects() {
   let mut encoder = Encoder::new();
-  
+
   let mut inner_obj = HashMap::new();
-  inner_obj.insert("inner_key".to_string(), Value::String("inner_value".to_string()));
-  
+  inner_obj.insert(
+    "inner_key".to_string(),
+    Value::String("inner_value".to_string()),
+  );
+
   let mut outer_obj = HashMap::new();
   outer_obj.insert("outer_key".to_string(), Value::Object(inner_obj));
   outer_obj.insert("simple_key".to_string(), Value::Signed(42));
-  
+
   let value = Value::Object(outer_obj);
-  
-  let result = encoder.encode(&value).expect("Failed to encode nested objects");
-  
+
+  let result = encoder
+    .encode(&value)
+    .expect("Failed to encode nested objects");
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -250,23 +268,28 @@ fn test_encode_nested_objects() {
 #[test]
 fn test_encode_mixed_nested_structure() {
   let mut encoder = Encoder::new();
-  
+
   let mut obj = HashMap::new();
-  obj.insert("array".to_string(), Value::Array(vec![
-    Value::Signed(1),
-    Value::Signed(2),
-    Value::Array(vec![Value::String("nested".to_string())]),
-  ]));
+  obj.insert(
+    "array".to_string(),
+    Value::Array(vec![
+      Value::Signed(1),
+      Value::Signed(2),
+      Value::Array(vec![Value::String("nested".to_string())]),
+    ]),
+  );
   obj.insert("object".to_string(), {
     let mut inner = HashMap::new();
     inner.insert("key".to_string(), Value::Bool(true));
     Value::Object(inner)
   });
-  
+
   let value = Value::Object(obj);
-  
-  let result = encoder.encode(&value).expect("Failed to encode mixed structure");
-  
+
+  let result = encoder
+    .encode(&value)
+    .expect("Failed to encode mixed structure");
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -276,20 +299,24 @@ fn test_encode_mixed_nested_structure() {
 #[test]
 fn test_encoder_reuse() {
   let mut encoder = Encoder::new();
-  
+
   // Encode first value
   let value1 = Value::String("first".to_string());
-  let result1 = encoder.encode(&value1).expect("Failed to encode first value");
-  
+  let result1 = encoder
+    .encode(&value1)
+    .expect("Failed to encode first value");
+
   // Encode second value (should reuse the encoder)
   let value2 = Value::Signed(42);
-  let result2 = encoder.encode(&value2).expect("Failed to encode second value");
-  
+  let result2 = encoder
+    .encode(&value2)
+    .expect("Failed to encode second value");
+
   // Verify both encodings work
   let mut decoder1 = Decoder::new(&result1);
   let decoded1 = decoder1.decode().expect("Failed to decode first");
   assert_eq!(decoded1, value1);
-  
+
   let mut decoder2 = Decoder::new(&result2);
   let decoded2 = decoder2.decode().expect("Failed to decode second");
   assert_eq!(decoded2, value2);
@@ -299,9 +326,11 @@ fn test_encoder_reuse() {
 fn test_encoder_with_capacity() {
   let mut encoder = Encoder::with_capacity(1024);
   let value = Value::String("test".to_string());
-  
-  let result = encoder.encode(&value).expect("Failed to encode with capacity");
-  
+
+  let result = encoder
+    .encode(&value)
+    .expect("Failed to encode with capacity");
+
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -311,16 +340,18 @@ fn test_encoder_with_capacity() {
 #[test]
 fn test_encoder_clear() {
   let mut encoder = Encoder::new();
-  
+
   // Encode a value
   let value = Value::String("test".to_string());
   encoder.encode(&value).expect("Failed to encode");
-  
+
   // Clear and encode another value
   encoder.clear();
   let value2 = Value::Signed(123);
-  let result = encoder.encode(&value2).expect("Failed to encode after clear");
-  
+  let result = encoder
+    .encode(&value2)
+    .expect("Failed to encode after clear");
+
   // Verify the second encoding works
   let mut decoder = Decoder::new(&result);
   let decoded = decoder.decode().expect("Failed to decode");
@@ -331,13 +362,13 @@ fn test_encoder_clear() {
 fn test_encoder_buffer_access() {
   let mut encoder = Encoder::new();
   let value = Value::String("test".to_string());
-  
+
   encoder.encode(&value).expect("Failed to encode");
-  
+
   // Access buffer without consuming encoder
   let buffer = encoder.buffer();
   assert!(!buffer.is_empty());
-  
+
   // Verify we can still use the encoder
   let value2 = Value::Signed(456);
   encoder.encode(&value2).expect("Failed to encode again");
@@ -346,24 +377,30 @@ fn test_encoder_buffer_access() {
 #[test]
 fn test_encode_large_numbers() {
   let mut encoder = Encoder::new();
-  
+
   // Test large positive signed
   let value1 = Value::Signed(i64::MAX);
-  let result1 = encoder.encode(&value1).expect("Failed to encode large positive");
+  let result1 = encoder
+    .encode(&value1)
+    .expect("Failed to encode large positive");
   let mut decoder1 = Decoder::new(&result1);
   let decoded1 = decoder1.decode().expect("Failed to decode");
   assert_eq!(decoded1, value1);
-  
+
   // Test large negative signed
   let value2 = Value::Signed(i64::MIN);
-  let result2 = encoder.encode(&value2).expect("Failed to encode large negative");
+  let result2 = encoder
+    .encode(&value2)
+    .expect("Failed to encode large negative");
   let mut decoder2 = Decoder::new(&result2);
   let decoded2 = decoder2.decode().expect("Failed to decode");
   assert_eq!(decoded2, value2);
-  
+
   // Test large unsigned that requires staying unsigned
   let value3 = Value::Unsigned(u64::MAX);
-  let result3 = encoder.encode(&value3).expect("Failed to encode large unsigned");
+  let result3 = encoder
+    .encode(&value3)
+    .expect("Failed to encode large unsigned");
   let mut decoder3 = Decoder::new(&result3);
   let decoded3 = decoder3.decode().expect("Failed to decode");
   assert_eq!(decoded3, value3); // u64::MAX cannot fit in i64, so should stay unsigned
@@ -372,35 +409,39 @@ fn test_encode_large_numbers() {
 #[test]
 fn test_encode_special_floats() {
   let mut encoder = Encoder::new();
-  
+
   // Test zero
   let value1 = Value::Float(0.0);
   let result1 = encoder.encode(&value1).expect("Failed to encode zero");
   let mut decoder1 = Decoder::new(&result1);
   let decoded1 = decoder1.decode().expect("Failed to decode");
   assert_eq!(decoded1, value1);
-  
+
   // Test negative zero
   let value2 = Value::Float(-0.0);
-  let result2 = encoder.encode(&value2).expect("Failed to encode negative zero");
+  let result2 = encoder
+    .encode(&value2)
+    .expect("Failed to encode negative zero");
   let mut decoder2 = Decoder::new(&result2);
   let decoded2 = decoder2.decode().expect("Failed to decode");
   assert_eq!(decoded2, value2);
-  
+
   // Test infinity
   let value3 = Value::Float(f64::INFINITY);
   let result3 = encoder.encode(&value3).expect("Failed to encode infinity");
   let mut decoder3 = Decoder::new(&result3);
   let decoded3 = decoder3.decode().expect("Failed to decode");
   assert_eq!(decoded3, value3);
-  
+
   // Test negative infinity
   let value4 = Value::Float(f64::NEG_INFINITY);
-  let result4 = encoder.encode(&value4).expect("Failed to encode negative infinity");
+  let result4 = encoder
+    .encode(&value4)
+    .expect("Failed to encode negative infinity");
   let mut decoder4 = Decoder::new(&result4);
   let decoded4 = decoder4.decode().expect("Failed to decode");
   assert_eq!(decoded4, value4);
-  
+
   // Test NaN (Note: NaN != NaN, so we need special handling)
   let value5 = Value::Float(f64::NAN);
   let result5 = encoder.encode(&value5).expect("Failed to encode NaN");
@@ -410,5 +451,314 @@ fn test_encode_special_floats() {
     assert!(f.is_nan());
   } else {
     panic!("Expected Float value");
+  }
+}
+
+#[test]
+fn test_encode_deeply_nested_mixed_structures() {
+  let mut encoder = Encoder::new();
+
+  // Build a complex deeply nested structure with mixed arrays and objects
+  let mut root_obj = HashMap::new();
+
+  // Add a deeply nested array structure (5 levels deep)
+  let deep_array = Value::Array(vec![
+    Value::Array(vec![
+      Value::Array(vec![
+        Value::Array(vec![
+          Value::Array(vec![
+            Value::Signed(42),
+            Value::String("deep".to_string()),
+            Value::Bool(true),
+          ]),
+          Value::Null,
+        ]),
+        Value::Float(3.14159),
+      ]),
+      Value::String("level3".to_string()),
+    ]),
+    Value::Signed(100),
+  ]);
+  root_obj.insert("deep_arrays".to_string(), deep_array);
+
+  // Add a mixed object-array-object structure
+  let mut level1_obj = HashMap::new();
+  level1_obj.insert(
+    "data".to_string(),
+    Value::Array(vec![
+      Value::Signed(1),
+      Value::Signed(2),
+      {
+        let mut nested_obj = HashMap::new();
+        nested_obj.insert(
+          "inner".to_string(),
+          Value::Array(vec![Value::String("nested_string".to_string()), {
+            let mut deep_obj = HashMap::new();
+            deep_obj.insert("deepest".to_string(), Value::Bool(false));
+            deep_obj.insert(
+              "numbers".to_string(),
+              Value::Array(vec![
+                Value::Unsigned(u64::MAX), // Use a value that won't fit in i64
+                Value::Float(-123.456),
+                Value::Signed(-789),
+              ]),
+            );
+            Value::Object(deep_obj)
+          }]),
+        );
+        nested_obj.insert("sibling".to_string(), Value::Null);
+        Value::Object(nested_obj)
+      },
+      Value::String("after_object".to_string()),
+    ]),
+  );
+  level1_obj.insert("metadata".to_string(), Value::String("info".to_string()));
+  root_obj.insert("mixed_structure".to_string(), Value::Object(level1_obj));
+
+  // Add an array of objects with various data types
+  let objects_array = Value::Array(vec![
+    {
+      let mut obj1 = HashMap::new();
+      obj1.insert("type".to_string(), Value::String("first".to_string()));
+      obj1.insert("value".to_string(), Value::Signed(123));
+      obj1.insert("active".to_string(), Value::Bool(true));
+      Value::Object(obj1)
+    },
+    {
+      let mut obj2 = HashMap::new();
+      obj2.insert("type".to_string(), Value::String("second".to_string()));
+      obj2.insert(
+        "coordinates".to_string(),
+        Value::Array(vec![
+          Value::Float(12.34),
+          Value::Float(56.78),
+          Value::Float(90.12),
+        ]),
+      );
+      obj2.insert(
+        "tags".to_string(),
+        Value::Array(vec![
+          Value::String("tag1".to_string()),
+          Value::String("tag2".to_string()),
+        ]),
+      );
+      Value::Object(obj2)
+    },
+    {
+      let mut obj3 = HashMap::new();
+      obj3.insert("type".to_string(), Value::String("third".to_string()));
+      obj3.insert("empty_array".to_string(), Value::Array(vec![]));
+      obj3.insert("empty_object".to_string(), Value::Object(HashMap::new()));
+      obj3.insert("null_value".to_string(), Value::Null);
+      Value::Object(obj3)
+    },
+  ]);
+  root_obj.insert("object_array".to_string(), objects_array);
+
+  // Add some simple values for completeness
+  root_obj.insert(
+    "simple_string".to_string(),
+    Value::String("simple".to_string()),
+  );
+  root_obj.insert("simple_number".to_string(), Value::Signed(999));
+  root_obj.insert("simple_bool".to_string(), Value::Bool(false));
+  root_obj.insert("simple_null".to_string(), Value::Null);
+
+  let complex_value = Value::Object(root_obj);
+
+  // Encode the complex structure
+  let result = encoder
+    .encode(&complex_value)
+    .expect("Failed to encode deeply nested structure");
+
+  // Verify we can decode it back
+  let mut decoder = Decoder::new(&result);
+  let decoded = decoder
+    .decode()
+    .expect("Failed to decode deeply nested structure");
+
+  // Since HashMap order is not guaranteed, we'll verify the structure piece by piece
+  // instead of doing a direct equality check
+  if let Value::Object(root) = &decoded {
+    // Verify the structure has the expected keys
+    assert_eq!(root.len(), 7); // Should have 7 top-level keys
+    assert!(root.contains_key("deep_arrays"));
+    assert!(root.contains_key("mixed_structure"));
+    assert!(root.contains_key("object_array"));
+    assert!(root.contains_key("simple_string"));
+    assert!(root.contains_key("simple_number"));
+    assert!(root.contains_key("simple_bool"));
+    assert!(root.contains_key("simple_null"));
+
+    // Verify the deeply nested array structure
+    if let Value::Array(deep_arrays) = root.get("deep_arrays").unwrap() {
+      assert_eq!(deep_arrays.len(), 2);
+      assert_eq!(deep_arrays[1], Value::Signed(100));
+
+      if let Value::Array(level1) = &deep_arrays[0] {
+        assert_eq!(level1.len(), 2);
+        assert_eq!(level1[1], Value::String("level3".to_string()));
+
+        if let Value::Array(level2) = &level1[0] {
+          assert_eq!(level2.len(), 2);
+          assert_eq!(level2[1], Value::Float(3.14159));
+
+          if let Value::Array(level3) = &level2[0] {
+            assert_eq!(level3.len(), 2);
+            assert_eq!(level3[1], Value::Null);
+
+            if let Value::Array(level4) = &level3[0] {
+              assert_eq!(level4.len(), 3); // This array has 3 elements
+              assert_eq!(level4[0], Value::Signed(42));
+              assert_eq!(level4[1], Value::String("deep".to_string()));
+              assert_eq!(level4[2], Value::Bool(true));
+            } else {
+              panic!("Expected array at level 4");
+            }
+          } else {
+            panic!("Expected array at level 3");
+          }
+        } else {
+          panic!("Expected array at level 2");
+        }
+      } else {
+        panic!("Expected array at level 1");
+      }
+    } else {
+      panic!("Expected array for deep_arrays");
+    }
+
+    // Verify the mixed structure
+    if let Value::Object(mixed) = root.get("mixed_structure").unwrap() {
+      assert_eq!(mixed.len(), 2);
+      assert_eq!(
+        mixed.get("metadata").unwrap(),
+        &Value::String("info".to_string())
+      );
+
+      if let Value::Array(data_array) = mixed.get("data").unwrap() {
+        assert_eq!(data_array.len(), 4);
+        assert_eq!(data_array[0], Value::Signed(1));
+        assert_eq!(data_array[1], Value::Signed(2));
+        assert_eq!(data_array[3], Value::String("after_object".to_string()));
+
+        if let Value::Object(nested_obj) = &data_array[2] {
+          assert_eq!(nested_obj.len(), 2);
+          assert_eq!(nested_obj.get("sibling").unwrap(), &Value::Null);
+
+          if let Value::Array(inner_array) = nested_obj.get("inner").unwrap() {
+            assert_eq!(inner_array.len(), 2);
+            assert_eq!(inner_array[0], Value::String("nested_string".to_string()));
+
+            if let Value::Object(deep_obj) = &inner_array[1] {
+              assert_eq!(deep_obj.len(), 2);
+              assert_eq!(deep_obj.get("deepest").unwrap(), &Value::Bool(false));
+
+              if let Value::Array(numbers) = deep_obj.get("numbers").unwrap() {
+                assert_eq!(numbers.len(), 3);
+                assert_eq!(numbers[0], Value::Unsigned(u64::MAX)); // Should stay unsigned
+                assert_eq!(numbers[1], Value::Float(-123.456));
+                assert_eq!(numbers[2], Value::Signed(-789));
+              } else {
+                panic!("Expected array for numbers");
+              }
+            } else {
+              panic!("Expected object in inner array");
+            }
+          } else {
+            panic!("Expected array for inner");
+          }
+        } else {
+          panic!("Expected object in data array");
+        }
+      } else {
+        panic!("Expected array for data");
+      }
+    } else {
+      panic!("Expected object for mixed_structure");
+    }
+
+    // Verify the array of objects
+    if let Value::Array(obj_array) = root.get("object_array").unwrap() {
+      assert_eq!(obj_array.len(), 3);
+
+      // Check first object
+      if let Value::Object(obj1) = &obj_array[0] {
+        assert_eq!(obj1.len(), 3);
+        assert_eq!(
+          obj1.get("type").unwrap(),
+          &Value::String("first".to_string())
+        );
+        assert_eq!(obj1.get("value").unwrap(), &Value::Signed(123));
+        assert_eq!(obj1.get("active").unwrap(), &Value::Bool(true));
+      } else {
+        panic!("Expected object at index 0");
+      }
+
+      // Check second object with nested arrays
+      if let Value::Object(obj2) = &obj_array[1] {
+        assert_eq!(obj2.len(), 3);
+        assert_eq!(
+          obj2.get("type").unwrap(),
+          &Value::String("second".to_string())
+        );
+
+        if let Value::Array(coords) = obj2.get("coordinates").unwrap() {
+          assert_eq!(coords.len(), 3);
+          assert_eq!(coords[0], Value::Float(12.34));
+          assert_eq!(coords[1], Value::Float(56.78));
+          assert_eq!(coords[2], Value::Float(90.12));
+        } else {
+          panic!("Expected array for coordinates");
+        }
+
+        if let Value::Array(tags) = obj2.get("tags").unwrap() {
+          assert_eq!(tags.len(), 2);
+          assert_eq!(tags[0], Value::String("tag1".to_string()));
+          assert_eq!(tags[1], Value::String("tag2".to_string()));
+        } else {
+          panic!("Expected array for tags");
+        }
+      } else {
+        panic!("Expected object at index 1");
+      }
+
+      // Check third object with empty containers
+      if let Value::Object(obj3) = &obj_array[2] {
+        assert_eq!(obj3.len(), 4);
+        assert_eq!(
+          obj3.get("type").unwrap(),
+          &Value::String("third".to_string())
+        );
+        assert_eq!(obj3.get("null_value").unwrap(), &Value::Null);
+
+        if let Value::Array(empty_arr) = obj3.get("empty_array").unwrap() {
+          assert!(empty_arr.is_empty());
+        } else {
+          panic!("Expected array for empty_array");
+        }
+
+        if let Value::Object(empty_obj) = obj3.get("empty_object").unwrap() {
+          assert!(empty_obj.is_empty());
+        } else {
+          panic!("Expected object for empty_object");
+        }
+      } else {
+        panic!("Expected object at index 2");
+      }
+    } else {
+      panic!("Expected array for object_array");
+    }
+
+    // Verify simple values are preserved
+    assert_eq!(
+      root.get("simple_string").unwrap(),
+      &Value::String("simple".to_string())
+    );
+    assert_eq!(root.get("simple_number").unwrap(), &Value::Signed(999));
+    assert_eq!(root.get("simple_bool").unwrap(), &Value::Bool(false));
+    assert_eq!(root.get("simple_null").unwrap(), &Value::Null);
+  } else {
+    panic!("Expected root object");
   }
 }

--- a/bd-bonjson/src/encoder_test.rs
+++ b/bd-bonjson/src/encoder_test.rs
@@ -52,7 +52,7 @@ fn test_encode_bool_false() {
 #[test]
 fn test_encode_float() {
   let mut buffer = Vec::new();
-  let value = Value::Float(3.14159);
+  let value = Value::Float(std::f64::consts::PI);
 
   let result = encode(&mut buffer, &value).expect("Failed to encode float");
 
@@ -104,7 +104,7 @@ fn test_encode_unsigned() {
   match decoded {
     Value::Signed(v) => assert_eq!(v, 98765),
     Value::Unsigned(v) => assert_eq!(v, 98765),
-    _ => panic!("Expected integer value, got {:?}", decoded),
+    _ => panic!("Expected integer value, got {decoded:?}"),
   }
 }
 
@@ -290,13 +290,13 @@ fn test_encoder_reuse() {
   let value1 = Value::String("first".to_string());
   let result1 = encode(&mut buffer, &value1)
     .expect("Failed to encode")
-    .to_vec();
+    .clone();
 
   // Encode second value (should reuse the encoder)
   let value2 = Value::Signed(42);
   let result2 = encode(&mut buffer, &value2)
     .expect("Failed to encode")
-    .to_vec();
+    .clone();
 
   // Verify both encodings work
   let decoded1 = decode(&result1).expect("Failed to decode first");
@@ -447,7 +447,7 @@ fn test_encode_deeply_nested_mixed_structures() {
           ]),
           Value::Null,
         ]),
-        Value::Float(3.14159),
+        Value::Float(std::f64::consts::PI),
       ]),
       Value::String("level3".to_string()),
     ]),
@@ -572,7 +572,7 @@ fn test_encode_deeply_nested_mixed_structures() {
 
         if let Value::Array(level2) = &level1[0] {
           assert_eq!(level2.len(), 2);
-          assert_eq!(level2[1], Value::Float(3.14159));
+          assert_eq!(level2[1], Value::Float(std::f64::consts::PI));
 
           if let Value::Array(level3) = &level2[0] {
             assert_eq!(level3.len(), 2);
@@ -924,6 +924,6 @@ fn test_standalone_encode_function() {
   let second_value = Value::String("second test".to_string());
   let second_result = encode(&mut buffer, &second_value).expect("Failed to encode second value");
 
-  let second_decoded = decode(&second_result).expect("Failed to decode second value");
+  let second_decoded = decode(second_result).expect("Failed to decode second value");
   assert_eq!(second_decoded, second_value);
 }

--- a/bd-bonjson/src/encoder_test.rs
+++ b/bd-bonjson/src/encoder_test.rs
@@ -777,7 +777,7 @@ fn test_in_place_encode_null() {
   assert_eq!(bytes_written, 1);
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[..bytes_written]);
+  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
   let decoded = decoder.decode().expect("Failed to decode");
   assert_eq!(decoded, value);
 }
@@ -791,7 +791,7 @@ fn test_in_place_encode_bool() {
   assert_eq!(bytes_written, 1);
 
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[..bytes_written]);
+  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
   let decoded = decoder.decode().expect("Failed to decode");
   assert_eq!(decoded, value);
 }
@@ -802,9 +802,9 @@ fn test_in_place_encode_string() {
   let value = Value::String("hello".to_string());
 
   let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode string");
-  
+
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[..bytes_written]);
+  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
   let decoded = decoder.decode().expect("Failed to decode");
   assert_eq!(decoded, value);
 }
@@ -819,9 +819,9 @@ fn test_in_place_encode_array() {
   ]);
 
   let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode array");
-  
+
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[..bytes_written]);
+  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
   let decoded = decoder.decode().expect("Failed to decode");
   assert_eq!(decoded, value);
 }
@@ -829,22 +829,25 @@ fn test_in_place_encode_array() {
 #[test]
 fn test_in_place_encode_object() {
   let mut buffer = [0u8; 128];
-  
+
   let mut obj = HashMap::new();
   obj.insert("name".to_string(), Value::String("test".to_string()));
   obj.insert("age".to_string(), Value::Signed(25));
   let value = Value::Object(obj);
 
   let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode object");
-  
+
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[..bytes_written]);
+  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
   let decoded = decoder.decode().expect("Failed to decode");
-  
+
   // Since HashMap ordering is not guaranteed, we need to check content differently
   if let Value::Object(decoded_obj) = decoded {
     assert_eq!(decoded_obj.len(), 2);
-    assert_eq!(decoded_obj.get("name").unwrap(), &Value::String("test".to_string()));
+    assert_eq!(
+      decoded_obj.get("name").unwrap(),
+      &Value::String("test".to_string())
+    );
     assert_eq!(decoded_obj.get("age").unwrap(), &Value::Signed(25));
   } else {
     panic!("Expected object");
@@ -864,16 +867,16 @@ fn test_in_place_encode_buffer_full() {
 #[test]
 fn test_in_place_encode_position_tracking() {
   let mut buffer = [0u8; 16];
-  
+
   let value = Value::Null;
   let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode null");
-  
+
   assert_eq!(bytes_written, 1);
-  
+
   // Second encode should start fresh (functions are stateless)
   let value2 = Value::Bool(true);
   let bytes_written2 = encode_into(&mut buffer, &value2).expect("Failed to encode bool");
-  
+
   assert_eq!(bytes_written2, 1);
 }
 
@@ -885,9 +888,9 @@ fn test_in_place_encode_exact_fit() {
 
   let bytes_written = encode_into(&mut buffer, &value).expect("Failed to encode");
   assert!(bytes_written <= buffer.len());
-  
+
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[..bytes_written]);
+  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
   let decoded = decoder.decode().expect("Failed to decode");
   assert_eq!(decoded, value);
 }
@@ -895,17 +898,17 @@ fn test_in_place_encode_exact_fit() {
 #[test]
 fn test_in_place_encode_reuse() {
   let mut buffer = [0u8; 32];
-  
+
   // First encoding
   let value1 = Value::Signed(123);
   encode_into(&mut buffer, &value1).expect("Failed to encode first value");
-  
+
   // Second encoding (functions are stateless, so each call starts from position 0)
   let value2 = Value::String("hello".to_string());
   let bytes_written2 = encode_into(&mut buffer, &value2).expect("Failed to encode second value");
-  
+
   // Verify the second value overwrote the first
-  let mut decoder = Decoder::new(&buffer[..bytes_written2]);
+  let mut decoder = Decoder::new(&buffer[.. bytes_written2]);
   let decoded = decoder.decode().expect("Failed to decode");
   assert_eq!(decoded, value2);
 }
@@ -913,21 +916,18 @@ fn test_in_place_encode_reuse() {
 #[test]
 fn test_in_place_encode_deeply_nested() {
   let mut buffer = [0u8; 256];
-  
-  // Create deeply nested structure
-  let nested_value = Value::Array(vec![
-    Value::Array(vec![
-      Value::Array(vec![
-        Value::String("deep".to_string()),
-        Value::Signed(42),
-      ]),
-    ]),
-  ]);
 
-  let bytes_written = encode_into(&mut buffer, &nested_value).expect("Failed to encode nested structure");
-  
+  // Create deeply nested structure
+  let nested_value = Value::Array(vec![Value::Array(vec![Value::Array(vec![
+    Value::String("deep".to_string()),
+    Value::Signed(42),
+  ])])]);
+
+  let bytes_written =
+    encode_into(&mut buffer, &nested_value).expect("Failed to encode nested structure");
+
   // Verify we can decode it back
-  let mut decoder = Decoder::new(&buffer[..bytes_written]);
+  let mut decoder = Decoder::new(&buffer[.. bytes_written]);
   let decoded = decoder.decode().expect("Failed to decode");
   assert_eq!(decoded, nested_value);
 }

--- a/bd-bonjson/src/encoder_test.rs
+++ b/bd-bonjson/src/encoder_test.rs
@@ -7,15 +7,15 @@
 
 use crate::Value;
 use crate::decoder::Decoder;
-use crate::encoder::{Encoder, encode};
+use crate::encoder::encode;
 use std::collections::HashMap;
 
 #[test]
 fn test_encode_null() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Null;
 
-  let result = encoder.encode(&value).expect("Failed to encode null");
+  let result = encode(&mut buffer, &value).expect("Failed to encode null");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -25,10 +25,10 @@ fn test_encode_null() {
 
 #[test]
 fn test_encode_bool_true() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Bool(true);
 
-  let result = encoder.encode(&value).expect("Failed to encode bool");
+  let result = encode(&mut buffer, &value).expect("Failed to encode bool");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -38,10 +38,10 @@ fn test_encode_bool_true() {
 
 #[test]
 fn test_encode_bool_false() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Bool(false);
 
-  let result = encoder.encode(&value).expect("Failed to encode bool");
+  let result = encode(&mut buffer, &value).expect("Failed to encode bool");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -51,10 +51,10 @@ fn test_encode_bool_false() {
 
 #[test]
 fn test_encode_float() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Float(3.14159);
 
-  let result = encoder.encode(&value).expect("Failed to encode float");
+  let result = encode(&mut buffer, &value).expect("Failed to encode float");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -64,10 +64,10 @@ fn test_encode_float() {
 
 #[test]
 fn test_encode_signed_positive() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Signed(12345);
 
-  let result = encoder.encode(&value).expect("Failed to encode signed");
+  let result = encode(&mut buffer, &value).expect("Failed to encode signed");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -77,10 +77,10 @@ fn test_encode_signed_positive() {
 
 #[test]
 fn test_encode_signed_negative() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Signed(-6789);
 
-  let result = encoder.encode(&value).expect("Failed to encode signed");
+  let result = encode(&mut buffer, &value).expect("Failed to encode signed");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -90,10 +90,10 @@ fn test_encode_signed_negative() {
 
 #[test]
 fn test_encode_unsigned() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Unsigned(98765);
 
-  let result = encoder.encode(&value).expect("Failed to encode unsigned");
+  let result = encode(&mut buffer, &value).expect("Failed to encode unsigned");
 
   // Verify we can decode it back
   // Note: The decoder may convert unsigned values that fit in i64 to Signed
@@ -110,10 +110,10 @@ fn test_encode_unsigned() {
 
 #[test]
 fn test_encode_string() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::String("Hello, World!".to_string());
 
-  let result = encoder.encode(&value).expect("Failed to encode string");
+  let result = encode(&mut buffer, &value).expect("Failed to encode string");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -123,12 +123,11 @@ fn test_encode_string() {
 
 #[test]
 fn test_encode_empty_string() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::String(String::new());
 
-  let result = encoder
-    .encode(&value)
-    .expect("Failed to encode empty string");
+  let result = encode(&mut buffer, &value)
+    .expect("Failed to encode");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -138,12 +137,11 @@ fn test_encode_empty_string() {
 
 #[test]
 fn test_encode_string_with_unicode() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::String("🦀 Rust is awesome! 🚀".to_string());
 
-  let result = encoder
-    .encode(&value)
-    .expect("Failed to encode unicode string");
+  let result = encode(&mut buffer, &value)
+    .expect("Failed to encode");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -153,12 +151,11 @@ fn test_encode_string_with_unicode() {
 
 #[test]
 fn test_encode_empty_array() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Array(Vec::new());
 
-  let result = encoder
-    .encode(&value)
-    .expect("Failed to encode empty array");
+  let result = encode(&mut buffer, &value)
+    .expect("Failed to encode");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -168,7 +165,7 @@ fn test_encode_empty_array() {
 
 #[test]
 fn test_encode_array_with_values() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Array(vec![
     Value::Null,
     Value::Bool(true),
@@ -176,7 +173,7 @@ fn test_encode_array_with_values() {
     Value::String("test".to_string()),
   ]);
 
-  let result = encoder.encode(&value).expect("Failed to encode array");
+  let result = encode(&mut buffer, &value).expect("Failed to encode array");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -186,7 +183,7 @@ fn test_encode_array_with_values() {
 
 #[test]
 fn test_encode_nested_arrays() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Array(vec![
     Value::Array(vec![Value::Signed(1), Value::Signed(2)]),
     Value::Array(vec![
@@ -195,9 +192,8 @@ fn test_encode_nested_arrays() {
     ]),
   ]);
 
-  let result = encoder
-    .encode(&value)
-    .expect("Failed to encode nested arrays");
+  let result = encode(&mut buffer, &value)
+    .expect("Failed to encode");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -207,12 +203,11 @@ fn test_encode_nested_arrays() {
 
 #[test]
 fn test_encode_empty_object() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::Object(HashMap::new());
 
-  let result = encoder
-    .encode(&value)
-    .expect("Failed to encode empty object");
+  let result = encode(&mut buffer, &value)
+    .expect("Failed to encode");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -222,7 +217,7 @@ fn test_encode_empty_object() {
 
 #[test]
 fn test_encode_object_with_values() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let mut obj = HashMap::new();
   obj.insert("null_key".to_string(), Value::Null);
   obj.insert("bool_key".to_string(), Value::Bool(false));
@@ -231,7 +226,7 @@ fn test_encode_object_with_values() {
 
   let value = Value::Object(obj);
 
-  let result = encoder.encode(&value).expect("Failed to encode object");
+  let result = encode(&mut buffer, &value).expect("Failed to encode object");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -241,7 +236,7 @@ fn test_encode_object_with_values() {
 
 #[test]
 fn test_encode_nested_objects() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
 
   let mut inner_obj = HashMap::new();
   inner_obj.insert(
@@ -255,9 +250,8 @@ fn test_encode_nested_objects() {
 
   let value = Value::Object(outer_obj);
 
-  let result = encoder
-    .encode(&value)
-    .expect("Failed to encode nested objects");
+  let result = encode(&mut buffer, &value)
+    .expect("Failed to encode");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -267,7 +261,7 @@ fn test_encode_nested_objects() {
 
 #[test]
 fn test_encode_mixed_nested_structure() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
 
   let mut obj = HashMap::new();
   obj.insert(
@@ -286,9 +280,8 @@ fn test_encode_mixed_nested_structure() {
 
   let value = Value::Object(obj);
 
-  let result = encoder
-    .encode(&value)
-    .expect("Failed to encode mixed structure");
+  let result = encode(&mut buffer, &value)
+    .expect("Failed to encode");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -298,19 +291,17 @@ fn test_encode_mixed_nested_structure() {
 
 #[test]
 fn test_encoder_reuse() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
 
   // Encode first value
   let value1 = Value::String("first".to_string());
-  let result1 = encoder
-    .encode(&value1)
-    .expect("Failed to encode first value");
+  let result1 = encode(&mut buffer, &value1)
+    .expect("Failed to encode");
 
   // Encode second value (should reuse the encoder)
   let value2 = Value::Signed(42);
-  let result2 = encoder
-    .encode(&value2)
-    .expect("Failed to encode second value");
+  let result2 = encode(&mut buffer, &value2)
+    .expect("Failed to encode");
 
   // Verify both encodings work
   let mut decoder1 = Decoder::new(&result1);
@@ -324,12 +315,11 @@ fn test_encoder_reuse() {
 
 #[test]
 fn test_encoder_with_capacity() {
-  let mut encoder = Encoder::with_capacity(1024);
+  let mut buffer = Vec::with_capacity(1024);
   let value = Value::String("test".to_string());
 
-  let result = encoder
-    .encode(&value)
-    .expect("Failed to encode with capacity");
+  let result = encode(&mut buffer, &value)
+    .expect("Failed to encode");
 
   // Verify we can decode it back
   let mut decoder = Decoder::new(&result);
@@ -339,18 +329,16 @@ fn test_encoder_with_capacity() {
 
 #[test]
 fn test_encoder_clear() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
 
   // Encode a value
   let value = Value::String("test".to_string());
-  encoder.encode(&value).expect("Failed to encode");
+  encode(&mut buffer, &value).expect("Failed to encode");
 
   // Clear and encode another value
-  encoder.clear();
+  buffer.clear();
   let value2 = Value::Signed(123);
-  let result = encoder
-    .encode(&value2)
-    .expect("Failed to encode after clear");
+  let result = encode(&mut buffer, &value2).expect("Failed to encode after clear");
 
   // Verify the second encoding works
   let mut decoder = Decoder::new(&result);
@@ -360,47 +348,48 @@ fn test_encoder_clear() {
 
 #[test]
 fn test_encoder_buffer_access() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
   let value = Value::String("test".to_string());
 
-  encoder.encode(&value).expect("Failed to encode");
+  encode(&mut buffer, &value).expect("Failed to encode");
 
-  // Access buffer without consuming encoder
-  let buffer = encoder.buffer();
+  // Access buffer
   assert!(!buffer.is_empty());
 
-  // Verify we can still use the encoder
+  // Verify we can still use the buffer for more encoding
   let value2 = Value::Signed(456);
-  encoder.encode(&value2).expect("Failed to encode again");
+  let second_result = encode(&mut buffer, &value2).expect("Failed to encode again");
+  
+  // The buffer now contains the second encoding result
+  let mut decoder = Decoder::new(&second_result);
+  let decoded = decoder.decode().expect("Failed to decode");
+  assert_eq!(decoded, value2);
 }
 
 #[test]
 fn test_encode_large_numbers() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
 
   // Test large positive signed
   let value1 = Value::Signed(i64::MAX);
-  let result1 = encoder
-    .encode(&value1)
-    .expect("Failed to encode large positive");
+  let result1 = encode(&mut buffer, &value1)
+    .expect("Failed to encode");
   let mut decoder1 = Decoder::new(&result1);
   let decoded1 = decoder1.decode().expect("Failed to decode");
   assert_eq!(decoded1, value1);
 
   // Test large negative signed
   let value2 = Value::Signed(i64::MIN);
-  let result2 = encoder
-    .encode(&value2)
-    .expect("Failed to encode large negative");
+  let result2 = encode(&mut buffer, &value2)
+    .expect("Failed to encode");
   let mut decoder2 = Decoder::new(&result2);
   let decoded2 = decoder2.decode().expect("Failed to decode");
   assert_eq!(decoded2, value2);
 
   // Test large unsigned that requires staying unsigned
   let value3 = Value::Unsigned(u64::MAX);
-  let result3 = encoder
-    .encode(&value3)
-    .expect("Failed to encode large unsigned");
+  let result3 = encode(&mut buffer, &value3)
+    .expect("Failed to encode");
   let mut decoder3 = Decoder::new(&result3);
   let decoded3 = decoder3.decode().expect("Failed to decode");
   assert_eq!(decoded3, value3); // u64::MAX cannot fit in i64, so should stay unsigned
@@ -408,43 +397,41 @@ fn test_encode_large_numbers() {
 
 #[test]
 fn test_encode_special_floats() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
 
   // Test zero
   let value1 = Value::Float(0.0);
-  let result1 = encoder.encode(&value1).expect("Failed to encode zero");
+  let result1 = encode(&mut buffer, &value1).expect("Failed to encode zero");
   let mut decoder1 = Decoder::new(&result1);
   let decoded1 = decoder1.decode().expect("Failed to decode");
   assert_eq!(decoded1, value1);
 
   // Test negative zero
   let value2 = Value::Float(-0.0);
-  let result2 = encoder
-    .encode(&value2)
-    .expect("Failed to encode negative zero");
+  let result2 = encode(&mut buffer, &value2)
+    .expect("Failed to encode");
   let mut decoder2 = Decoder::new(&result2);
   let decoded2 = decoder2.decode().expect("Failed to decode");
   assert_eq!(decoded2, value2);
 
   // Test infinity
   let value3 = Value::Float(f64::INFINITY);
-  let result3 = encoder.encode(&value3).expect("Failed to encode infinity");
+  let result3 = encode(&mut buffer, &value3).expect("Failed to encode infinity");
   let mut decoder3 = Decoder::new(&result3);
   let decoded3 = decoder3.decode().expect("Failed to decode");
   assert_eq!(decoded3, value3);
 
   // Test negative infinity
   let value4 = Value::Float(f64::NEG_INFINITY);
-  let result4 = encoder
-    .encode(&value4)
-    .expect("Failed to encode negative infinity");
+  let result4 = encode(&mut buffer, &value4)
+    .expect("Failed to encode");
   let mut decoder4 = Decoder::new(&result4);
   let decoded4 = decoder4.decode().expect("Failed to decode");
   assert_eq!(decoded4, value4);
 
   // Test NaN (Note: NaN != NaN, so we need special handling)
   let value5 = Value::Float(f64::NAN);
-  let result5 = encoder.encode(&value5).expect("Failed to encode NaN");
+  let result5 = encode(&mut buffer, &value5).expect("Failed to encode NaN");
   let mut decoder5 = Decoder::new(&result5);
   let decoded5 = decoder5.decode().expect("Failed to decode");
   if let Value::Float(f) = decoded5 {
@@ -456,7 +443,7 @@ fn test_encode_special_floats() {
 
 #[test]
 fn test_encode_deeply_nested_mixed_structures() {
-  let mut encoder = Encoder::new();
+  let mut buffer = Vec::new();
 
   // Build a complex deeply nested structure with mixed arrays and objects
   let mut root_obj = HashMap::new();
@@ -567,8 +554,7 @@ fn test_encode_deeply_nested_mixed_structures() {
   let complex_value = Value::Object(root_obj);
 
   // Encode the complex structure
-  let result = encoder
-    .encode(&complex_value)
+  let result = encode(&mut buffer, &complex_value)
     .expect("Failed to encode deeply nested structure");
 
   // Verify we can decode it back

--- a/bd-bonjson/src/lib.rs
+++ b/bd-bonjson/src/lib.rs
@@ -14,7 +14,6 @@
   clippy::unwrap_used
 )]
 
-
 pub mod decoder;
 pub mod ffi;
 pub mod writer;
@@ -22,3 +21,135 @@ pub mod writer;
 mod deserialize_primitives;
 mod serialize_primitives;
 mod type_codes;
+
+use deserialize_primitives::DeserializationError;
+use std::collections::HashMap;
+
+/// BONJSON has the same value types and structure as JSON.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+  Null,
+  Bool(bool),
+  Float(f64),
+  Signed(i64),
+  Unsigned(u64),
+  String(String),
+  Array(Vec<Value>),
+  Object(HashMap<String, Value>),
+}
+
+// Helper methods for Value
+impl Value {
+  pub fn as_null(&self) -> deserialize_primitives::Result<()> {
+    match self {
+      Self::Null => Ok(()),
+      _ => Err(DeserializationError::ExpectedNull),
+    }
+  }
+
+  pub fn as_bool(&self) -> deserialize_primitives::Result<bool> {
+    match self {
+      Self::Bool(b) => Ok(*b),
+      _ => Err(DeserializationError::ExpectedBoolean),
+    }
+  }
+
+  pub fn as_integer(&self) -> deserialize_primitives::Result<i64> {
+    match self {
+      Self::Signed(n) => Ok(*n),
+      _ => Err(DeserializationError::ExpectedSignedInteger),
+    }
+  }
+
+  pub fn as_unsigned(&self) -> deserialize_primitives::Result<u64> {
+    match self {
+      Self::Unsigned(n) => Ok(*n),
+      _ => Err(DeserializationError::ExpectedUnsignedInteger),
+    }
+  }
+
+  pub fn as_float(&self) -> deserialize_primitives::Result<f64> {
+    match self {
+      Self::Float(n) => Ok(*n),
+      _ => Err(DeserializationError::ExpectedFloat),
+    }
+  }
+
+  pub fn as_string(&self) -> deserialize_primitives::Result<&str> {
+    match self {
+      Self::String(s) => Ok(s),
+      _ => Err(DeserializationError::ExpectedString),
+    }
+  }
+
+  pub fn as_array(&self) -> deserialize_primitives::Result<&Vec<Self>> {
+    match self {
+      Self::Array(arr) => Ok(arr),
+      _ => Err(DeserializationError::ExpectedArray),
+    }
+  }
+
+  pub fn as_object(&self) -> deserialize_primitives::Result<&HashMap<String, Self>> {
+    match self {
+      Self::Object(obj) => Ok(obj),
+      _ => Err(DeserializationError::ExpectedMap),
+    }
+  }
+
+  // JSON-like accessor methods
+  #[must_use]
+  pub fn get(&self, key: &str) -> Option<&Self> {
+    match self {
+      Self::Object(obj) => obj.get(key),
+      _ => None,
+    }
+  }
+
+  #[must_use]
+  pub fn get_index(&self, index: usize) -> Option<&Self> {
+    match self {
+      Self::Array(arr) => arr.get(index),
+      _ => None,
+    }
+  }
+
+  #[must_use]
+  pub fn is_null(&self) -> bool {
+    matches!(self, Self::Null)
+  }
+
+  #[must_use]
+  pub fn is_bool(&self) -> bool {
+    matches!(self, Self::Bool(_))
+  }
+
+  #[must_use]
+  pub fn is_integer(&self) -> bool {
+    matches!(self, Self::Signed(_))
+  }
+
+  #[must_use]
+  pub fn is_unsigned(&self) -> bool {
+    matches!(self, Self::Unsigned(_))
+  }
+
+  #[must_use]
+  pub fn is_float(&self) -> bool {
+    matches!(self, Self::Float(_))
+  }
+
+  #[must_use]
+  pub fn is_string(&self) -> bool {
+    matches!(self, Self::String(_))
+  }
+
+  #[must_use]
+  pub fn is_array(&self) -> bool {
+    matches!(self, Self::Array(_))
+  }
+
+  #[must_use]
+  pub fn is_object(&self) -> bool {
+    matches!(self, Self::Object(_))
+  }
+}

--- a/bd-bonjson/src/lib.rs
+++ b/bd-bonjson/src/lib.rs
@@ -15,6 +15,7 @@
 )]
 
 pub mod decoder;
+pub mod encoder;
 pub mod ffi;
 pub mod writer;
 

--- a/bd-bonjson/src/lib.rs
+++ b/bd-bonjson/src/lib.rs
@@ -27,6 +27,7 @@ use deserialize_primitives::DeserializationError;
 use std::collections::HashMap;
 
 /// BONJSON has the same value types and structure as JSON.
+/// Internally, the "Number" type can be a signed integer, unsigned integer, or float.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
   Null,

--- a/bd-bonjson/src/lib.rs
+++ b/bd-bonjson/src/lib.rs
@@ -40,6 +40,10 @@ pub enum Value {
 
 // Helper methods for Value
 impl Value {
+  /// Extract null value from this Value.
+  ///
+  /// # Errors
+  /// Returns `DeserializationError::ExpectedNull` if this Value is not null.
   pub fn as_null(&self) -> deserialize_primitives::Result<()> {
     match self {
       Self::Null => Ok(()),
@@ -47,6 +51,10 @@ impl Value {
     }
   }
 
+  /// Extract boolean value from this Value.
+  ///
+  /// # Errors
+  /// Returns `DeserializationError::ExpectedBoolean` if this Value is not a boolean.
   pub fn as_bool(&self) -> deserialize_primitives::Result<bool> {
     match self {
       Self::Bool(b) => Ok(*b),
@@ -54,6 +62,10 @@ impl Value {
     }
   }
 
+  /// Extract signed integer value from this Value.
+  ///
+  /// # Errors
+  /// Returns `DeserializationError::ExpectedSignedInteger` if this Value is not a signed integer.
   pub fn as_integer(&self) -> deserialize_primitives::Result<i64> {
     match self {
       Self::Signed(n) => Ok(*n),
@@ -61,6 +73,11 @@ impl Value {
     }
   }
 
+  /// Extract unsigned integer value from this Value.
+  ///
+  /// # Errors
+  /// Returns `DeserializationError::ExpectedUnsignedInteger` if this Value is not an unsigned
+  /// integer.
   pub fn as_unsigned(&self) -> deserialize_primitives::Result<u64> {
     match self {
       Self::Unsigned(n) => Ok(*n),
@@ -68,6 +85,10 @@ impl Value {
     }
   }
 
+  /// Extract floating point value from this Value.
+  ///
+  /// # Errors
+  /// Returns `DeserializationError::ExpectedFloat` if this Value is not a float.
   pub fn as_float(&self) -> deserialize_primitives::Result<f64> {
     match self {
       Self::Float(n) => Ok(*n),
@@ -75,6 +96,10 @@ impl Value {
     }
   }
 
+  /// Extract string value from this Value.
+  ///
+  /// # Errors
+  /// Returns `DeserializationError::ExpectedString` if this Value is not a string.
   pub fn as_string(&self) -> deserialize_primitives::Result<&str> {
     match self {
       Self::String(s) => Ok(s),
@@ -82,6 +107,10 @@ impl Value {
     }
   }
 
+  /// Extract array value from this Value.
+  ///
+  /// # Errors
+  /// Returns `DeserializationError::ExpectedArray` if this Value is not an array.
   pub fn as_array(&self) -> deserialize_primitives::Result<&Vec<Self>> {
     match self {
       Self::Array(arr) => Ok(arr),
@@ -89,6 +118,10 @@ impl Value {
     }
   }
 
+  /// Extract object value from this Value.
+  ///
+  /// # Errors
+  /// Returns `DeserializationError::ExpectedMap` if this Value is not an object.
   pub fn as_object(&self) -> deserialize_primitives::Result<&HashMap<String, Self>> {
     match self {
       Self::Object(obj) => Ok(obj),

--- a/bd-bonjson/src/writer.rs
+++ b/bd-bonjson/src/writer.rs
@@ -28,42 +28,70 @@ impl<W: std::io::Write + Send + Sync> Writer<W> {
     self.writer.write(bytes).map_err(|_| SerializationError::Io)
   }
 
+  /// Write a null value to the output.
+  ///
+  /// # Errors
+  /// Returns `SerializationError::Io` if writing to the underlying writer fails.
   pub fn write_null(&mut self) -> Result<usize> {
     let mut buffer: [u8; 1] = [0; 1];
     let size = serialize_primitives::serialize_null(&mut buffer)?;
     self.write_bytes(&buffer[.. size])
   }
 
+  /// Write a boolean value to the output.
+  ///
+  /// # Errors
+  /// Returns `SerializationError::Io` if writing to the underlying writer fails.
   pub fn write_boolean(&mut self, v: bool) -> Result<usize> {
     let mut buffer: [u8; 1] = [0; 1];
     let size = serialize_primitives::serialize_boolean(&mut buffer, v)?;
     self.write_bytes(&buffer[.. size])
   }
 
+  /// Write a signed integer value to the output.
+  ///
+  /// # Errors
+  /// Returns `SerializationError::Io` if writing to the underlying writer fails.
   pub fn write_signed(&mut self, v: i64) -> Result<usize> {
     let mut buffer: [u8; 16] = [0; 16];
     let size = serialize_primitives::serialize_i64(&mut buffer, v)?;
     self.write_bytes(&buffer[.. size])
   }
 
+  /// Write an unsigned integer value to the output.
+  ///
+  /// # Errors
+  /// Returns `SerializationError::Io` if writing to the underlying writer fails.
   pub fn write_unsigned(&mut self, v: u64) -> Result<usize> {
     let mut buffer: [u8; 16] = [0; 16];
     let size = serialize_primitives::serialize_u64(&mut buffer, v)?;
     self.write_bytes(&buffer[.. size])
   }
 
+  /// Write a 64-bit floating point value to the output.
+  ///
+  /// # Errors
+  /// Returns `SerializationError::Io` if writing to the underlying writer fails.
   pub fn write_float(&mut self, v: f64) -> Result<usize> {
     let mut buffer: [u8; 16] = [0; 16];
     let size = serialize_primitives::serialize_f64(&mut buffer, v)?;
     self.write_bytes(&buffer[.. size])
   }
 
+  /// Write a 32-bit floating point value to the output.
+  ///
+  /// # Errors
+  /// Returns `SerializationError::Io` if writing to the underlying writer fails.
   pub fn write_f32(&mut self, v: f32) -> Result<usize> {
     let mut buffer: [u8; 16] = [0; 16];
     let size = serialize_primitives::serialize_f32(&mut buffer, v)?;
     self.write_bytes(&buffer[.. size])
   }
 
+  /// Write a string value to the output.
+  ///
+  /// # Errors
+  /// Returns `SerializationError::Io` if writing to the underlying writer fails.
   pub fn write_str(&mut self, v: &str) -> Result<usize> {
     let mut buffer: [u8; 16] = [0; 16];
     let header_size = serialize_primitives::serialize_string_header(&mut buffer, v)?;
@@ -72,18 +100,30 @@ impl<W: std::io::Write + Send + Sync> Writer<W> {
     Ok(header_size + v.len())
   }
 
+  /// Write the beginning of an array to the output.
+  ///
+  /// # Errors
+  /// Returns `SerializationError::Io` if writing to the underlying writer fails.
   pub fn write_array_begin(&mut self) -> Result<usize> {
     let mut buffer: [u8; 1] = [0; 1];
     let size = serialize_primitives::serialize_array_begin(&mut buffer)?;
     self.write_bytes(&buffer[.. size])
   }
 
+  /// Write the beginning of a map/object to the output.
+  ///
+  /// # Errors
+  /// Returns `SerializationError::Io` if writing to the underlying writer fails.
   pub fn write_map_begin(&mut self) -> Result<usize> {
     let mut buffer: [u8; 1] = [0; 1];
     let size = serialize_primitives::serialize_map_begin(&mut buffer)?;
     self.write_bytes(&buffer[.. size])
   }
 
+  /// Write the end of a container (array or map) to the output.
+  ///
+  /// # Errors
+  /// Returns `SerializationError::Io` if writing to the underlying writer fails.
   pub fn write_container_end(&mut self) -> Result<usize> {
     let mut buffer: [u8; 1] = [0; 1];
     let size = serialize_primitives::serialize_container_end(&mut buffer)?;

--- a/fuzz/fuzz_targets/bonjson.rs
+++ b/fuzz/fuzz_targets/bonjson.rs
@@ -7,12 +7,11 @@
 
 #![no_main]
 
-use bd_bonjson::decoder::Decoder;
+use bd_bonjson::decoder::decode_value;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-  let mut decoder = Decoder::new(data);
-  match decoder.decode() {
+  match decode_value(data) {
     Ok(_) | Err(_) => {},
   }
 });

--- a/fuzz/fuzz_targets/bonjson.rs
+++ b/fuzz/fuzz_targets/bonjson.rs
@@ -7,11 +7,11 @@
 
 #![no_main]
 
-use bd_bonjson::decoder::decode_value;
+use bd_bonjson::decoder::decode;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-  match decode_value(data) {
+  match decode(data) {
     Ok(_) | Err(_) => {},
   }
 });


### PR DESCRIPTION
* Removed `Value::None` because it was only being used to signal a failure to get a value
* Moved `Value` to the library level so that it works much like `Value` does in JSON serde
* Hid the `Decoder` struct and changed the decoder public interface to only one function: `decode`
* Added a matching `encode` function that fills a vector, and an `encode_into` function that fills a slice

This is an API breaking change that will require updates in capture-sdk (which I'll do in parallel).
