### PR TITLE
improved runtime/workflow crash loop detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,13 +493,16 @@ dependencies = [
  "bd-log-primitives",
  "bd-metadata",
  "bd-proto",
+ "bd-test-helpers",
  "crc32fast",
+ "ctor",
  "flatbuffers",
  "flate2",
  "log",
  "mockall",
  "parking_lot",
  "protobuf 4.0.0-alpha.0",
+ "tempfile",
  "thiserror 2.0.16",
  "time",
  "tokio",
@@ -1363,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.35"
+version = "1.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1754,7 +1757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1765,9 +1768,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "flatbuffers"
@@ -2578,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "logger-cli"
@@ -3384,7 +3387,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3397,7 +3400,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3800,7 +3803,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4454,7 +4457,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ base64ct        = { version = "1.8.0", features = ["alloc", "std"] }
 bincode         = { version = "2.0.1", features = ["serde"] }
 bytes           = "1.10.1"
 cbindgen        = "0.29.0"
-cc              = "1.2.35"
+cc              = "1.2.36"
 clap            = { version = "4.5.47", features = ["derive", "env"] }
 cmake           = "0.1.54"
 color-backtrace = "0.7.1"
@@ -100,7 +100,7 @@ intrusive-collections = "0.9.7"
 itertools             = "0.14.0"
 jni                   = "0.21.1"
 libfuzzer-sys         = "0.4.10"
-log                   = "0.4.27"
+log                   = "0.4.28"
 matches               = "0.1.10"
 memmap2               = "0.9.8"
 mockall               = "0.13.1"

--- a/bd-artifact-upload/src/uploader.rs
+++ b/bd-artifact-upload/src/uploader.rs
@@ -322,7 +322,7 @@ impl Uploader {
         log::debug!("starting file upload for {:?}", next.name);
         self.upload_task_handle = Some(tokio::spawn(Self::upload_artifact(
           self.data_upload_tx.clone(),
-          contents.to_vec(),
+          contents.clone(),
           next.name.clone(),
           next.time.to_offset_date_time(),
           next.session_id.clone(),

--- a/bd-artifact-upload/src/uploader.rs
+++ b/bd-artifact-upload/src/uploader.rs
@@ -322,7 +322,7 @@ impl Uploader {
         log::debug!("starting file upload for {:?}", next.name);
         self.upload_task_handle = Some(tokio::spawn(Self::upload_artifact(
           self.data_upload_tx.clone(),
-          contents.clone(),
+          contents,
           next.name.clone(),
           next.time.to_offset_date_time(),
           next.session_id.clone(),

--- a/bd-artifact-upload/src/uploader_test.rs
+++ b/bd-artifact-upload/src/uploader_test.rs
@@ -101,7 +101,8 @@ impl Setup {
         )],
         "1".to_string(),
       ))
-      .await;
+      .await
+      .unwrap();
 
     let (mut uploader, client) = super::Uploader::new(
       filesystem.clone(),

--- a/bd-client-common/Cargo.toml
+++ b/bd-client-common/Cargo.toml
@@ -21,9 +21,12 @@ log.workspace          = true
 mockall.workspace      = true
 parking_lot.workspace  = true
 protobuf.workspace     = true
+tempfile.workspace     = true
 thiserror.workspace    = true
 time.workspace         = true
 tokio.workspace        = true
 
 [dev-dependencies]
-uuid.workspace = true
+bd-test-helpers.path = "../bd-test-helpers"
+ctor.workspace       = true
+uuid.workspace       = true

--- a/bd-client-common/Cargo.toml
+++ b/bd-client-common/Cargo.toml
@@ -21,7 +21,6 @@ log.workspace          = true
 mockall.workspace      = true
 parking_lot.workspace  = true
 protobuf.workspace     = true
-tempfile.workspace     = true
 thiserror.workspace    = true
 time.workspace         = true
 tokio.workspace        = true
@@ -29,4 +28,5 @@ tokio.workspace        = true
 [dev-dependencies]
 bd-test-helpers.path = "../bd-test-helpers"
 ctor.workspace       = true
+tempfile.workspace   = true
 uuid.workspace       = true

--- a/bd-client-common/src/file.rs
+++ b/bd-client-common/src/file.rs
@@ -69,7 +69,7 @@ pub fn write_checksummed_data(bytes: &[u8]) -> Vec<u8> {
 
 /// Reads the data and checks the CRC checksum at the end of the slice. If the checksum is valid, it
 /// returns the data.
-pub fn read_checksummed_data(bytes: &[u8]) -> anyhow::Result<&[u8]> {
+pub fn read_checksummed_data(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
   if bytes.len() < 4 {
     anyhow::bail!("data too small to contain CRC checksum");
   }
@@ -82,5 +82,5 @@ pub fn read_checksummed_data(bytes: &[u8]) -> anyhow::Result<&[u8]> {
     anyhow::bail!("crc mismatch");
   }
 
-  Ok(data)
+  Ok(data.to_vec())
 }

--- a/bd-client-common/src/file_test.rs
+++ b/bd-client-common/src/file_test.rs
@@ -13,7 +13,9 @@ fn write_checksummed_data() {
 
   assert_eq!(
     data,
-    super::read_checksummed_data(&checksummed_data).unwrap()
+    super::read_checksummed_data(&checksummed_data)
+      .unwrap()
+      .as_slice()
   );
 }
 

--- a/bd-client-common/src/safe_file_cache.rs
+++ b/bd-client-common/src/safe_file_cache.rs
@@ -176,11 +176,12 @@ impl<T: Message> SafeFileCache<T> {
     // runtime config to accidentally set this really high, but right now this is not
     // configurable at all.
     if retry_count >= MAX_RETRY_COUNT {
-      // Note that eventually if the client is killed this is going to kick in since we attempt
-      // to load cached runtime very early on. Since we don't clean state so that we can do changed
-      // nonce detection below, this could pause killed clients to not get new config when they
-      // come back online since there is no crash loop and the nonce hasn't changed. We handle
-      // this directly in the API code by having the state reset when it enters killed mode.
+      // Note that eventually if the client is killed this is going to kick in since we attempt to
+      // load cached runtime very early on. Since we don't clean state so that we can do changed
+      // nonce detection in the cache_update() function, this could cause killed clients to not get
+      // new config when they come back online since there is no crash loop and the nonce hasn't
+      // changed. We handle this directly in the API code by having the state reset when it enters
+      // killed mode.
       log::debug!(
         "cached config for {} has retry count {retry_count} >= {MAX_RETRY_COUNT}, refusing to read",
         self.name

--- a/bd-client-common/src/safe_file_cache.rs
+++ b/bd-client-common/src/safe_file_cache.rs
@@ -5,20 +5,30 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::file::read_compressed_protobuf;
+#[cfg(test)]
+#[path = "./safe_file_cache_test.rs"]
+mod safe_file_cache_test;
+
+use crate::file::{read_checksummed_data, read_compressed_protobuf, write_checksummed_data};
 use anyhow::bail;
+use parking_lot::Mutex;
 use protobuf::Message;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
 
 const MAX_RETRY_COUNT: u8 = 5;
 
 pub struct SafeFileCache<T> {
   directory: PathBuf,
-  cached_config_validated: AtomicBool,
+  locked_state: Mutex<LockedState>,
   name: &'static str,
   phantom: PhantomData<T>,
+}
+#[derive(Default)]
+struct LockedState {
+  cached_config_validated: bool,
+  cached_nonce: Vec<u8>,
+  current_retry_count: u8,
 }
 
 impl<T: Message> SafeFileCache<T> {
@@ -35,7 +45,7 @@ impl<T: Message> SafeFileCache<T> {
     Self {
       name,
       directory,
-      cached_config_validated: AtomicBool::new(false),
+      locked_state: Mutex::default(),
       phantom: PhantomData,
     }
   }
@@ -44,9 +54,13 @@ impl<T: Message> SafeFileCache<T> {
   /// the app continue to read this from disk.
   pub async fn mark_safe(&self) {
     // We load the config from cache only at startup, so we only need to update the file once.
-    if !self.cached_config_validated.swap(true, Ordering::SeqCst) {
+    if !{
+      let mut state = self.locked_state.lock();
+      std::mem::replace(&mut state.cached_config_validated, true)
+    } {
       // If this fails worst case we'll use a stale retry count and eventually disable caching.
       let _ignored = self.persist_cache_load_retry_count(0).await;
+      log::debug!("marked cached config for {} as safe", self.name);
     }
   }
 
@@ -58,10 +72,23 @@ impl<T: Message> SafeFileCache<T> {
     self.directory.join("protobuf.pb")
   }
 
+  fn last_nonce_file(&self) -> PathBuf {
+    self.directory.join("last_nonce")
+  }
+
   async fn persist_cache_load_retry_count(&self, retry_count: u8) -> anyhow::Result<()> {
     // This could fail, but by being defensive when we read this we should ideally worst case just
     // fall back to not reading from cache.
-    Ok(tokio::fs::write(&self.retry_count_file(), &[retry_count]).await?)
+    tokio::fs::write(&self.retry_count_file(), &[retry_count]).await?;
+    log::debug!("wrote retry count {retry_count} for {}", self.name);
+    Ok(())
+  }
+
+  pub async fn reset(&self) {
+    // Recreate the directory instead of deleting individual files, making sure we really clean
+    // up any bad state.
+    let _ignored = tokio::fs::remove_dir_all(&self.directory).await;
+    let _ignored = tokio::fs::create_dir(&self.directory).await;
   }
 
   pub async fn handle_cached_config(&self) -> Option<T> {
@@ -80,10 +107,7 @@ impl<T: Message> SafeFileCache<T> {
     };
 
     if reset {
-      // Recreate the directory instead of deleting individual files, making sure we really clean
-      // up any bad state.
-      let _ignored = tokio::fs::remove_dir_all(&self.directory).await;
-      let _ignored = tokio::fs::create_dir(&self.directory).await;
+      self.reset().await;
     }
 
     cached
@@ -109,9 +133,12 @@ impl<T: Message> SafeFileCache<T> {
       || !tokio::fs::try_exists(self.protobuf_file())
         .await
         .is_ok_and(|e| e)
+      || !tokio::fs::try_exists(self.last_nonce_file())
+        .await
+        .is_ok_and(|e| e)
     {
       log::debug!(
-        "cached retry count or config not found for {:?}, resetting cache",
+        "cached retry count, config, or last nonce not found for {:?}, resetting cache",
         self.name
       );
       return Ok((true, None));
@@ -125,27 +152,47 @@ impl<T: Message> SafeFileCache<T> {
     else {
       return Ok((true, None));
     };
+    log::debug!("loaded retry count {retry_count} for {}", self.name);
 
+    // Same for the cached nonce file.
+    let Ok(nonce) =
+      async { read_checksummed_data(&tokio::fs::read(&self.last_nonce_file()).await?) }.await
+    else {
+      return Ok((true, None));
+    };
     log::debug!(
-      "loaded file at retry count {retry_count} for {:?}",
+      "loaded nonce {} for {}",
+      std::str::from_utf8(&nonce).unwrap_or_default(),
       self.name
     );
+
+    {
+      let mut locked = self.locked_state.lock();
+      locked.current_retry_count = retry_count;
+      locked.cached_nonce = nonce;
+    }
+
+    // TODO(snowp): Should we read this from runtime as well? It would make it possible for a bad
+    // runtime config to accidentally set this really high, but right now this is not
+    // configurable at all.
+    if retry_count >= MAX_RETRY_COUNT {
+      // Note that eventually if the client is killed this is going to kick in since we attempt
+      // to load cached runtime very early on. Since we don't clean state so that we can do changed
+      // nonce detection below, this could pause killed clients to not get new config when they
+      // come back online since there is no crash loop and the nonce hasn't changed. We handle
+      // this directly in the API code by having the state reset when it enters killed mode.
+      log::debug!(
+        "cached config for {} has retry count {retry_count} >= {MAX_RETRY_COUNT}, refusing to read",
+        self.name
+      );
+      return Ok((false, None));
+    }
 
     // Update the retry count before we apply the config. If this fails, we bail out (which will
     // attempt to clear the cache directory) and disable caching. We do this because being unable
     // to update the retry count may result in us getting stuck processing what we think is retry
     // 0 over and over again.
     self.persist_cache_load_retry_count(retry_count + 1).await?;
-
-    // TODO(snowp): Should we read this from runtime as well? It would make it possible for a bad
-    // runtime config to accidentally set this really high, but right now this is not
-    // configurable at all.
-    if retry_count > MAX_RETRY_COUNT {
-      // Note that eventually if the client is killed this is going to kick in and delete cached
-      // config. This is OK since we are still covered by the kill file, and ultimately we would
-      // like the client to come up and get fresh config anyway.
-      return Ok((true, None));
-    }
 
     let bytes = tokio::fs::read(&self.protobuf_file()).await?;
     let protobuf: T = read_compressed_protobuf(&bytes)?;
@@ -163,8 +210,33 @@ impl<T: Message> SafeFileCache<T> {
     Ok(data[0])
   }
 
-  pub async fn cache_update(&self, compressed_protobuf: Vec<u8>) {
+  pub async fn cache_update(
+    &self,
+    compressed_protobuf: Vec<u8>,
+    version_nonce: &str,
+    apply_fn: impl Future<Output = anyhow::Result<()>>,
+  ) -> anyhow::Result<()> {
+    let res = {
+      let state = self.locked_state.lock();
+      state.current_retry_count >= MAX_RETRY_COUNT && state.cached_nonce == version_nonce.as_bytes()
+    };
+    if res {
+      log::debug!(
+        "refusing to cache config for {} at nonce {version_nonce} since retry count is already at \
+         max and nonce has not changed",
+        self.name
+      );
+      bail!("refusing to cache config during suspected crash loop with no nonce change");
+    }
+
+    apply_fn.await?;
+
     if let Err(e) = async {
+      tokio::fs::write(
+        &self.last_nonce_file(),
+        write_checksummed_data(version_nonce.as_bytes()),
+      )
+      .await?;
       Ok::<_, anyhow::Error>(tokio::fs::write(&self.protobuf_file(), compressed_protobuf).await?)
     }
     .await
@@ -174,9 +246,15 @@ impl<T: Message> SafeFileCache<T> {
 
     // Failing here is fine, worst case we'll use an old retry count or leave it missing, which
     // will eventually disable caching.
-    self.cached_config_validated.store(true, Ordering::SeqCst);
+    self.locked_state.lock().cached_config_validated = true;
     if let Err(e) = self.persist_cache_load_retry_count(0).await {
       log::debug!("failed to write retry count for {}: {e}", self.name);
     }
+
+    log::debug!(
+      "cached config for {} successfully at nonce {version_nonce}",
+      self.name
+    );
+    Ok(())
   }
 }

--- a/bd-client-common/src/safe_file_cache_test.rs
+++ b/bd-client-common/src/safe_file_cache_test.rs
@@ -1,3 +1,10 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 use crate::file::write_compressed_protobuf;
 use crate::safe_file_cache::{MAX_RETRY_COUNT, SafeFileCache};
 use bd_proto::protos::client::api::ClientKillFile;

--- a/bd-client-common/src/safe_file_cache_test.rs
+++ b/bd-client-common/src/safe_file_cache_test.rs
@@ -46,7 +46,7 @@ async fn basic_flow() {
   let cache = SafeFileCache::<ClientKillFile>::new("test", tempdir.path());
   assert!(cache.handle_cached_config().await.is_none());
 
-  // We should need delete any state so make sure we come up again but get no config.
+  // We should delete any state so make sure we come up again but get no config.
   let cache = SafeFileCache::<ClientKillFile>::new("test", tempdir.path());
   assert!(cache.handle_cached_config().await.is_none());
 

--- a/bd-client-common/src/safe_file_cache_test.rs
+++ b/bd-client-common/src/safe_file_cache_test.rs
@@ -1,0 +1,70 @@
+use crate::file::write_compressed_protobuf;
+use crate::safe_file_cache::{MAX_RETRY_COUNT, SafeFileCache};
+use bd_proto::protos::client::api::ClientKillFile;
+use protobuf::Message;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn basic_flow() {
+  let tempdir = tempdir().unwrap();
+  let cache = SafeFileCache::<ClientKillFile>::new("test", tempdir.path());
+  assert!(cache.handle_cached_config().await.is_none());
+  cache
+    .cache_update(
+      write_compressed_protobuf(ClientKillFile::default_instance()).unwrap(),
+      "123",
+      async { Ok(()) },
+    )
+    .await
+    .unwrap();
+
+  // Reload and make sure we get the cached config.
+  let cache = SafeFileCache::<ClientKillFile>::new("test", tempdir.path());
+  assert_eq!(
+    ClientKillFile::default(),
+    cache.handle_cached_config().await.unwrap()
+  );
+  cache.mark_safe().await;
+
+  // Simulate a crash loop by coming up several times without marking safe.
+  for _i in 0 .. (MAX_RETRY_COUNT) {
+    let cache = SafeFileCache::<ClientKillFile>::new("test", tempdir.path());
+    assert_eq!(
+      ClientKillFile::default(),
+      cache.handle_cached_config().await.unwrap()
+    );
+  }
+
+  // The next time we come up we should refuse to load the cached config.
+  let cache = SafeFileCache::<ClientKillFile>::new("test", tempdir.path());
+  assert!(cache.handle_cached_config().await.is_none());
+
+  // We should need delete any state so make sure we come up again but get no config.
+  let cache = SafeFileCache::<ClientKillFile>::new("test", tempdir.path());
+  assert!(cache.handle_cached_config().await.is_none());
+
+  // Now that we are up, deliver the same config again with the same nonce, it should not be
+  // applied since it's the same version.
+  assert_eq!(
+    cache
+      .cache_update(
+        write_compressed_protobuf(ClientKillFile::default_instance()).unwrap(),
+        "123",
+        async { panic!() },
+      )
+      .await
+      .unwrap_err()
+      .to_string(),
+    "refusing to cache config during suspected crash loop with no nonce change"
+  );
+
+  // Delivering a new nonce should work.
+  cache
+    .cache_update(
+      write_compressed_protobuf(ClientKillFile::default_instance()).unwrap(),
+      "456",
+      async { Ok(()) },
+    )
+    .await
+    .unwrap();
+}

--- a/bd-client-stats/src/stats_test.rs
+++ b/bd-client-stats/src/stats_test.rs
@@ -144,7 +144,8 @@ impl Setup {
         bd_runtime::runtime::stats::MaxAggregatedFilesFlag::path(),
         ValueKind::Int(2),
       )]))
-      .await;
+      .await
+      .unwrap();
 
     let stats = Stats::new(Collector::new(Some(watch::channel(limit).1)));
     let (data_tx, data_rx) = mpsc::channel(1);

--- a/bd-crash-handler/src/config_writer_test.rs
+++ b/bd-crash-handler/src/config_writer_test.rs
@@ -32,7 +32,8 @@ impl Setup {
           "crash_reporting.enabled",
           ValueKind::Bool(crash_reporting_enabled),
         )]))
-        .await;
+        .await
+        .unwrap();
     }
 
     let shutdown = ComponentShutdownTrigger::default();
@@ -53,7 +54,8 @@ impl Setup {
         "crash_reporting.enabled",
         ValueKind::Bool(value),
       )]))
-      .await;
+      .await
+      .unwrap();
   }
 
   fn read_config_file(&self) -> String {

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -62,7 +62,8 @@ impl Setup {
           runtime::artifact_upload::Enabled::path(),
           ValueKind::Bool(artifact_upload),
         )]))
-        .await;
+        .await
+        .unwrap();
     }
 
     let shutdown = ComponentShutdownTrigger::default();

--- a/bd-events/src/listener_test.rs
+++ b/bd-events/src/listener_test.rs
@@ -46,7 +46,8 @@ impl Setup {
         bd_runtime::runtime::platform_events::ListenerEnabledFlag::path(),
         ValueKind::Bool(events_listener_enabled),
       )]))
-      .await;
+      .await
+      .unwrap();
   }
 }
 

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -615,7 +615,8 @@ async fn logs_resource_utilization_log() {
         ValueKind::Int(250),
       ),
     ]))
-    .await;
+    .await
+    .unwrap();
 
   let config_update = setup.make_config_update(WorkflowsConfiguration::default());
   let task = std::thread::spawn(move || {

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -15,7 +15,6 @@ use crate::logger::Logger;
 use crate::logging_state::UninitializedLoggingContext;
 use bd_api::DataUpload;
 use bd_api::api::SimpleNetworkQualityProvider;
-use bd_client_common::ConfigurationUpdate;
 use bd_client_common::file_system::RealFileSystem;
 use bd_client_stats::FlushTrigger;
 use bd_client_stats::stats::{

--- a/bd-logger/src/client_config_test.rs
+++ b/bd-logger/src/client_config_test.rs
@@ -7,7 +7,7 @@
 
 use super::{Config, Configuration};
 use anyhow::anyhow;
-use bd_client_common::{ConfigurationUpdate as _, HANDSHAKE_FLAG_CONFIG_UP_TO_DATE};
+use bd_client_common::{ClientConfigurationUpdate, HANDSHAKE_FLAG_CONFIG_UP_TO_DATE};
 use bd_proto::protos::client::api::ConfigurationUpdate;
 use bd_proto::protos::client::api::configuration_update::{StateOfTheWorld, Update_type};
 use bd_proto::protos::config::v1::config::BufferConfigList;

--- a/bd-logger/src/consumer_test.rs
+++ b/bd-logger/src/consumer_test.rs
@@ -149,7 +149,8 @@ async fn upload_retries() {
       bd_runtime::runtime::log_upload::BatchSizeFlag::path(),
       ValueKind::Int(10),
     )]))
-    .await;
+    .await
+    .unwrap();
 
   // Write logs for one batch upload.
   for _ in 0 .. 10 {
@@ -201,7 +202,8 @@ async fn upload_retries() {
       bd_runtime::runtime::log_upload::RetryCountFlag::path(),
       ValueKind::Int(1),
     )]))
-    .await;
+    .await
+    .unwrap();
 
   for _ in 0 .. 10 {
     setup.producer.write(b"c").unwrap();
@@ -255,7 +257,8 @@ async fn continuous_buffer_upload_byte_limit() {
       bd_runtime::runtime::log_upload::BatchSizeBytesFlag::path(),
       ValueKind::Int(10),
     )]))
-    .await;
+    .await
+    .unwrap();
 
   for _ in 0 .. 2 {
     setup.producer.write(&[0; 150]).unwrap();
@@ -292,7 +295,8 @@ async fn continuous_buffer_upload_shutdown() {
       bd_runtime::runtime::log_upload::BatchSizeBytesFlag::path(),
       ValueKind::Int(10),
     )]))
-    .await;
+    .await
+    .unwrap();
 
   setup.producer.write(&[0; 150]).unwrap();
 
@@ -316,7 +320,8 @@ async fn uploading_full_batch_failure() {
       bd_runtime::runtime::log_upload::BatchSizeFlag::path(),
       ValueKind::Int(10),
     )]))
-    .await;
+    .await
+    .unwrap();
 
   for i in 0 .. 11 {
     setup.producer.write(&[i]).unwrap();
@@ -511,7 +516,8 @@ async fn age_limit_log_uploads() {
         ValueKind::Int(10),
       ),
     ]))
-    .await;
+    .await
+    .unwrap();
 
   let now = time::OffsetDateTime::now_utc().floor(1.minutes());
   for i in (0 .. 5).rev() {
@@ -605,7 +611,8 @@ impl SetupMultiConsumer {
           ValueKind::Int(byte_limit),
         ),
       ]))
-      .await;
+      .await
+      .unwrap();
     let shutdown = shutdown_trigger.make_shutdown();
     let config_loader_clone = config_loader.clone();
     let collector_clone = stats.clone();
@@ -928,7 +935,8 @@ async fn streaming_batch_size_flag() {
       bd_runtime::runtime::log_upload::StreamingBatchSizeFlag::path(),
       ValueKind::Int(2),
     )]))
-    .await;
+    .await
+    .unwrap();
 
   let upload_service = service::new(
     log_upload_tx,

--- a/bd-logger/src/ratelimit_test.rs
+++ b/bd-logger/src/ratelimit_test.rs
@@ -62,7 +62,8 @@ async fn ratelimit() {
         ValueKind::Int(1000),
       ),
     ]))
-    .await;
+    .await
+    .unwrap();
 
   let rate_limit = RateLimitLayer::new(super::Rate::new(&runtime_loader));
   let mut service = tower::ServiceBuilder::new()
@@ -106,7 +107,8 @@ async fn shared_quota() {
         ValueKind::Int(1000),
       ),
     ]))
-    .await;
+    .await
+    .unwrap();
 
   let rate_limit = RateLimitLayer::new(super::Rate::new(&runtime_loader));
   let mut service1 = tower::ServiceBuilder::new()

--- a/bd-resource-utilization/src/reporter_test.rs
+++ b/bd-resource-utilization/src/reporter_test.rs
@@ -54,7 +54,8 @@ impl Setup {
           ValueKind::Int(interval.whole_milliseconds().try_into().unwrap()),
         ),
       ]))
-      .await;
+      .await
+      .unwrap();
   }
 }
 
@@ -88,7 +89,8 @@ async fn does_not_report_if_disabled() {
         ValueKind::Int(10),
       ),
     ]))
-    .await;
+    .await
+    .unwrap();
 
   let target = Box::<MockTarget>::default();
   let ticks_count = target.ticks_count.clone();

--- a/bd-runtime/src/test.rs
+++ b/bd-runtime/src/test.rs
@@ -9,7 +9,6 @@
 #![allow(clippy::expect_used)]
 
 use crate::runtime::ConfigLoader;
-use bd_client_common::ConfigurationUpdate;
 use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;

--- a/bd-session-replay/src/recorder_test.rs
+++ b/bd-session-replay/src/recorder_test.rs
@@ -69,7 +69,8 @@ impl Setup {
           ValueKind::Int(interval.whole_milliseconds().try_into().unwrap()),
         ),
       ]))
-      .await;
+      .await
+      .unwrap();
   }
 }
 
@@ -112,7 +113,8 @@ async fn does_not_report_if_disabled() {
         ValueKind::Int(10),
       ),
     ]))
-    .await;
+    .await
+    .unwrap();
 
   let target = Box::<MockTarget>::default();
   let capture_screen_count = target.capture_screen_count.clone();
@@ -191,7 +193,8 @@ async fn taking_screenshots_is_wired_up() {
       bd_runtime::runtime::session_replay::ScreenshotsEnabledFlag::path(),
       ValueKind::Bool(true),
     )]))
-    .await;
+    .await
+    .unwrap();
 
   100.milliseconds().sleep().await;
 
@@ -219,7 +222,8 @@ async fn limits_the_number_of_concurrent_screenshots_to_one() {
       bd_runtime::runtime::session_replay::ScreenshotsEnabledFlag::path(),
       ValueKind::Bool(true),
     )]))
-    .await;
+    .await
+    .unwrap();
 
   let target = Box::<MockTarget>::default();
   let capture_screenshot_count = target.capture_screenshot_count.clone();

--- a/profiling/src/main.rs
+++ b/profiling/src/main.rs
@@ -411,7 +411,8 @@ fn run_profiling<T: Fn(&mut AnnotatedWorkflowsEngine) + std::marker::Send + 'sta
             .into(),
             ..Default::default()
           })
-          .await;
+          .await
+          .unwrap();
 
         // Given the runtime configuration update time to propagate.
         1.seconds().sleep().await;


### PR DESCRIPTION
Now we store the nonce of the last accepted/cached configuration. If we think we have entered a crash loop, we refuse to receive new configuration unless the nonce has changed. In order to support this we no longer clean the cached files when we hit the retry count. The downside of this is that if a client is put into the killed state it would likely come back online and refuse to accept new config if the config hasn't changed. To handle this case we clear cached config when the client enters the killed state.

Fixes BIT-6168