### PR TITLE
put the C++ validation code behind a cargo feature

### DIFF
--- a/bd-proto-util/Cargo.toml
+++ b/bd-proto-util/Cargo.toml
@@ -20,3 +20,6 @@ time.workspace        = true
 
 [build-dependencies]
 cc.workspace = true
+
+[features]
+buffer-log-validate = []

--- a/bd-proto-util/build.rs
+++ b/bd-proto-util/build.rs
@@ -6,6 +6,11 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 fn main() {
+  println!("cargo:rerun-if-changed=src/cpp/verify.cc");
+  println!("cargo:rerun-if-changed=../bd-proto/src/flatbuffers");
+  println!("cargo:rerun-if-changed=../thirdparty/flatbuffers/include");
+
+  #[cfg(feature = "buffer-log-validate")]
   // Compile verifier library for use in verifying incoming flatbuffers. Currently the Rust
   // verifier is not production ready.
   cc::Build::new()

--- a/bd-proto-util/src/lib.rs
+++ b/bd-proto-util/src/lib.rs
@@ -8,7 +8,9 @@
 pub mod fbs;
 pub mod proto;
 
+#[cfg(feature = "buffer-log-validate")]
 use anyhow::bail;
+#[cfg(feature = "buffer-log-validate")]
 use bd_proto::flatbuffers::buffer_log::bitdrift_public::fbs::logging::v_1::{
   Log,
   root_as_log_unchecked,
@@ -18,10 +20,12 @@ use protobuf::MessageFull;
 use std::borrow::Cow;
 use std::fmt::Debug;
 
+#[cfg(feature = "buffer-log-validate")]
 unsafe extern "C" {
   fn verify_log_buffer(buf: *const u8, buf_len: usize) -> bool;
 }
 
+#[cfg(feature = "buffer-log-validate")]
 pub fn call_verify_log_buffer(buf: &[u8]) -> anyhow::Result<Log<'_>> {
   // The Rust verification code is noted as experimental, which was quickly proven via a failing
   // fuzz test. The following code calls out to the C++ verifier code (see src/cpp/verify.cc) to


### PR DESCRIPTION
This avoids bringing it into the SDK where it runs into Bazel issues with the build.rs script