### PR TITLE
various cleanups 

### DIFF
--- a/bd-log-primitives/src/lib.rs
+++ b/bd-log-primitives/src/lib.rs
@@ -228,7 +228,7 @@ pub struct Log {
   pub session_id: String,
   pub occurred_at: time::OffsetDateTime,
 
-  pub capture_session: Option<String>,
+  pub capture_session: Option<&'static str>,
 }
 
 //

--- a/bd-log/src/rate_limit_log.rs
+++ b/bd-log/src/rate_limit_log.rs
@@ -55,9 +55,12 @@ macro_rules! warn_every_debug_panic {
 
 #[macro_export]
 macro_rules! warn_every {
+  ($duration:expr, $first:tt) => {
+    $crate::log_every!(log::Level::Warn, $duration, "{}", $first);
+  };
   ($duration:expr, $first:tt, $($arg:tt)+) => {
     $crate::log_every!(log::Level::Warn, $duration, $first, $($arg)+);
-  }
+  };
 }
 
 #[macro_export]

--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -855,7 +855,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
         builder
           .current_feature_flags()
           .map_err(|e| {
-            handle_unexpected_error_with_details(e, "feature flag initialization", || None)
+            handle_unexpected_error_with_details(e, "feature flag initialization", || None);
           })
           .ok()
       })

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -298,7 +298,7 @@ fn annotated_log_line_size_is_computed_correctly() {
       log_level: 0,
       log_type: LogType::Normal,
       message: "foo".into(),
-      fields: [("foo".into(), StringOrBytes::String("bar".to_string()))].into(),
+      fields: [("foo".into(), "bar".into())].into(),
       matching_fields: [].into(),
       session_id: "foo".into(),
       occurred_at: time::OffsetDateTime::now_utc(),
@@ -306,7 +306,7 @@ fn annotated_log_line_size_is_computed_correctly() {
     }
   }
 
-  let baseline_log_expected_size = 569;
+  let baseline_log_expected_size = 561;
   let baseline_log = create_baseline_log();
   assert_eq!(baseline_log_expected_size, baseline_log.size());
 

--- a/bd-logger/src/internal.rs
+++ b/bd-logger/src/internal.rs
@@ -51,7 +51,7 @@ impl bd_internal_logging::Logger for InternalLogger {
       [].into(),
       None,
       Block::No,
-      CaptureSession::default(),
+      &CaptureSession::default(),
     );
   }
 }

--- a/bd-logger/src/log_replay.rs
+++ b/bd-logger/src/log_replay.rs
@@ -182,7 +182,7 @@ impl ProcessingPipeline {
       fields: FieldsRef::new(&log.fields, &log.matching_fields),
       session_id: &log.session_id,
       occurred_at: log.occurred_at,
-      capture_session: log.capture_session.as_deref(),
+      capture_session: log.capture_session,
     };
 
     let flush_stats_trigger = self.flush_stats_trigger.clone();

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -191,7 +191,7 @@ impl LoggerHandle {
     matching_fields: AnnotatedLogFields,
     attributes_overrides: Option<LogAttributesOverrides>,
     block: Block,
-    capture_session: CaptureSession,
+    capture_session: &CaptureSession,
   ) {
     with_reentrancy_guard!(
       {
@@ -232,7 +232,7 @@ impl LoggerHandle {
       [].into(),
       None,
       Block::No,
-      CaptureSession::default(),
+      &CaptureSession::default(),
     );
   }
 
@@ -284,7 +284,7 @@ impl LoggerHandle {
       [].into(),
       None,
       Block::No,
-      CaptureSession::default(),
+      &CaptureSession::default(),
     );
 
     self
@@ -317,7 +317,7 @@ impl LoggerHandle {
       [].into(),
       None,
       Block::No,
-      CaptureSession::default(),
+      &CaptureSession::default(),
     );
   }
 
@@ -385,7 +385,7 @@ impl LoggerHandle {
       [].into(),
       None,
       Block::No,
-      CaptureSession::default(),
+      &CaptureSession::default(),
     );
   }
 

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -108,7 +108,7 @@ thread_local! {
 /// logger.
 ///
 /// # Panics
-/// This will panic if the logger guard has an outstanding borrowk, e.g. either if this function is
+/// This will panic if the logger guard has an outstanding borrow, e.g. either if this function is
 /// called again within the provided closure or some other code starts holding a borrow while
 /// calling this.
 pub fn with_thread_local_logger_guard<R>(f: impl FnOnce() -> R) -> R {
@@ -116,6 +116,22 @@ pub fn with_thread_local_logger_guard<R>(f: impl FnOnce() -> R) -> R {
     let _guard = cell.borrow_mut();
     f()
   })
+}
+
+/// Macro to execute a block of code with the reentrancy guard, logging a warning if the guard is
+/// already held.
+macro_rules! with_reentrancy_guard {
+  ($f:expr, $msg:expr, $($args:expr),*) => {
+    // We just need to see if we can borrow - no need to hold it for any longer than that, as
+    // this indicates that nothing is holding a mut borrow.
+    LOGGER_GUARD.with(|cell| {
+      if cell.try_borrow().is_ok() {
+        $f
+      } else {
+        warn_every!(30.seconds(), "{}", format!($msg, $($args),*));
+      }
+    });
+  };
 }
 
 #[derive(Clone, Copy)]
@@ -138,12 +154,12 @@ impl From<Block> for bool {
 //
 
 #[derive(Default)]
-pub struct CaptureSession(Option<String>);
+pub struct CaptureSession(Option<&'static str>);
 
 impl CaptureSession {
   #[must_use]
-  pub fn capture_with_id(id: &str) -> Self {
-    Self(Some(id.to_string()))
+  pub fn capture_with_id(id: &'static str) -> Self {
+    Self(Some(id))
   }
 }
 
@@ -177,11 +193,8 @@ impl LoggerHandle {
     block: Block,
     capture_session: CaptureSession,
   ) {
-    LOGGER_GUARD.with(|cell| {
-      // We just need to see if we can borrow - no need to hold it for any longer than that, as
-      // this indicates that nothing is holding a mut borrow. This also guards for a hypothetical
-      // situation in which code in `enqueue_log` would try to mut borrow the guard.
-      if cell.try_borrow().is_ok() {
+    with_reentrancy_guard!(
+      {
         let result = AsyncLogBuffer::<LoggerReplay>::enqueue_log(
           &self.tx,
           log_level,
@@ -199,14 +212,10 @@ impl LoggerHandle {
         if let Err(e) = result {
           warn_every!(15.seconds(), "dropping log: {:?}", e);
         }
-      } else {
-        warn_every!(
-          15.seconds(),
-          "dropping log: message {:?}: emitting logs from within a field provider is not allowed",
-          message
-        );
-      }
-    });
+      },
+      "failed to log {:?}, emitting logs from within a field provider is not allowed",
+      message
+    );
   }
 
   pub fn log_resource_utilization(&self, mut fields: AnnotatedLogFields, duration: time::Duration) {
@@ -381,76 +390,57 @@ impl LoggerHandle {
   }
 
   pub fn add_log_field(&self, key: String, value: LogFieldValue) {
-    LOGGER_GUARD.with(|cell| {
-      if cell.try_borrow().is_ok() {
+    with_reentrancy_guard!(
+      {
         let field_name = key.clone();
         let result = AsyncLogBuffer::<LoggerReplay>::add_log_field(&self.tx, key, value);
         if let Err(e) = result {
           log::warn!("failed to add {field_name:?} log field: {e:?}");
         }
-      } else {
-        warn_every!(
-          15.seconds(),
-          "failed to add {:?} log field, adding log fields from within a field provider is not \
-           allowed",
-          key
-        );
-      }
-    });
+      },
+      "failed to add {:?} log field, adding log fields from within a field provider is not allowed",
+      key
+    );
   }
 
   pub fn remove_log_field(&self, field_name: &str) {
-    LOGGER_GUARD.with(|cell| {
-      if cell.try_borrow().is_ok() {
+    with_reentrancy_guard!(
+      {
         let result = AsyncLogBuffer::<LoggerReplay>::remove_log_field(&self.tx, field_name);
         if let Err(e) = result {
           log::warn!("failed to remove {field_name:?} log field: {e:?}");
         }
-      } else {
-        warn_every!(
-          15.seconds(),
-          "failed to remove {:?} log field, adding log fields from within a field provider is not \
-           allowed",
-          field_name
-        );
-      }
-    });
+      },
+      "failed to remove {:?} log field, adding log fields from within a callback is not permitted",
+      field_name
+    );
   }
 
   pub fn set_feature_flag(&self, flag: String, variant: Option<String>) {
-    LOGGER_GUARD.with(|cell| {
-      if cell.try_borrow().is_ok() {
-        let result = AsyncLogBuffer::<LoggerReplay>::set_feature_flag(&self.tx, flag, variant);
+    with_reentrancy_guard!(
+      {
+        let result =
+          AsyncLogBuffer::<LoggerReplay>::set_feature_flag(&self.tx, flag.clone(), variant);
         if let Err(e) = result {
-          log::warn!("failed to set feature flag: {e:?}");
+          log::warn!("failed to set feature flag {flag:?}: {e:?}");
         }
-      } else {
-        warn_every!(
-          15.seconds(),
-          "failed to set {:?} feature flag, setting flags from within a field provider is not \
-           allowed",
-          flag
-        );
-      }
-    });
+      },
+      "failed to set {:?} feature flag, setting flags from within a callback is not permitted",
+      flag
+    );
   }
 
   pub fn remove_feature_flag(&self, flag: String) {
-    LOGGER_GUARD.with(|cell| {
-      if cell.try_borrow().is_ok() {
+    with_reentrancy_guard!(
+      {
         let result = AsyncLogBuffer::<LoggerReplay>::remove_feature_flag(&self.tx, flag);
         if let Err(e) = result {
           log::warn!("failed to remove feature flag: {e:?}");
         }
-      } else {
-        warn_every!(
-          15.seconds(),
-          "failed to remove {:?} feature flag, removing flags from within a field provider is not \
-           allowed",
-          flag
-        );
-      }
-    });
+      },
+      "failed to remove {:?} feature flag, removing flags from within a callback is not permitted",
+      flag
+    );
   }
 
   pub fn flush_state(&self, block: Block) {

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -416,11 +416,11 @@ impl LoggerHandle {
     );
   }
 
-  pub fn set_feature_flag(&self, flag: String, variant: Option<String>) {
+  pub fn set_feature_flag(&self, flag: &str, variant: Option<String>) {
     with_reentrancy_guard!(
       {
         let result =
-          AsyncLogBuffer::<LoggerReplay>::set_feature_flag(&self.tx, flag.clone(), variant);
+          AsyncLogBuffer::<LoggerReplay>::set_feature_flag(&self.tx, flag.to_string(), variant);
         if let Err(e) = result {
           log::warn!("failed to set feature flag {flag:?}: {e:?}");
         }

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -128,7 +128,7 @@ macro_rules! with_reentrancy_guard {
       if cell.try_borrow().is_ok() {
         $f
       } else {
-        warn_every!(30.seconds(), "{}", format!($msg, $($args),*));
+        warn_every!(30.seconds(), $msg, $($args),*);
       }
     });
   };

--- a/bd-logger/src/logger_test.rs
+++ b/bd-logger/src/logger_test.rs
@@ -49,7 +49,7 @@ async fn thread_local_logger_guard() {
       [].into(),
       None,
       Block::No,
-      CaptureSession::default(),
+      &CaptureSession::default(),
     );
   });
 

--- a/bd-logger/src/test/crash_handler_integration.rs
+++ b/bd-logger/src/test/crash_handler_integration.rs
@@ -8,12 +8,14 @@
 use super::setup::Setup;
 use crate::logger::{Block, CaptureSession, ReportProcessingSession};
 use crate::test::setup::SetupOptions;
+use assert_matches::assert_matches;
 use bd_log_primitives::LogType;
 use bd_test_helpers::metadata_provider::LogMetadata;
 use bd_test_helpers::test_api_server::log_upload::LogUpload;
 use itertools::Itertools as _;
 use std::collections::HashSet;
 use std::sync::Arc;
+use time::ext::NumericalStdDuration;
 use time::macros::datetime;
 
 // empty fbs format report
@@ -43,7 +45,7 @@ fn crash_reports_artifact_upload() {
       [].into(),
       [].into(),
       None,
-      Block::No,
+      Block::Yes(5.std_seconds()),
       &CaptureSession::default(),
     );
 
@@ -83,17 +85,17 @@ fn crash_reports_artifact_upload() {
     .flat_map(bd_test_helpers::test_api_server::log_upload::LogUpload::logs)
     .collect_vec();
 
-  let crash1 = logs
+  let crash = logs
     .iter()
     .find(|log| log.field("_app_exit_info") == "crash1")
     .unwrap();
-  assert_eq!(crash1.message(), "AppExit");
-  assert_eq!(crash1.session_id(), initial_session_id);
-  assert_ne!(crash1.timestamp(), timestamp);
-  assert_eq!(crash1.field("_ootb_field"), "ootb");
-  assert!(!crash1.has_field("_crash_artifact"));
-  assert!(crash1.has_field("custom"));
-  let crash1_uuid = crash1.field("_crash_artifact_id");
+  assert_eq!(crash.message(), "AppExit");
+  assert_eq!(crash.session_id(), initial_session_id);
+  assert_ne!(crash.timestamp(), timestamp);
+  assert_eq!(crash.field("_ootb_field"), "ootb");
+  assert!(!crash.has_field("_crash_artifact"));
+  assert!(crash.has_field("custom"));
+  let crash1_uuid = crash.field("_crash_artifact_id");
 
   let mut remaining_uploads: HashSet<_> = [crash1_uuid].into();
   // Verify that out of band uploads happen.
@@ -105,6 +107,120 @@ fn crash_reports_artifact_upload() {
     let request = setup.server.blocking_next_artifact_upload().unwrap();
     assert_eq!(request.artifact_id, uuid);
     assert_eq!(request.contents, CRASH_CONTENTS.as_bytes());
+    remaining_uploads.remove(uuid.as_str());
+  }
+
+  assert!(
+    remaining_uploads.is_empty(),
+    "all uploads should have been seen"
+  );
+}
+
+#[test]
+fn crash_reports_feature_flags() {
+  let timestamp = datetime!(2021-01-01 00:00:00 UTC);
+
+  let (directory, initial_session_id) = {
+    let setup = Setup::new_with_options(SetupOptions {
+      disk_storage: true,
+      metadata_provider: Arc::new(LogMetadata {
+        timestamp: time::OffsetDateTime::now_utc().into(),
+        ootb_fields: [("_ootb_field".into(), "ootb".into())].into(),
+        custom_fields: [("custom".into(), "custom".into())].into(),
+      }),
+      ..Default::default()
+    });
+
+    setup
+      .logger_handle
+      .set_feature_flag("flag_name".to_string(), None);
+
+    setup
+      .logger_handle
+      .set_feature_flag("flag_with_variant".to_string(), Some("variant".to_string()));
+
+    // Log one log to trigger a global state update, blocking to make sure it gets processed.
+    setup.logger_handle.log(
+      0,
+      LogType::Normal,
+      "".into(),
+      [].into(),
+      [].into(),
+      None,
+      Block::Yes(5.std_seconds()),
+      &CaptureSession::default(),
+    );
+
+    std::fs::create_dir_all(setup.sdk_directory.path().join("reports/new")).unwrap();
+
+    std::fs::write(
+      setup.sdk_directory.path().join("reports/new/crash1.cap"),
+      CRASH_CONTENTS,
+    )
+    .unwrap();
+
+    (
+      setup.sdk_directory.clone(),
+      setup.logger.new_logger_handle().session_id(),
+    )
+  };
+
+  let mut setup = Setup::new_with_options(SetupOptions {
+    sdk_directory: directory,
+    disk_storage: true,
+    ..Default::default()
+  });
+
+  assert_ne!(
+    initial_session_id,
+    setup.logger.new_logger_handle().session_id()
+  );
+
+  setup.configure_stream_all_logs();
+  setup.upload_individual_logs();
+  setup.upload_crash_reports(ReportProcessingSession::PreviousRun);
+
+  let uploads: Vec<LogUpload> = vec![setup.server.blocking_next_log_upload().unwrap()];
+
+  let logs = uploads
+    .iter()
+    .flat_map(bd_test_helpers::test_api_server::log_upload::LogUpload::logs)
+    .collect_vec();
+
+  let crash_log = logs
+    .iter()
+    .find(|log| log.field("_app_exit_info") == "crash1")
+    .unwrap();
+  assert_eq!(crash_log.message(), "AppExit");
+  assert_eq!(crash_log.session_id(), initial_session_id);
+  assert_ne!(crash_log.timestamp(), timestamp);
+  assert_eq!(crash_log.field("_ootb_field"), "ootb");
+  assert!(!crash_log.has_field("_crash_artifact"));
+  assert!(crash_log.has_field("custom"));
+  let crash1_uuid = crash_log.field("_crash_artifact_id");
+
+  let mut remaining_uploads: HashSet<_> = [crash1_uuid].into();
+  // Verify that out of band uploads happen.
+  for _ in 0 .. 1 {
+    // Verify that out of band uploads happen.
+    let request = setup.server.blocking_next_artifact_intent().unwrap();
+    let uuid = request.artifact_id;
+
+    let request = setup.server.blocking_next_artifact_upload().unwrap();
+    assert_eq!(request.artifact_id, uuid);
+    assert_eq!(request.contents, CRASH_CONTENTS.as_bytes());
+    let mut feature_flags = request
+      .feature_flags
+      .iter()
+      .sorted_by(|a, b| a.name.cmp(&b.name));
+    assert_matches!(feature_flags.next(), Some(flag) => {
+      assert_eq!(flag.name, "flag_name");
+        assert!(flag.variant.is_none());
+    });
+    assert_matches!(feature_flags.next(), Some(flag) => {
+      assert_eq!(flag.name, "flag_with_variant");
+        assert_eq!(flag.variant.as_deref(), Some("variant"));
+    });
     remaining_uploads.remove(uuid.as_str());
   }
 

--- a/bd-logger/src/test/crash_handler_integration.rs
+++ b/bd-logger/src/test/crash_handler_integration.rs
@@ -44,7 +44,7 @@ fn crash_reports_artifact_upload() {
       [].into(),
       None,
       Block::No,
-      CaptureSession::default(),
+      &CaptureSession::default(),
     );
 
     std::fs::create_dir_all(setup.sdk_directory.path().join("reports/new")).unwrap();

--- a/bd-logger/src/test/crash_handler_integration.rs
+++ b/bd-logger/src/test/crash_handler_integration.rs
@@ -131,13 +131,11 @@ fn crash_reports_feature_flags() {
       ..Default::default()
     });
 
-    setup
-      .logger_handle
-      .set_feature_flag("flag_name".to_string(), None);
+    setup.logger_handle.set_feature_flag("flag_name", None);
 
     setup
       .logger_handle
-      .set_feature_flag("flag_with_variant".to_string(), Some("variant".to_string()));
+      .set_feature_flag("flag_with_variant", Some("variant".to_string()));
 
     // Log one log to trigger a global state update, blocking to make sure it gets processed.
     setup.logger_handle.log(

--- a/bd-logger/src/test/embedded_logger_integration.rs
+++ b/bd-logger/src/test/embedded_logger_integration.rs
@@ -179,7 +179,7 @@ async fn configuration_update_with_log_uploads() {
     [].into(),
     None,
     Block::No,
-    CaptureSession::default(),
+    &CaptureSession::default(),
   );
 
   assert_matches!(setup.server.next_log_upload().await, Some(log_upload) => {

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -2053,7 +2053,7 @@ fn logs_before_cache_load() {
       [].into(),
       None,
       Block::No,
-      CaptureSession::default(),
+      &CaptureSession::default(),
     );
   }
 
@@ -2066,7 +2066,7 @@ fn logs_before_cache_load() {
     [].into(),
     None,
     Block::No,
-    CaptureSession::default(),
+    &CaptureSession::default(),
   );
 
   setup

--- a/bd-logger/src/test/setup.rs
+++ b/bd-logger/src/test/setup.rs
@@ -287,7 +287,7 @@ impl Setup {
       matching_fields,
       attributes_overrides,
       Block::No,
-      CaptureSession::default(),
+      &CaptureSession::default(),
     );
   }
 
@@ -307,7 +307,7 @@ impl Setup {
       matching_fields,
       None,
       Block::Yes(15.std_seconds()),
-      CaptureSession::default(),
+      &CaptureSession::default(),
     );
   }
 
@@ -327,7 +327,7 @@ impl Setup {
       matching_fields,
       None,
       Block::No,
-      CaptureSession::capture_with_id("test"),
+      &CaptureSession::capture_with_id("test"),
     );
   }
 

--- a/bd-test-helpers/src/test_api_server/log_upload.rs
+++ b/bd-test-helpers/src/test_api_server/log_upload.rs
@@ -110,7 +110,18 @@ impl Log<'_> {
             .data()
         })
       })
-      .unwrap_or_else(|| panic!("field {key:?} should exist"))
+      .unwrap_or_else(|| {
+        panic!(
+          "field {key:?} should exist, keys: {:?}",
+          self
+            .0
+            .fields()
+            .unwrap_or_default()
+            .iter()
+            .map(|f| f.key())
+            .collect::<Vec<_>>()
+        )
+      })
   }
 
   #[must_use]

--- a/logger-cli/src/logger.rs
+++ b/logger-cli/src/logger.rs
@@ -120,7 +120,7 @@ impl LoggerHolder {
       [].into(),
       None,
       bd_logger::Block::Yes(1.std_seconds()),
-      session_capture,
+      &session_capture,
     );
   }
 }


### PR DESCRIPTION
- Rework feature flag initialization to not require a mutex and fail permanently in the case of disk issues
- Use a &'static str for the CaptureSession string to save an allocation
- Remove initial_logs from async_log_buffer, no longer used
- Add macro for repeated reentrancy logic in logger.rs