### PR TITLE
logger streaming mode changes

### DIFF
--- a/bd-api/src/api.rs
+++ b/bd-api/src/api.rs
@@ -280,6 +280,7 @@ impl StreamState {
         let req = self.upload_state_tracker.track_upload(request);
         self.send_request(req).await
       },
+      DataUpload::AcklessLogsUpload(request) => self.send_request(request).await,
       DataUpload::StatsUpload(mut request) => {
         request.payload.sent_at = self.time_provider.now().into_proto();
         let req = self.upload_state_tracker.track_upload(request);

--- a/bd-api/src/lib.rs
+++ b/bd-api/src/lib.rs
@@ -51,6 +51,9 @@ pub enum DataUpload {
   /// A logs upload request with an associated tracking id that is used to ensure delivery.
   LogsUpload(TrackedUpload<LogUploadRequest>),
 
+  /// An ackless logs upload request.
+  AcklessLogsUpload(LogUploadRequest),
+
   /// A stats upload request with an associated tracking id that is used to ensure delivery.
   StatsUpload(TrackedUpload<StatsUploadRequest>),
 

--- a/bd-logger/src/service_test.rs
+++ b/bd-logger/src/service_test.rs
@@ -40,10 +40,13 @@ async fn test_retry_backoff() {
     retry_limit_exceeded_dropped_logs,
   };
 
-  let mut req = UploadRequest::new(LogBatch {
-    logs: vec![],
-    buffer_id: "buffer".to_string(),
-  });
+  let mut req = UploadRequest::new(
+    LogBatch {
+      logs: vec![],
+      buffer_id: "buffer".to_string(),
+    },
+    false,
+  );
   let mut retry_task = tokio_test::task::spawn(
     retry
       .retry(&mut req, &mut Ok(UploadResult::Failure))

--- a/bd-runtime/src/runtime.rs
+++ b/bd-runtime/src/runtime.rs
@@ -577,19 +577,19 @@ pub mod log_upload {
   // Continuous logs are uploaded in batches either when the batch size is hit or when the deadline
   // has been hit. This controls how long the client will wait before triggering a flush for a
   // batch that has not yet reached the batch limit.
-  int_feature_flag!(
+  duration_feature_flag!(
     BatchDeadlineFlag,
     "log_uploader.batch_deadline_ms",
-    30 * 1000
-  ); // 30s
+    30.seconds()
+  );
 
   // This controls the maximum number of logs that will be uploaded in a single streaming upload
   // request. This is used to batch the uploads to improve the throughput of log streaming in the
   // case where a lot of logs are being emitted.
-  int_feature_flag!(
-    StreamingBatchSizeFlag,
-    "log_uploader.streaming_batch_size",
-    100
+  duration_feature_flag!(
+    StreamingBatchDeadlineFlag,
+    "log_uploader.streaming_batch_deadline_ms",
+    500.milliseconds()
   );
 
   // This controls how many times we'll retry an upload before giving up. Note that this tracks the

--- a/bd-test-helpers/src/test_api_server.rs
+++ b/bd-test-helpers/src/test_api_server.rs
@@ -290,6 +290,9 @@ impl RequestProcessor {
           .log_upload_tx
           .send(log_upload.clone())
           .await;
+        if log_upload.ackless {
+          return None;
+        }
         Some(ApiResponse {
           response_type: Some(Response_type::LogUpload(LogUploadResponse {
             upload_uuid,

--- a/logger-cli/Cargo.toml
+++ b/logger-cli/Cargo.toml
@@ -2,36 +2,31 @@
 edition      = "2024"
 license-file = "../LICENSE"
 name         = "logger-cli"
-version      = "1.0.0"
 publish      = false
+version      = "1.0.0"
 
 [dependencies]
-anyhow.workspace = true
-bd-api.path = "../bd-api"
-bd-device.path = "../bd-device"
-bd-hyper-network.path = "../bd-hyper-network"
-bd-key-value.path = "../bd-key-value"
-bd-log.path = "../bd-log"
-bd-logger.path = "../bd-logger"
-bd-session.path = "../bd-session"
-bd-shutdown.path = "../bd-shutdown"
-bd-test-helpers.path = "../bd-test-helpers"
-clap.workspace = true
-futures = "0.3"
-libc = "0.2.175"
-log.workspace = true
-parking_lot.workspace = true
-serde.workspace = true
-sqlite.workspace = true
-tarpc = { version = "0.37", features = ["full"] }
-time.workspace = true
-tokio.workspace = true
+anyhow.workspace             = true
+bd-api.path                  = "../bd-api"
+bd-device.path               = "../bd-device"
+bd-hyper-network.path        = "../bd-hyper-network"
+bd-key-value.path            = "../bd-key-value"
+bd-log.path                  = "../bd-log"
+bd-logger.path               = "../bd-logger"
+bd-session.path              = "../bd-session"
+bd-shutdown.path             = "../bd-shutdown"
+bd-test-helpers.path         = "../bd-test-helpers"
+clap.workspace               = true
+futures                      = "0.3"
+libc                         = "0.2.175"
+log.workspace                = true
+parking_lot.workspace        = true
+serde.workspace              = true
+sqlite.workspace             = true
+tarpc                        = { version = "0.37", features = ["full"] }
+time.workspace               = true
+tokio.workspace              = true
 tracing-subscriber.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-
-# improved rust-lldb accessibility:
-[profile.dev]
-debug = true
-opt-level = 0


### PR DESCRIPTION
1) Use ackless uploads to increase throughput at the expense of
   losing data. Logs still go through rate limiting and back
   pressure will be applied on the API so client memory is
   bounded.
2) Making the streaming uploader use BatchBuilder and have a
   flush deadline which defaults to 500ms. This should in general
   increase payload sizes and keep things snappy.

Fixes BIT-6338