### PR TITLE
api: implement better rate limiting backoff

### DIFF
--- a/bd-artifact-upload/src/uploader_test.rs
+++ b/bd-artifact-upload/src/uploader_test.rs
@@ -94,7 +94,7 @@ impl Setup {
     let config_loader = TestConfigLoader::new().await;
 
     config_loader
-      .update_snapshot(&bd_test_helpers::runtime::make_update(
+      .update_snapshot(bd_test_helpers::runtime::make_update(
         vec![(
           artifact_upload::MaxPendingEntries::path(),
           ValueKind::Int(max_entries),

--- a/bd-client-common/src/payload_conversion.rs
+++ b/bd-client-common/src/payload_conversion.rs
@@ -49,20 +49,20 @@ use bd_proto::protos::client::api::{
 //
 
 /// A transport independent representation of the possible multiplexed response types.
-pub enum ResponseKind<'a> {
-  Handshake(&'a HandshakeResponse),
-  ErrorShutdown(&'a ErrorShutdown),
-  Pong(&'a PongResponse),
-  LogUpload(&'a LogUploadResponse),
-  LogUploadIntent(&'a LogUploadIntentResponse),
-  StatsUpload(&'a StatsUploadResponse),
-  FlushBuffers(&'a FlushBuffers),
-  SankeyPathUpload(&'a SankeyPathUploadResponse),
-  SankeyPathUploadIntent(&'a SankeyIntentResponse),
-  ArtifactUploadIntent(&'a UploadArtifactIntentResponse),
-  ArtifactUpload(&'a UploadArtifactResponse),
-  ConfigurationUpdate(&'a ConfigurationUpdate),
-  RuntimeUpdate(&'a RuntimeUpdate),
+pub enum ResponseKind {
+  Handshake(HandshakeResponse),
+  ErrorShutdown(ErrorShutdown),
+  Pong(PongResponse),
+  LogUpload(LogUploadResponse),
+  LogUploadIntent(LogUploadIntentResponse),
+  StatsUpload(StatsUploadResponse),
+  FlushBuffers(FlushBuffers),
+  SankeyPathUpload(SankeyPathUploadResponse),
+  SankeyPathUploadIntent(SankeyIntentResponse),
+  ArtifactUploadIntent(UploadArtifactIntentResponse),
+  ArtifactUpload(UploadArtifactResponse),
+  ConfigurationUpdate(ConfigurationUpdate),
+  RuntimeUpdate(RuntimeUpdate),
 }
 
 //
@@ -71,7 +71,7 @@ pub enum ResponseKind<'a> {
 
 /// Used to convert a response type into the transport independent `ResponseKind`.
 pub trait MuxResponse {
-  fn demux(&self) -> Option<ResponseKind<'_>>;
+  fn demux(self) -> Option<ResponseKind>;
 }
 
 /// Used to allow the API mux operate against multiple different transport APIs. The code is able
@@ -163,8 +163,8 @@ impl IntoRequest for ClientConfigurationUpdate {
 }
 
 impl MuxResponse for ApiResponse {
-  fn demux(&self) -> Option<ResponseKind<'_>> {
-    match self.response_type.as_ref()? {
+  fn demux(self) -> Option<ResponseKind> {
+    match self.response_type? {
       Response_type::Handshake(handshake) => Some(ResponseKind::Handshake(handshake)),
       Response_type::LogUpload(log_upload) => Some(ResponseKind::LogUpload(log_upload)),
       Response_type::LogUploadIntent(intent) => Some(ResponseKind::LogUploadIntent(intent)),

--- a/bd-client-common/src/safe_file_cache.rs
+++ b/bd-client-common/src/safe_file_cache.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::file::{read_compressed_protobuf, write_compressed_protobuf};
+use crate::file::read_compressed_protobuf;
 use anyhow::bail;
 use protobuf::Message;
 use std::marker::PhantomData;
@@ -163,11 +163,9 @@ impl<T: Message> SafeFileCache<T> {
     Ok(data[0])
   }
 
-  pub async fn cache_update(&self, protobuf: &T) {
+  pub async fn cache_update(&self, compressed_protobuf: Vec<u8>) {
     if let Err(e) = async {
-      Ok::<_, anyhow::Error>(
-        tokio::fs::write(&self.protobuf_file(), write_compressed_protobuf(protobuf)?).await?,
-      )
+      Ok::<_, anyhow::Error>(tokio::fs::write(&self.protobuf_file(), compressed_protobuf).await?)
     }
     .await
     {

--- a/bd-client-stats/src/stats_test.rs
+++ b/bd-client-stats/src/stats_test.rs
@@ -140,7 +140,7 @@ impl Setup {
     let shutdown_trigger = ComponentShutdownTrigger::default();
     let runtime_loader = ConfigLoader::new(directory.path());
     runtime_loader
-      .update_snapshot(&make_simple_update(vec![(
+      .update_snapshot(make_simple_update(vec![(
         bd_runtime::runtime::stats::MaxAggregatedFilesFlag::path(),
         ValueKind::Int(2),
       )]))

--- a/bd-crash-handler/src/config_writer_test.rs
+++ b/bd-crash-handler/src/config_writer_test.rs
@@ -28,7 +28,7 @@ impl Setup {
 
     if crash_reporting_enabled {
       runtime
-        .update_snapshot(&make_simple_update(vec![(
+        .update_snapshot(make_simple_update(vec![(
           "crash_reporting.enabled",
           ValueKind::Bool(crash_reporting_enabled),
         )]))
@@ -49,7 +49,7 @@ impl Setup {
   async fn configure_runtime_flag(&self, value: bool) {
     self
       .runtime
-      .update_snapshot(&make_simple_update(vec![(
+      .update_snapshot(make_simple_update(vec![(
         "crash_reporting.enabled",
         ValueKind::Bool(value),
       )]))

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -58,7 +58,7 @@ impl Setup {
 
     if artifact_upload {
       runtime
-        .update_snapshot(&make_simple_update(vec![(
+        .update_snapshot(make_simple_update(vec![(
           runtime::artifact_upload::Enabled::path(),
           ValueKind::Bool(artifact_upload),
         )]))

--- a/bd-events/src/listener_test.rs
+++ b/bd-events/src/listener_test.rs
@@ -42,7 +42,7 @@ impl Setup {
   async fn make_runtime_update(&self, events_listener_enabled: bool) {
     self
       .runtime
-      .update_snapshot(&make_simple_update(vec![(
+      .update_snapshot(make_simple_update(vec![(
         bd_runtime::runtime::platform_events::ListenerEnabledFlag::path(),
         ValueKind::Bool(events_listener_enabled),
       )]))

--- a/bd-grpc-codec/src/code.rs
+++ b/bd-grpc-codec/src/code.rs
@@ -1,0 +1,61 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+//
+// Code
+//
+
+// Wrapper for supported gRPC status codes. Unknown is a synthetic code if mapping is not possible.
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum Code {
+  Ok,
+  Unknown,
+  InvalidArgument,
+  FailedPrecondition,
+  Internal,
+  Unavailable,
+  Unauthenticated,
+  NotFound,
+  PermissionDenied,
+  ResourceExhausted,
+}
+
+impl Code {
+  // Convert to an int via https://grpc.github.io/grpc/core/md_doc_statuscodes.html.
+  #[must_use]
+  pub const fn to_int(&self) -> i32 {
+    match self {
+      Self::Ok => 0,
+      Self::Unknown => 2,
+      Self::InvalidArgument => 3,
+      Self::NotFound => 5,
+      Self::PermissionDenied => 7,
+      Self::ResourceExhausted => 8,
+      Self::FailedPrecondition => 9,
+      Self::Internal => 13,
+      Self::Unavailable => 14,
+      Self::Unauthenticated => 16,
+    }
+  }
+
+  // Convert from a string via https://grpc.github.io/grpc/core/md_doc_statuscodes.html.
+  #[must_use]
+  pub fn from_string(status: &str) -> Self {
+    match status {
+      "0" => Self::Ok,
+      "3" => Self::InvalidArgument,
+      "5" => Self::NotFound,
+      "7" => Self::PermissionDenied,
+      "8" => Self::ResourceExhausted,
+      "9" => Self::FailedPrecondition,
+      "13" => Self::Internal,
+      "14" => Self::Unavailable,
+      "16" => Self::Unauthenticated,
+      _ => Self::Unknown,
+    }
+  }
+}

--- a/bd-grpc-codec/src/code.rs
+++ b/bd-grpc-codec/src/code.rs
@@ -44,7 +44,8 @@ impl Code {
 
   // Convert from a string via https://grpc.github.io/grpc/core/md_doc_statuscodes.html.
   #[must_use]
-  pub fn from_string(status: &str) -> Self {
+  #[allow(clippy::should_implement_trait)] // Infallible
+  pub fn from_str(status: &str) -> Self {
     match status {
       "0" => Self::Ok,
       "3" => Self::InvalidArgument,

--- a/bd-grpc-codec/src/lib.rs
+++ b/bd-grpc-codec/src/lib.rs
@@ -18,6 +18,7 @@
 #[path = "./coding_test.rs"]
 mod coding_test;
 
+pub mod code;
 pub mod stats;
 
 use crate::stats::DeferredCounter;

--- a/bd-grpc/src/client.rs
+++ b/bd-grpc/src/client.rs
@@ -9,7 +9,7 @@ use crate::compression::Compression;
 use crate::connect_protocol::{ConnectProtocolType, ToContentType};
 use crate::error::{Error, Result};
 use crate::service::ServiceMethod;
-use crate::status::{Code, Status};
+use crate::status::Status;
 use crate::{
   CONNECT_PROTOCOL_VERSION,
   CONTENT_ENCODING_SNAPPY,
@@ -22,6 +22,7 @@ use crate::{
 use assert_matches::debug_assert_matches;
 use axum::body::Body;
 use axum::response::Response;
+use bd_grpc_codec::code::Code;
 use bd_grpc_codec::{
   Decoder,
   DecodingResult,

--- a/bd-grpc/src/connect_protocol.rs
+++ b/bd-grpc/src/connect_protocol.rs
@@ -5,7 +5,7 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::status::Status;
+use crate::status::{Status, code_to_connect_code_string};
 use crate::{
   CONNECT_PROTOCOL_VERSION,
   CONTENT_TYPE_CONNECT_STREAMING,
@@ -75,7 +75,7 @@ impl ErrorResponse {
   #[must_use]
   pub fn new(status: Status) -> Self {
     Self {
-      code: status.code.to_connect_code_string().to_string(),
+      code: code_to_connect_code_string(status.code).to_string(),
       message: status.message,
     }
   }

--- a/bd-grpc/src/error.rs
+++ b/bd-grpc/src/error.rs
@@ -7,9 +7,10 @@
 
 use crate::CONTENT_TYPE_JSON;
 use crate::connect_protocol::{ConnectProtocolType, ErrorResponse};
-use crate::status::{Code, Status};
+use crate::status::{Status, code_to_connect_http_status};
 use axum::BoxError;
 use axum::response::Response;
+use bd_grpc_codec::code::Code;
 use http::header::CONTENT_TYPE;
 
 //
@@ -78,7 +79,7 @@ impl Error {
   pub fn to_connect_error_response(self) -> Response {
     let status = self.into_status();
     Response::builder()
-      .status(status.code.to_connect_http_status())
+      .status(code_to_connect_http_status(status.code))
       .header(CONTENT_TYPE, CONTENT_TYPE_JSON)
       .body(
         serde_json::to_vec(&ErrorResponse::new(status))

--- a/bd-grpc/src/lib.rs
+++ b/bd-grpc/src/lib.rs
@@ -29,6 +29,7 @@ use axum::response::Response;
 use axum::routing::post;
 use axum::{BoxError, Router};
 use base64ct::Encoding;
+use bd_grpc_codec::code::Code;
 use bd_grpc_codec::stats::DeferredCounter;
 use bd_grpc_codec::{
   Decoder,
@@ -51,7 +52,7 @@ use http_body_util::{BodyExt, StreamBody};
 use protobuf::{Message, MessageFull};
 use service::ServiceMethod;
 use stats::{BandwidthStatsSummary, EndpointStats, StreamStats};
-use status::{Code, Status};
+use status::Status;
 use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::sync::Arc;

--- a/bd-grpc/src/lib.rs
+++ b/bd-grpc/src/lib.rs
@@ -256,7 +256,7 @@ impl<IncomingType: DecodingResult> StreamingApiReceiver<IncomingType> {
           });
 
           if let Some(grpc_status) = grpc_status {
-            let code = Code::from_string(grpc_status.to_str().unwrap_or_default());
+            let code = Code::from_str(grpc_status.to_str().unwrap_or_default());
             if code == Code::Ok {
               return Ok(None);
             }

--- a/bd-grpc/src/status.rs
+++ b/bd-grpc/src/status.rs
@@ -70,7 +70,7 @@ impl Status {
   #[must_use]
   pub fn from_headers(headers: &HeaderMap) -> Self {
     Self {
-      code: Code::from_string(
+      code: Code::from_str(
         headers
           .get(GRPC_STATUS)
           .expect("caller should verify grpc-status exists")

--- a/bd-grpc/src/status.rs
+++ b/bd-grpc/src/status.rs
@@ -8,88 +8,39 @@
 use crate::{CONTENT_TYPE_GRPC, GRPC_MESSAGE, GRPC_STATUS};
 use axum::body::Body;
 use axum::response::Response;
+use bd_grpc_codec::code::Code;
 use http::header::CONTENT_TYPE;
 use http::{HeaderMap, HeaderValue, StatusCode};
 
-//
-// Code
-//
-
-// Wrapper for supported gRPC status codes. Unknown is a synthetic code if mapping is not possible.
-#[derive(PartialEq, Eq, Debug)]
-pub enum Code {
-  Ok,
-  Unknown,
-  InvalidArgument,
-  FailedPrecondition,
-  Internal,
-  Unavailable,
-  Unauthenticated,
-  NotFound,
-  PermissionDenied,
+// https://connectrpc.com/docs/protocol#error-codes
+#[must_use]
+pub const fn code_to_connect_http_status(code: Code) -> StatusCode {
+  match code {
+    Code::Ok => StatusCode::OK,
+    Code::Unknown | Code::Internal => StatusCode::INTERNAL_SERVER_ERROR,
+    Code::InvalidArgument | Code::FailedPrecondition => StatusCode::BAD_REQUEST,
+    Code::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+    Code::Unauthenticated => StatusCode::UNAUTHORIZED,
+    Code::NotFound => StatusCode::NOT_FOUND,
+    Code::PermissionDenied => StatusCode::FORBIDDEN,
+    Code::ResourceExhausted => StatusCode::TOO_MANY_REQUESTS,
+  }
 }
 
-impl Code {
-  // Convert to an int via https://grpc.github.io/grpc/core/md_doc_statuscodes.html.
-  #[must_use]
-  pub const fn to_int(&self) -> i32 {
-    match self {
-      Self::Ok => 0,
-      Self::Unknown => 2,
-      Self::InvalidArgument => 3,
-      Self::NotFound => 5,
-      Self::PermissionDenied => 7,
-      Self::FailedPrecondition => 9,
-      Self::Internal => 13,
-      Self::Unavailable => 14,
-      Self::Unauthenticated => 16,
-    }
-  }
-
-  // Convert from a string via https://grpc.github.io/grpc/core/md_doc_statuscodes.html.
-  #[must_use]
-  pub fn from_string(status: &str) -> Self {
-    match status {
-      "0" => Self::Ok,
-      "3" => Self::InvalidArgument,
-      "5" => Self::NotFound,
-      "7" => Self::PermissionDenied,
-      "9" => Self::FailedPrecondition,
-      "13" => Self::Internal,
-      "14" => Self::Unavailable,
-      "16" => Self::Unauthenticated,
-      _ => Self::Unknown,
-    }
-  }
-
-  // https://connectrpc.com/docs/protocol#error-codes
-  #[must_use]
-  pub const fn to_connect_http_status(&self) -> StatusCode {
-    match self {
-      Self::Ok => StatusCode::OK,
-      Self::Unknown | Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-      Self::InvalidArgument | Self::FailedPrecondition => StatusCode::BAD_REQUEST,
-      Self::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-      Self::Unauthenticated => StatusCode::UNAUTHORIZED,
-      Self::NotFound => StatusCode::NOT_FOUND,
-      Self::PermissionDenied => StatusCode::FORBIDDEN,
-    }
-  }
-
-  // https://connectrpc.com/docs/protocol#error-codes
-  #[must_use]
-  pub const fn to_connect_code_string(&self) -> &'static str {
-    match self {
-      Self::Ok => "ok",
-      Self::Unknown => "unknown",
-      Self::InvalidArgument => "invalid_argument",
-      Self::FailedPrecondition => "failed_precondition",
-      Self::Internal => "internal",
-      Self::Unavailable => "unavailable",
-      Self::Unauthenticated => "unauthenticated",
-      Self::NotFound => "not_found",
-      Self::PermissionDenied => "permission_denied",
-    }
+// https://connectrpc.com/docs/protocol#error-codes
+#[must_use]
+pub const fn code_to_connect_code_string(code: Code) -> &'static str {
+  match code {
+    Code::Ok => "ok",
+    Code::Unknown => "unknown",
+    Code::InvalidArgument => "invalid_argument",
+    Code::FailedPrecondition => "failed_precondition",
+    Code::Internal => "internal",
+    Code::Unavailable => "unavailable",
+    Code::Unauthenticated => "unauthenticated",
+    Code::NotFound => "not_found",
+    Code::PermissionDenied => "permission_denied",
+    Code::ResourceExhausted => "resource_exhausted",
   }
 }
 

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -597,7 +597,7 @@ async fn logs_resource_utilization_log() {
 
   setup
     .runtime
-    .update_snapshot(&bd_test_helpers::runtime::make_simple_update(vec![
+    .update_snapshot(bd_test_helpers::runtime::make_simple_update(vec![
       (
         bd_runtime::runtime::debugging::PeriodicInternalLoggingFlag::path(),
         ValueKind::Bool(true),

--- a/bd-logger/src/client_config_test.rs
+++ b/bd-logger/src/client_config_test.rs
@@ -49,7 +49,7 @@ async fn process_and_load() {
   let config = Config::new(directory.path(), update);
 
   config
-    .process_configuration_update(&configuration_update())
+    .process_configuration_update(configuration_update())
     .await
     .unwrap();
 
@@ -107,7 +107,7 @@ async fn cache_write_fails() {
   });
 
   let nack = config
-    .process_configuration_update(&configuration_update())
+    .process_configuration_update(configuration_update())
     .await;
 
   // The config was valid, so we don't expect a nack.

--- a/bd-logger/src/consumer_test.rs
+++ b/bd-logger/src/consumer_test.rs
@@ -145,7 +145,7 @@ async fn upload_retries() {
   // Set the batch size to 10 before writing 10 logs that should be uploaded.
   setup
     .runtime_loader
-    .update_snapshot(&make_simple_update(vec![(
+    .update_snapshot(make_simple_update(vec![(
       bd_runtime::runtime::log_upload::BatchSizeFlag::path(),
       ValueKind::Int(10),
     )]))
@@ -197,7 +197,7 @@ async fn upload_retries() {
   // Now update the max retries to 1 via runtime. The next upload should only retry once.
   setup
     .runtime_loader
-    .update_snapshot(&make_simple_update(vec![(
+    .update_snapshot(make_simple_update(vec![(
       bd_runtime::runtime::log_upload::RetryCountFlag::path(),
       ValueKind::Int(1),
     )]))
@@ -251,7 +251,7 @@ async fn continuous_buffer_upload_byte_limit() {
   // Set the byte limit per batch to 10. The log limit remains at the default of 1,000.
   setup
     .runtime_loader
-    .update_snapshot(&make_simple_update(vec![(
+    .update_snapshot(make_simple_update(vec![(
       bd_runtime::runtime::log_upload::BatchSizeBytesFlag::path(),
       ValueKind::Int(10),
     )]))
@@ -288,7 +288,7 @@ async fn continuous_buffer_upload_shutdown() {
   // Set the byte limit per batch to 10. The log limit remains at the default of 1,000.
   setup
     .runtime_loader
-    .update_snapshot(&make_simple_update(vec![(
+    .update_snapshot(make_simple_update(vec![(
       bd_runtime::runtime::log_upload::BatchSizeBytesFlag::path(),
       ValueKind::Int(10),
     )]))
@@ -312,7 +312,7 @@ async fn uploading_full_batch_failure() {
   // Set the batch size to 10 before writing 11 logs that should be uploaded.
   setup
     .runtime_loader
-    .update_snapshot(&make_simple_update(vec![(
+    .update_snapshot(make_simple_update(vec![(
       bd_runtime::runtime::log_upload::BatchSizeFlag::path(),
       ValueKind::Int(10),
     )]))
@@ -501,7 +501,7 @@ async fn age_limit_log_uploads() {
 
   setup
     .runtime_loader
-    .update_snapshot(&make_simple_update(vec![
+    .update_snapshot(make_simple_update(vec![
       (
         bd_runtime::runtime::log_upload::FlushBufferLookbackWindow::path(),
         ValueKind::Int(2.minutes().whole_milliseconds().try_into().unwrap()),
@@ -595,7 +595,7 @@ impl SetupMultiConsumer {
     let shutdown_trigger = ComponentShutdownTrigger::default();
     let config_loader = ConfigLoader::new(temp_directory.path());
     config_loader
-      .update_snapshot(&make_simple_update(vec![
+      .update_snapshot(make_simple_update(vec![
         (
           bd_runtime::runtime::log_upload::BatchSizeFlag::path(),
           ValueKind::Int(batch_size),
@@ -924,7 +924,7 @@ async fn streaming_batch_size_flag() {
   let (log_upload_tx, mut log_upload_rx) = tokio::sync::mpsc::channel(1);
   // Set streaming batch size to 2
   runtime_loader
-    .update_snapshot(&make_simple_update(vec![(
+    .update_snapshot(make_simple_update(vec![(
       bd_runtime::runtime::log_upload::StreamingBatchSizeFlag::path(),
       ValueKind::Int(2),
     )]))

--- a/bd-logger/src/ratelimit_test.rs
+++ b/bd-logger/src/ratelimit_test.rs
@@ -52,7 +52,7 @@ async fn ratelimit() {
 
   // Set the ratelimit parameters to 10 characters per minute.
   runtime_loader
-    .update_snapshot(&make_simple_update(vec![
+    .update_snapshot(make_simple_update(vec![
       (
         bd_runtime::runtime::log_upload::RatelimitByteCountPerPeriodFlag::path(),
         ValueKind::Int(10),
@@ -96,7 +96,7 @@ async fn shared_quota() {
 
   // Set the ratelimit parameters to 2 characters per second.
   runtime_loader
-    .update_snapshot(&make_simple_update(vec![
+    .update_snapshot(make_simple_update(vec![
       (
         bd_runtime::runtime::log_upload::RatelimitByteCountPerPeriodFlag::path(),
         ValueKind::Int(2),

--- a/bd-proto/src/protos/client/api.rs
+++ b/bd-proto/src/protos/client/api.rs
@@ -4771,6 +4771,9 @@ pub mod handshake_response {
 // @@protoc_insertion_point(message:bitdrift_public.protobuf.client.v1.RateLimited)
 #[derive(PartialEq,Clone,Default,Debug)]
 pub struct RateLimited {
+    // message fields
+    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.RateLimited.retry_after)
+    pub retry_after: ::protobuf::MessageField<::protobuf::well_known_types::duration::Duration>,
     // special fields
     // @@protoc_insertion_point(special_field:bitdrift_public.protobuf.client.v1.RateLimited.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -4788,8 +4791,13 @@ impl RateLimited {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(0);
+        let mut fields = ::std::vec::Vec::with_capacity(1);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
+        fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, ::protobuf::well_known_types::duration::Duration>(
+            "retry_after",
+            |m: &RateLimited| { &m.retry_after },
+            |m: &mut RateLimited| { &mut m.retry_after },
+        ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<RateLimited>(
             "RateLimited",
             fields,
@@ -4808,6 +4816,9 @@ impl ::protobuf::Message for RateLimited {
     fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::Result<()> {
         while let Some(tag) = is.read_raw_tag_or_eof()? {
             match tag {
+                10 => {
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.retry_after)?;
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -4820,12 +4831,19 @@ impl ::protobuf::Message for RateLimited {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u64 {
         let mut my_size = 0;
+        if let Some(v) = self.retry_after.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::Result<()> {
+        if let Some(v) = self.retry_after.as_ref() {
+            ::protobuf::rt::write_message_field_with_cached_size(1, v, os)?;
+        }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -4843,11 +4861,13 @@ impl ::protobuf::Message for RateLimited {
     }
 
     fn clear(&mut self) {
+        self.retry_after.clear();
         self.special_fields.clear();
     }
 
     fn default_instance() -> &'static RateLimited {
         static instance: RateLimited = RateLimited {
+            retry_after: ::protobuf::MessageField::none(),
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -6514,6 +6534,8 @@ pub struct ErrorShutdown {
     pub grpc_status: i32,
     // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.ErrorShutdown.grpc_message)
     pub grpc_message: ::std::string::String,
+    // @@protoc_insertion_point(field:bitdrift_public.protobuf.client.v1.ErrorShutdown.rate_limited)
+    pub rate_limited: ::protobuf::MessageField<RateLimited>,
     // special fields
     // @@protoc_insertion_point(special_field:bitdrift_public.protobuf.client.v1.ErrorShutdown.special_fields)
     pub special_fields: ::protobuf::SpecialFields,
@@ -6531,7 +6553,7 @@ impl ErrorShutdown {
     }
 
     fn generated_message_descriptor_data() -> ::protobuf::reflect::GeneratedMessageDescriptorData {
-        let mut fields = ::std::vec::Vec::with_capacity(2);
+        let mut fields = ::std::vec::Vec::with_capacity(3);
         let mut oneofs = ::std::vec::Vec::with_capacity(0);
         fields.push(::protobuf::reflect::rt::v2::make_simpler_field_accessor::<_, _>(
             "grpc_status",
@@ -6542,6 +6564,11 @@ impl ErrorShutdown {
             "grpc_message",
             |m: &ErrorShutdown| { &m.grpc_message },
             |m: &mut ErrorShutdown| { &mut m.grpc_message },
+        ));
+        fields.push(::protobuf::reflect::rt::v2::make_message_field_accessor::<_, RateLimited>(
+            "rate_limited",
+            |m: &ErrorShutdown| { &m.rate_limited },
+            |m: &mut ErrorShutdown| { &mut m.rate_limited },
         ));
         ::protobuf::reflect::GeneratedMessageDescriptorData::new_2::<ErrorShutdown>(
             "ErrorShutdown",
@@ -6567,6 +6594,9 @@ impl ::protobuf::Message for ErrorShutdown {
                 18 => {
                     self.grpc_message = is.read_string()?;
                 },
+                26 => {
+                    ::protobuf::rt::read_singular_message_into_field(is, &mut self.rate_limited)?;
+                },
                 tag => {
                     ::protobuf::rt::read_unknown_or_skip_group(tag, is, self.special_fields.mut_unknown_fields())?;
                 },
@@ -6585,6 +6615,10 @@ impl ::protobuf::Message for ErrorShutdown {
         if !self.grpc_message.is_empty() {
             my_size += ::protobuf::rt::string_size(2, &self.grpc_message);
         }
+        if let Some(v) = self.rate_limited.as_ref() {
+            let len = v.compute_size();
+            my_size += 1 + ::protobuf::rt::compute_raw_varint64_size(len) + len;
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.special_fields.unknown_fields());
         self.special_fields.cached_size().set(my_size as u32);
         my_size
@@ -6596,6 +6630,9 @@ impl ::protobuf::Message for ErrorShutdown {
         }
         if !self.grpc_message.is_empty() {
             os.write_string(2, &self.grpc_message)?;
+        }
+        if let Some(v) = self.rate_limited.as_ref() {
+            ::protobuf::rt::write_message_field_with_cached_size(3, v, os)?;
         }
         os.write_unknown_fields(self.special_fields.unknown_fields())?;
         ::std::result::Result::Ok(())
@@ -6616,6 +6653,7 @@ impl ::protobuf::Message for ErrorShutdown {
     fn clear(&mut self) {
         self.grpc_status = 0;
         self.grpc_message.clear();
+        self.rate_limited.clear();
         self.special_fields.clear();
     }
 
@@ -6623,6 +6661,7 @@ impl ::protobuf::Message for ErrorShutdown {
         static instance: ErrorShutdown = ErrorShutdown {
             grpc_status: 0,
             grpc_message: ::std::string::String::new(),
+            rate_limited: ::protobuf::MessageField::none(),
             special_fields: ::protobuf::SpecialFields::new(),
         };
         &instance
@@ -8561,85 +8600,88 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     treamSettings\x12>\n\x1bconfiguration_update_status\x18\x02\x20\x01(\rR\
     \x19configurationUpdateStatus\x1aP\n\x0eStreamSettings\x12>\n\rping_inte\
     rval\x18\x01\x20\x01(\x0b2\x19.google.protobuf.DurationR\x0cpingInterval\
-    \"\r\n\x0bRateLimited\"\xca\x01\n\x11LogUploadResponse\x12(\n\x0bupload_\
-    uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\
-    \n\x05error\x18\x02\x20\x01(\tR\x05error\x12!\n\x0clogs_dropped\x18\x03\
-    \x20\x01(\rR\x0blogsDropped\x12R\n\x0crate_limited\x18\x04\x20\x01(\x0b2\
-    /.bitdrift_public.protobuf.client.v1.RateLimitedR\x0brateLimited\"\xae\
-    \x06\n\x12StatsUploadRequest\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\n\
-    uploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12e\n\x08snapshot\x18\x02\x20\x03\
-    (\x0b2?.bitdrift_public.protobuf.client.v1.StatsUploadRequest.SnapshotR\
-    \x08snapshotB\x08\xfaB\x05\x92\x01\x02\x08\x01\x123\n\x07sent_at\x18\x03\
-    \x20\x01(\x0b2\x1a.google.protobuf.TimestampR\x06sentAt\x1a\xd1\x04\n\
-    \x08Snapshot\x12K\n\x07metrics\x18\x01\x20\x01(\x0b2/.bitdrift_public.pr\
-    otobuf.client.v1.MetricsListH\0R\x07metrics\x12l\n\naggregated\x18\x02\
-    \x20\x01(\x0b2J.bitdrift_public.protobuf.client.v1.StatsUploadRequest.Sn\
-    apshot.AggregatedH\x01R\naggregated\x12\x86\x01\n\x13metric_id_overflows\
-    \x18\x03\x20\x03(\x0b2V.bitdrift_public.protobuf.client.v1.StatsUploadRe\
-    quest.Snapshot.MetricIdOverflowsEntryR\x11metricIdOverflows\x1a\x90\x01\
-    \n\nAggregated\x12G\n\x0cperiod_start\x18\x04\x20\x01(\x0b2\x1a.google.p\
-    rotobuf.TimestampR\x0bperiodStartB\x08\xfaB\x05\x8a\x01\x02\x10\x01\x129\
-    \n\nperiod_end\x18\x05\x20\x01(\x0b2\x1a.google.protobuf.TimestampR\tper\
-    iodEnd\x1aD\n\x16MetricIdOverflowsEntry\x12\x10\n\x03key\x18\x01\x20\x01\
-    (\tR\x03key\x12\x14\n\x05value\x18\x02\x20\x01(\x04R\x05value:\x028\x01B\
-    \x14\n\rsnapshot_type\x12\x03\xf8B\x01B\x12\n\x0boccurred_at\x12\x03\xf8\
-    B\x01\"~\n\x13StatsUploadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\
-    \tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\
-    \x20\x01(\tR\x05error\x12'\n\x0fmetrics_dropped\x18\x03\x20\x01(\rR\x0em\
-    etricsDropped\"\x0e\n\x0cPongResponse\"\xba\x05\n\x13ConfigurationUpdate\
-    \x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNonce\x12v\n\x12sta\
-    te_of_the_world\x18\x02\x20\x01(\x0b2G.bitdrift_public.protobuf.client.v\
-    1.ConfigurationUpdate.StateOfTheWorldH\0R\x0fstateOfTheWorld\x1a\xf6\x03\
-    \n\x0fStateOfTheWorld\x12b\n\x12buffer_config_list\x18\x03\x20\x01(\x0b2\
-    4.bitdrift_public.protobuf.config.v1.BufferConfigListR\x10bufferConfigLi\
-    st\x12u\n\x17workflows_configuration\x18\x04\x20\x01(\x0b2<.bitdrift_pub\
-    lic.protobuf.workflow.v1.WorkflowsConfigurationR\x16workflowsConfigurati\
-    on\x12k\n\x14bdtail_configuration\x18\x06\x20\x01(\x0b28.bitdrift_public\
-    .protobuf.bdtail.v1.BdTailConfigurationsR\x13bdtailConfiguration\x12m\n\
-    \x15filters_configuration\x18\x08\x20\x01(\x0b28.bitdrift_public.protobu\
-    f.filter.v1.FiltersConfigurationR\x14filtersConfigurationJ\x04\x08\x02\
-    \x10\x03J\x04\x08\x07\x10\x08R\x08mll_listR\x16insights_configurationB\r\
-    \n\x0bupdate_type\"{\n\rRuntimeUpdate\x12#\n\rversion_nonce\x18\x01\x20\
-    \x01(\tR\x0cversionNonce\x12E\n\x07runtime\x18\x02\x20\x01(\x0b2+.bitdri\
-    ft_public.protobuf.client.v1.RuntimeR\x07runtime\"S\n\rErrorShutdown\x12\
-    \x1f\n\x0bgrpc_status\x18\x01\x20\x01(\x05R\ngrpcStatus\x12!\n\x0cgrpc_m\
-    essage\x18\x02\x20\x01(\tR\x0bgrpcMessage\"4\n\x0cFlushBuffers\x12$\n\
-    \x0ebuffer_id_list\x18\x01\x20\x03(\tR\x0cbufferIdList\"Z\n\x18SankeyPat\
-    hUploadResponse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\
-    \x07\xfaB\x04r\x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05err\
-    or\"\xcb\x02\n\x14SankeyIntentResponse\x12(\n\x0bintent_uuid\x18\x01\x20\
-    \x01(\tR\nintentUuidB\x07\xfaB\x04r\x02\x10\x01\x12{\n\x12upload_immedia\
-    tely\x18\x03\x20\x01(\x0b2J.bitdrift_public.protobuf.client.v1.SankeyInt\
-    entResponse.UploadImmediatelyH\0R\x11uploadImmediately\x12S\n\x04drop\
-    \x18\x04\x20\x01(\x0b2=.bitdrift_public.protobuf.client.v1.SankeyIntentR\
-    esponse.DropH\0R\x04drop\x1a\x13\n\x11UploadImmediately\x1a\x06\n\x04Dro\
-    pB\n\n\x08decisionJ\x04\x08\x02\x10\x03R\x08decision\"\xa8\n\n\x0bApiRes\
-    ponse\x12U\n\thandshake\x18\x01\x20\x01(\x0b25.bitdrift_public.protobuf.\
-    client.v1.HandshakeResponseH\0R\thandshake\x12V\n\nlog_upload\x18\x02\
-    \x20\x01(\x0b25.bitdrift_public.protobuf.client.v1.LogUploadResponseH\0R\
-    \tlogUpload\x12i\n\x11log_upload_intent\x18\x08\x20\x01(\x0b2;.bitdrift_\
-    public.protobuf.client.v1.LogUploadIntentResponseH\0R\x0flogUploadIntent\
-    \x12\\\n\x0cstats_upload\x18\x07\x20\x01(\x0b27.bitdrift_public.protobuf\
-    .client.v1.StatsUploadResponseH\0R\x0bstatsUpload\x12F\n\x04pong\x18\x03\
-    \x20\x01(\x0b20.bitdrift_public.protobuf.client.v1.PongResponseH\0R\x04p\
-    ong\x12l\n\x14configuration_update\x18\x04\x20\x01(\x0b27.bitdrift_publi\
-    c.protobuf.client.v1.ConfigurationUpdateH\0R\x13configurationUpdate\x12Z\
-    \n\x0eruntime_update\x18\x05\x20\x01(\x0b21.bitdrift_public.protobuf.cli\
-    ent.v1.RuntimeUpdateH\0R\rruntimeUpdate\x12Z\n\x0eerror_shutdown\x18\x06\
-    \x20\x01(\x0b21.bitdrift_public.protobuf.client.v1.ErrorShutdownH\0R\rer\
-    rorShutdown\x12W\n\rflush_buffers\x18\t\x20\x01(\x0b20.bitdrift_public.p\
-    rotobuf.client.v1.FlushBuffersH\0R\x0cflushBuffers\x12r\n\x15sankey_diag\
-    ram_upload\x18\x0c\x20\x01(\x0b2<.bitdrift_public.protobuf.client.v1.San\
-    keyPathUploadResponseH\0R\x13sankeyDiagramUpload\x12p\n\x16sankey_intent\
-    _response\x18\r\x20\x01(\x0b28.bitdrift_public.protobuf.client.v1.Sankey\
-    IntentResponseH\0R\x14sankeyIntentResponse\x12e\n\x0fartifact_upload\x18\
-    \x0e\x20\x01(\x0b2:.bitdrift_public.protobuf.client.v1.UploadArtifactRes\
-    ponseH\0R\x0eartifactUpload\x12k\n\x0fartifact_intent\x18\x0f\x20\x01(\
-    \x0b2@.bitdrift_public.protobuf.client.v1.UploadArtifactIntentResponseH\
-    \0R\x0eartifactIntentB\x14\n\rresponse_type\x12\x03\xf8B\x01J\x04\x08\n\
-    \x10\x0bJ\x04\x08\x0b\x10\x0c2x\n\nApiService\x12j\n\x03Mux\x12..bitdrif\
-    t_public.protobuf.client.v1.ApiRequest\x1a/.bitdrift_public.protobuf.cli\
-    ent.v1.ApiResponse(\x010\x01b\x06proto3\
+    \"I\n\x0bRateLimited\x12:\n\x0bretry_after\x18\x01\x20\x01(\x0b2\x19.goo\
+    gle.protobuf.DurationR\nretryAfter\"\xca\x01\n\x11LogUploadResponse\x12(\
+    \n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\
+    \x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05error\x12!\n\x0clogs_drop\
+    ped\x18\x03\x20\x01(\rR\x0blogsDropped\x12R\n\x0crate_limited\x18\x04\
+    \x20\x01(\x0b2/.bitdrift_public.protobuf.client.v1.RateLimitedR\x0brateL\
+    imited\"\xae\x06\n\x12StatsUploadRequest\x12(\n\x0bupload_uuid\x18\x01\
+    \x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12e\n\x08snapshot\
+    \x18\x02\x20\x03(\x0b2?.bitdrift_public.protobuf.client.v1.StatsUploadRe\
+    quest.SnapshotR\x08snapshotB\x08\xfaB\x05\x92\x01\x02\x08\x01\x123\n\x07\
+    sent_at\x18\x03\x20\x01(\x0b2\x1a.google.protobuf.TimestampR\x06sentAt\
+    \x1a\xd1\x04\n\x08Snapshot\x12K\n\x07metrics\x18\x01\x20\x01(\x0b2/.bitd\
+    rift_public.protobuf.client.v1.MetricsListH\0R\x07metrics\x12l\n\naggreg\
+    ated\x18\x02\x20\x01(\x0b2J.bitdrift_public.protobuf.client.v1.StatsUplo\
+    adRequest.Snapshot.AggregatedH\x01R\naggregated\x12\x86\x01\n\x13metric_\
+    id_overflows\x18\x03\x20\x03(\x0b2V.bitdrift_public.protobuf.client.v1.S\
+    tatsUploadRequest.Snapshot.MetricIdOverflowsEntryR\x11metricIdOverflows\
+    \x1a\x90\x01\n\nAggregated\x12G\n\x0cperiod_start\x18\x04\x20\x01(\x0b2\
+    \x1a.google.protobuf.TimestampR\x0bperiodStartB\x08\xfaB\x05\x8a\x01\x02\
+    \x10\x01\x129\n\nperiod_end\x18\x05\x20\x01(\x0b2\x1a.google.protobuf.Ti\
+    mestampR\tperiodEnd\x1aD\n\x16MetricIdOverflowsEntry\x12\x10\n\x03key\
+    \x18\x01\x20\x01(\tR\x03key\x12\x14\n\x05value\x18\x02\x20\x01(\x04R\x05\
+    value:\x028\x01B\x14\n\rsnapshot_type\x12\x03\xf8B\x01B\x12\n\x0boccurre\
+    d_at\x12\x03\xf8B\x01\"~\n\x13StatsUploadResponse\x12(\n\x0bupload_uuid\
+    \x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\x02\x10\x01\x12\x14\n\
+    \x05error\x18\x02\x20\x01(\tR\x05error\x12'\n\x0fmetrics_dropped\x18\x03\
+    \x20\x01(\rR\x0emetricsDropped\"\x0e\n\x0cPongResponse\"\xba\x05\n\x13Co\
+    nfigurationUpdate\x12#\n\rversion_nonce\x18\x01\x20\x01(\tR\x0cversionNo\
+    nce\x12v\n\x12state_of_the_world\x18\x02\x20\x01(\x0b2G.bitdrift_public.\
+    protobuf.client.v1.ConfigurationUpdate.StateOfTheWorldH\0R\x0fstateOfThe\
+    World\x1a\xf6\x03\n\x0fStateOfTheWorld\x12b\n\x12buffer_config_list\x18\
+    \x03\x20\x01(\x0b24.bitdrift_public.protobuf.config.v1.BufferConfigListR\
+    \x10bufferConfigList\x12u\n\x17workflows_configuration\x18\x04\x20\x01(\
+    \x0b2<.bitdrift_public.protobuf.workflow.v1.WorkflowsConfigurationR\x16w\
+    orkflowsConfiguration\x12k\n\x14bdtail_configuration\x18\x06\x20\x01(\
+    \x0b28.bitdrift_public.protobuf.bdtail.v1.BdTailConfigurationsR\x13bdtai\
+    lConfiguration\x12m\n\x15filters_configuration\x18\x08\x20\x01(\x0b28.bi\
+    tdrift_public.protobuf.filter.v1.FiltersConfigurationR\x14filtersConfigu\
+    rationJ\x04\x08\x02\x10\x03J\x04\x08\x07\x10\x08R\x08mll_listR\x16insigh\
+    ts_configurationB\r\n\x0bupdate_type\"{\n\rRuntimeUpdate\x12#\n\rversion\
+    _nonce\x18\x01\x20\x01(\tR\x0cversionNonce\x12E\n\x07runtime\x18\x02\x20\
+    \x01(\x0b2+.bitdrift_public.protobuf.client.v1.RuntimeR\x07runtime\"\xa7\
+    \x01\n\rErrorShutdown\x12\x1f\n\x0bgrpc_status\x18\x01\x20\x01(\x05R\ngr\
+    pcStatus\x12!\n\x0cgrpc_message\x18\x02\x20\x01(\tR\x0bgrpcMessage\x12R\
+    \n\x0crate_limited\x18\x03\x20\x01(\x0b2/.bitdrift_public.protobuf.clien\
+    t.v1.RateLimitedR\x0brateLimited\"4\n\x0cFlushBuffers\x12$\n\x0ebuffer_i\
+    d_list\x18\x01\x20\x03(\tR\x0cbufferIdList\"Z\n\x18SankeyPathUploadRespo\
+    nse\x12(\n\x0bupload_uuid\x18\x01\x20\x01(\tR\nuploadUuidB\x07\xfaB\x04r\
+    \x02\x10\x01\x12\x14\n\x05error\x18\x02\x20\x01(\tR\x05error\"\xcb\x02\n\
+    \x14SankeyIntentResponse\x12(\n\x0bintent_uuid\x18\x01\x20\x01(\tR\ninte\
+    ntUuidB\x07\xfaB\x04r\x02\x10\x01\x12{\n\x12upload_immediately\x18\x03\
+    \x20\x01(\x0b2J.bitdrift_public.protobuf.client.v1.SankeyIntentResponse.\
+    UploadImmediatelyH\0R\x11uploadImmediately\x12S\n\x04drop\x18\x04\x20\
+    \x01(\x0b2=.bitdrift_public.protobuf.client.v1.SankeyIntentResponse.Drop\
+    H\0R\x04drop\x1a\x13\n\x11UploadImmediately\x1a\x06\n\x04DropB\n\n\x08de\
+    cisionJ\x04\x08\x02\x10\x03R\x08decision\"\xa8\n\n\x0bApiResponse\x12U\n\
+    \thandshake\x18\x01\x20\x01(\x0b25.bitdrift_public.protobuf.client.v1.Ha\
+    ndshakeResponseH\0R\thandshake\x12V\n\nlog_upload\x18\x02\x20\x01(\x0b25\
+    .bitdrift_public.protobuf.client.v1.LogUploadResponseH\0R\tlogUpload\x12\
+    i\n\x11log_upload_intent\x18\x08\x20\x01(\x0b2;.bitdrift_public.protobuf\
+    .client.v1.LogUploadIntentResponseH\0R\x0flogUploadIntent\x12\\\n\x0csta\
+    ts_upload\x18\x07\x20\x01(\x0b27.bitdrift_public.protobuf.client.v1.Stat\
+    sUploadResponseH\0R\x0bstatsUpload\x12F\n\x04pong\x18\x03\x20\x01(\x0b20\
+    .bitdrift_public.protobuf.client.v1.PongResponseH\0R\x04pong\x12l\n\x14c\
+    onfiguration_update\x18\x04\x20\x01(\x0b27.bitdrift_public.protobuf.clie\
+    nt.v1.ConfigurationUpdateH\0R\x13configurationUpdate\x12Z\n\x0eruntime_u\
+    pdate\x18\x05\x20\x01(\x0b21.bitdrift_public.protobuf.client.v1.RuntimeU\
+    pdateH\0R\rruntimeUpdate\x12Z\n\x0eerror_shutdown\x18\x06\x20\x01(\x0b21\
+    .bitdrift_public.protobuf.client.v1.ErrorShutdownH\0R\rerrorShutdown\x12\
+    W\n\rflush_buffers\x18\t\x20\x01(\x0b20.bitdrift_public.protobuf.client.\
+    v1.FlushBuffersH\0R\x0cflushBuffers\x12r\n\x15sankey_diagram_upload\x18\
+    \x0c\x20\x01(\x0b2<.bitdrift_public.protobuf.client.v1.SankeyPathUploadR\
+    esponseH\0R\x13sankeyDiagramUpload\x12p\n\x16sankey_intent_response\x18\
+    \r\x20\x01(\x0b28.bitdrift_public.protobuf.client.v1.SankeyIntentRespons\
+    eH\0R\x14sankeyIntentResponse\x12e\n\x0fartifact_upload\x18\x0e\x20\x01(\
+    \x0b2:.bitdrift_public.protobuf.client.v1.UploadArtifactResponseH\0R\x0e\
+    artifactUpload\x12k\n\x0fartifact_intent\x18\x0f\x20\x01(\x0b2@.bitdrift\
+    _public.protobuf.client.v1.UploadArtifactIntentResponseH\0R\x0eartifactI\
+    ntentB\x14\n\rresponse_type\x12\x03\xf8B\x01J\x04\x08\n\x10\x0bJ\x04\x08\
+    \x0b\x10\x0c2x\n\nApiService\x12j\n\x03Mux\x12..bitdrift_public.protobuf\
+    .client.v1.ApiRequest\x1a/.bitdrift_public.protobuf.client.v1.ApiRespons\
+    e(\x010\x01b\x06proto3\
 ";
 
 /// `FileDescriptorProto` object which was a source for this generated file

--- a/bd-resource-utilization/src/reporter_test.rs
+++ b/bd-resource-utilization/src/reporter_test.rs
@@ -42,7 +42,7 @@ impl Setup {
   async fn update_reporting_interval(&self, interval: Duration) {
     self
       .runtime
-      .update_snapshot(&make_simple_update(vec![
+      .update_snapshot(make_simple_update(vec![
         (
           bd_runtime::runtime::resource_utilization::ResourceUtilizationEnabledFlag::path(),
           ValueKind::Bool(true),
@@ -78,7 +78,7 @@ async fn does_not_report_if_disabled() {
   let setup = Setup::new();
   setup
     .runtime
-    .update_snapshot(&make_simple_update(vec![
+    .update_snapshot(make_simple_update(vec![
       (
         bd_runtime::runtime::resource_utilization::ResourceUtilizationEnabledFlag::path(),
         ValueKind::Bool(false),

--- a/bd-runtime/src/runtime_test.rs
+++ b/bd-runtime/src/runtime_test.rs
@@ -29,7 +29,7 @@ async fn feature_flag_registration() {
 
   // After updating the value it now reflects the updated value.
   loader
-    .update_snapshot(&make_update(
+    .update_snapshot(make_update(
       vec![
         (TestFlag::path(), ValueKind::Int(10)),
         (BoolFlag::path(), ValueKind::Bool(true)),
@@ -42,14 +42,14 @@ async fn feature_flag_registration() {
 
   // When we clear out the runtime, it reverts to the default.
   loader
-    .update_snapshot(&make_update(vec![], String::new()))
+    .update_snapshot(make_update(vec![], String::new()))
     .await;
   assert_eq!(*int_feature_flag.read_mark_update(), 1);
   assert!(!*bool_feature_flag.read_mark_update());
 
   // If the value doesn't change, no events are pushed.
   loader
-    .update_snapshot(&make_update(vec![], String::new()))
+    .update_snapshot(make_update(vec![], String::new()))
     .await;
   assert!(!int_feature_flag.watch.has_changed().unwrap());
   assert!(!bool_feature_flag.watch.has_changed().unwrap());
@@ -63,7 +63,7 @@ async fn registration_after_update() {
   let loader = ConfigLoader::new(sdk_directory.path());
 
   loader
-    .update_snapshot(&make_update(
+    .update_snapshot(make_update(
       vec![(TestFlag::path(), ValueKind::Int(10))],
       "1".to_string(),
     ))
@@ -88,7 +88,7 @@ async fn duration_flag() {
   assert_eq!(*flag.borrow().read(), time::Duration::seconds(5));
 
   loader
-    .update_snapshot(&make_update(
+    .update_snapshot(make_update(
       vec![(DurationFlag::path(), ValueKind::Int(100))],
       "1".to_string(),
     ))
@@ -131,7 +131,7 @@ async fn disk_persistence_happy_path() {
   {
     let loader = setup.new_loader();
     loader
-      .update_snapshot(&bd_test_helpers::runtime::make_update(
+      .update_snapshot(bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
       ))
@@ -172,7 +172,7 @@ async fn disk_persistence_config_corruption() {
   {
     setup
       .new_loader()
-      .update_snapshot(&bd_test_helpers::runtime::make_update(
+      .update_snapshot(bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
       ))
@@ -199,7 +199,7 @@ async fn disk_persistence_retry_corruption() {
   {
     setup
       .new_loader()
-      .update_snapshot(&bd_test_helpers::runtime::make_update(
+      .update_snapshot(bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
       ))
@@ -226,7 +226,7 @@ async fn disk_persistence_retry_limit() {
   {
     setup
       .new_loader()
-      .update_snapshot(&bd_test_helpers::runtime::make_update(
+      .update_snapshot(bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
       ))
@@ -258,7 +258,7 @@ async fn disk_persistence_retry_marked_safe() {
   {
     setup
       .new_loader()
-      .update_snapshot(&bd_test_helpers::runtime::make_update(
+      .update_snapshot(bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
       ))
@@ -291,7 +291,7 @@ async fn disk_persistence_missing_config_file() {
   {
     setup
       .new_loader()
-      .update_snapshot(&bd_test_helpers::runtime::make_update(
+      .update_snapshot(bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
       ))
@@ -321,7 +321,7 @@ async fn disk_persistence_missing_retry_file() {
   {
     setup
       .new_loader()
-      .update_snapshot(&bd_test_helpers::runtime::make_update(
+      .update_snapshot(bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
       ))
@@ -351,7 +351,7 @@ async fn disk_persistence_cannot_update_retry() {
   {
     setup
       .new_loader()
-      .update_snapshot(&bd_test_helpers::runtime::make_update(
+      .update_snapshot(bd_test_helpers::runtime::make_update(
         vec![(TestFlag::path(), ValueKind::Int(10))],
         "1".to_string(),
       ))

--- a/bd-session-replay/src/recorder_test.rs
+++ b/bd-session-replay/src/recorder_test.rs
@@ -58,7 +58,7 @@ impl Setup {
   async fn update_reporting_interval(&self, interval: Duration) {
     self
       .runtime
-      .update_snapshot(&make_simple_update(vec![
+      .update_snapshot(make_simple_update(vec![
         (
           bd_runtime::runtime::session_replay::PeriodicScreensEnabledFlag::path(),
           ValueKind::Bool(true),
@@ -102,7 +102,7 @@ async fn does_not_report_if_disabled() {
   let setup = Setup::new();
   setup
     .runtime
-    .update_snapshot(&make_simple_update(vec![
+    .update_snapshot(make_simple_update(vec![
       (
         bd_runtime::runtime::session_replay::PeriodicScreensEnabledFlag::path(),
         ValueKind::Bool(false),
@@ -187,7 +187,7 @@ async fn taking_screenshots_is_wired_up() {
 
   setup
     .runtime
-    .update_snapshot(&make_simple_update(vec![(
+    .update_snapshot(make_simple_update(vec![(
       bd_runtime::runtime::session_replay::ScreenshotsEnabledFlag::path(),
       ValueKind::Bool(true),
     )]))
@@ -215,7 +215,7 @@ async fn limits_the_number_of_concurrent_screenshots_to_one() {
 
   setup
     .runtime
-    .update_snapshot(&make_simple_update(vec![(
+    .update_snapshot(make_simple_update(vec![(
       bd_runtime::runtime::session_replay::ScreenshotsEnabledFlag::path(),
       ValueKind::Bool(true),
     )]))

--- a/profiling/src/main.rs
+++ b/profiling/src/main.rs
@@ -402,7 +402,7 @@ fn run_profiling<T: Fn(&mut AnnotatedWorkflowsEngine) + std::marker::Send + 'sta
       .block_on(async {
         setup
           .runtime_loader
-          .update_snapshot(&RuntimeUpdate {
+          .update_snapshot(RuntimeUpdate {
             version_nonce: "123".to_string(),
             runtime: Some(bd_test_helpers::runtime::make_proto(vec![(
               bd_runtime::runtime::stats::DirectStatFlushIntervalFlag::path(),


### PR DESCRIPTION
1) Remove shutdown handling in the API. It makes the code convoluted and
   doesn't do anything useful. Instead just move the shutdown wait to
   the top level future.
2) Add retry after handling in the API.
3) Move gRPC Code to the codec crate so it can be used in client code. 
4) Some cleanups in order to remove a bunch of clones during config
   processing.

Fixes BIT-5835