### PR TITLE
network quality: add a DNS based network monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,12 @@ dependencies = [
 name = "bd-network-quality"
 version = "1.0.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "bd-workspace-hack",
+ "parking_lot",
+ "tokio",
+ "tokio-test",
 ]
 
 [[package]]

--- a/bd-network-quality/Cargo.toml
+++ b/bd-network-quality/Cargo.toml
@@ -9,4 +9,11 @@ version      = "1.0.0"
 doctest = false
 
 [dependencies]
+anyhow.workspace           = true
+async-trait.workspace      = true
 bd-workspace-hack.workspace = true
+parking_lot.workspace      = true
+tokio.workspace            = true
+
+[dev-dependencies]
+tokio-test.workspace = true

--- a/bd-network-quality/src/dns_monitor.rs
+++ b/bd-network-quality/src/dns_monitor.rs
@@ -1,0 +1,174 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use crate::{NetworkQuality, NetworkQualityMonitor};
+use parking_lot::RwLock;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[cfg(test)]
+#[path = "./dns_monitor_test.rs"]
+mod tests;
+
+//
+// PlatformDnsResolver
+//
+
+/// A trait for platform-specific DNS resolution implementations.
+/// This allows different platforms to provide their own DNS resolution logic.
+#[async_trait::async_trait]
+pub trait PlatformDnsResolver: Send + Sync {
+  /// Attempts to resolve the given hostname.
+  /// Returns `Ok(true)` if resolution succeeds, `Ok(false)` if it fails,
+  /// or `Err` if there's an error performing the check.
+  async fn resolve(&self, hostname: &str) -> anyhow::Result<bool>;
+}
+
+//
+// TokioDnsResolver
+//
+
+/// A default DNS resolver implementation using tokio's built-in DNS lookup.
+pub struct TokioDnsResolver;
+
+#[async_trait::async_trait]
+impl PlatformDnsResolver for TokioDnsResolver {
+  async fn resolve(&self, hostname: &str) -> anyhow::Result<bool> {
+    Ok(
+      tokio::net::lookup_host(hostname)
+        .await
+        .map_or_else(|_| false, |mut addrs| addrs.next().is_some()),
+    )
+  }
+}
+
+//
+// DnsMonitorConfig
+//
+
+/// Configuration for the DNS-based network quality monitor.
+#[derive(Debug, Clone)]
+pub struct DnsMonitorConfig {
+  /// The hostname to perform DNS lookups on. Defaults to "dns.google.com:443".
+  pub hostname: String,
+  /// How often to check DNS resolution. Defaults to 30 seconds.
+  pub check_interval: Duration,
+  /// Timeout for each DNS lookup attempt. Defaults to 5 seconds.
+  pub lookup_timeout: Duration,
+}
+
+impl Default for DnsMonitorConfig {
+  fn default() -> Self {
+    Self {
+      hostname: "dns.google.com:443".to_string(),
+      check_interval: Duration::from_secs(30),
+      lookup_timeout: Duration::from_secs(5),
+    }
+  }
+}
+
+//
+// DnsNetworkMonitor
+//
+
+/// A network quality monitor that periodically checks DNS resolution to determine network status.
+/// This implementation delegates DNS resolution to a platform-specific resolver.
+pub struct DnsNetworkMonitor {
+  config: DnsMonitorConfig,
+  resolver: Arc<dyn PlatformDnsResolver>,
+  quality: Arc<RwLock<NetworkQuality>>,
+  shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl DnsNetworkMonitor {
+  /// Creates a new DNS network monitor with the given configuration and resolver.
+  #[must_use]
+  pub fn new(config: DnsMonitorConfig, resolver: Arc<dyn PlatformDnsResolver>) -> Self {
+    Self {
+      config,
+      resolver,
+      quality: Arc::new(RwLock::new(NetworkQuality::Unknown)),
+      shutdown_tx: None,
+    }
+  }
+
+  /// Starts the monitoring loop in the background.
+  /// Returns an error if the monitor has already been started.
+  pub fn start(&mut self) -> anyhow::Result<()> {
+    if self.shutdown_tx.is_some() {
+      anyhow::bail!("DNS network monitor already started");
+    }
+
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
+    self.shutdown_tx = Some(shutdown_tx);
+
+    let config = self.config.clone();
+    let resolver = self.resolver.clone();
+    let quality = self.quality.clone();
+
+    tokio::spawn(async move {
+      let mut interval = tokio::time::interval(config.check_interval);
+      interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+      loop {
+        tokio::select! {
+          _ = interval.tick() => {
+            let new_quality = Self::check_dns(&config, resolver.as_ref()).await;
+            let mut current_quality = quality.write();
+            if *current_quality != new_quality {
+              *current_quality = new_quality;
+            }
+          }
+          _ = &mut shutdown_rx => {
+            break;
+          }
+        }
+      }
+    });
+
+    Ok(())
+  }
+
+  /// Stops the monitoring loop.
+  pub fn stop(&mut self) {
+    if let Some(shutdown_tx) = self.shutdown_tx.take() {
+      let _ = shutdown_tx.send(());
+    }
+  }
+
+  /// Gets the current network quality.
+  #[must_use]
+  pub fn get_quality(&self) -> NetworkQuality {
+    *self.quality.read()
+  }
+
+  /// Performs a DNS lookup to check network connectivity using the provided resolver.
+  async fn check_dns(
+    config: &DnsMonitorConfig,
+    resolver: &dyn PlatformDnsResolver,
+  ) -> NetworkQuality {
+    let result =
+      tokio::time::timeout(config.lookup_timeout, resolver.resolve(&config.hostname)).await;
+
+    match result {
+      Ok(Ok(true)) => NetworkQuality::Online,
+      Ok(Ok(false) | Err(_)) | Err(_) => NetworkQuality::Offline,
+    }
+  }
+}
+
+impl NetworkQualityMonitor for DnsNetworkMonitor {
+  fn set_network_quality(&self, quality: NetworkQuality) {
+    *self.quality.write() = quality;
+  }
+}
+
+impl Drop for DnsNetworkMonitor {
+  fn drop(&mut self) {
+    self.stop();
+  }
+}

--- a/bd-network-quality/src/dns_monitor_test.rs
+++ b/bd-network-quality/src/dns_monitor_test.rs
@@ -1,0 +1,185 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use super::*;
+use std::time::Duration;
+
+#[tokio::test]
+async fn creates_monitor_with_default_config() {
+  let resolver = Arc::new(TokioDnsResolver);
+  let monitor = DnsNetworkMonitor::new(DnsMonitorConfig::default(), resolver);
+  assert_eq!(monitor.get_quality(), NetworkQuality::Unknown);
+}
+
+#[tokio::test]
+async fn creates_monitor_with_custom_config() {
+  let config = DnsMonitorConfig {
+    hostname: "example.com:80".to_string(),
+    check_interval: Duration::from_secs(10),
+    lookup_timeout: Duration::from_secs(2),
+  };
+
+  let resolver = Arc::new(TokioDnsResolver);
+  let monitor = DnsNetworkMonitor::new(config, resolver);
+  assert_eq!(monitor.config.hostname, "example.com:80");
+  assert_eq!(monitor.config.check_interval, Duration::from_secs(10));
+  assert_eq!(monitor.config.lookup_timeout, Duration::from_secs(2));
+}
+
+#[tokio::test]
+async fn implements_network_quality_monitor_trait() {
+  let resolver = Arc::new(TokioDnsResolver);
+  let monitor = DnsNetworkMonitor::new(DnsMonitorConfig::default(), resolver);
+
+  monitor.set_network_quality(NetworkQuality::Online);
+  assert_eq!(monitor.get_quality(), NetworkQuality::Online);
+
+  monitor.set_network_quality(NetworkQuality::Offline);
+  assert_eq!(monitor.get_quality(), NetworkQuality::Offline);
+}
+
+#[tokio::test]
+async fn starts_and_stops_monitoring() {
+  let resolver = Arc::new(TokioDnsResolver);
+  let mut monitor = DnsNetworkMonitor::new(
+    DnsMonitorConfig {
+      hostname: "dns.google.com:443".to_string(),
+      check_interval: Duration::from_millis(100),
+      lookup_timeout: Duration::from_secs(2),
+    },
+    resolver,
+  );
+
+  let result = monitor.start();
+  assert!(result.is_ok());
+
+  // Wait for at least one check to complete
+  tokio::time::sleep(Duration::from_millis(200)).await;
+
+  // Quality should be either Online or Offline (not Unknown) after a check
+  let quality = monitor.get_quality();
+  assert!(quality == NetworkQuality::Online || quality == NetworkQuality::Offline);
+
+  monitor.stop();
+}
+
+#[tokio::test]
+async fn prevents_double_start() {
+  let resolver = Arc::new(TokioDnsResolver);
+  let mut monitor = DnsNetworkMonitor::new(DnsMonitorConfig::default(), resolver);
+
+  let result1 = monitor.start();
+  assert!(result1.is_ok());
+
+  let result2 = monitor.start();
+  assert!(result2.is_err());
+
+  monitor.stop();
+}
+
+#[tokio::test]
+async fn resolves_valid_hostname() {
+  let config = DnsMonitorConfig {
+    hostname: "dns.google.com:443".to_string(),
+    check_interval: Duration::from_secs(30),
+    lookup_timeout: Duration::from_secs(5),
+  };
+
+  let resolver = TokioDnsResolver;
+  let quality = DnsNetworkMonitor::check_dns(&config, &resolver).await;
+  assert_eq!(quality, NetworkQuality::Online);
+}
+
+#[tokio::test]
+async fn handles_invalid_hostname() {
+  let config = DnsMonitorConfig {
+    hostname: "this-hostname-definitely-does-not-exist-12345.invalid:80".to_string(),
+    check_interval: Duration::from_secs(30),
+    lookup_timeout: Duration::from_secs(2),
+  };
+
+  let resolver = TokioDnsResolver;
+  let quality = DnsNetworkMonitor::check_dns(&config, &resolver).await;
+  assert_eq!(quality, NetworkQuality::Offline);
+}
+
+#[tokio::test]
+async fn handles_timeout() {
+  let config = DnsMonitorConfig {
+    hostname: "dns.google.com:443".to_string(),
+    check_interval: Duration::from_secs(30),
+    lookup_timeout: Duration::from_nanos(1), // Extremely short timeout
+  };
+
+  let resolver = TokioDnsResolver;
+  let quality = DnsNetworkMonitor::check_dns(&config, &resolver).await;
+  assert_eq!(quality, NetworkQuality::Offline);
+}
+
+#[tokio::test]
+async fn stops_on_drop() {
+  let resolver = Arc::new(TokioDnsResolver);
+  let mut monitor = DnsNetworkMonitor::new(
+    DnsMonitorConfig {
+      hostname: "dns.google.com:443".to_string(),
+      check_interval: Duration::from_millis(100),
+      lookup_timeout: Duration::from_secs(2),
+    },
+    resolver,
+  );
+
+  monitor.start().ok();
+  tokio::time::sleep(Duration::from_millis(50)).await;
+
+  // Drop the monitor
+  drop(monitor);
+
+  // If we get here without hanging, the monitor stopped successfully
+}
+
+// Test that custom resolvers work correctly
+
+struct MockResolver {
+  should_succeed: bool,
+}
+
+#[async_trait::async_trait]
+impl PlatformDnsResolver for MockResolver {
+  async fn resolve(&self, _hostname: &str) -> anyhow::Result<bool> {
+    Ok(self.should_succeed)
+  }
+}
+
+#[tokio::test]
+async fn uses_custom_resolver_success() {
+  let config = DnsMonitorConfig {
+    hostname: "example.com:80".to_string(),
+    check_interval: Duration::from_secs(30),
+    lookup_timeout: Duration::from_secs(5),
+  };
+
+  let resolver = MockResolver {
+    should_succeed: true,
+  };
+  let quality = DnsNetworkMonitor::check_dns(&config, &resolver).await;
+  assert_eq!(quality, NetworkQuality::Online);
+}
+
+#[tokio::test]
+async fn uses_custom_resolver_failure() {
+  let config = DnsMonitorConfig {
+    hostname: "example.com:80".to_string(),
+    check_interval: Duration::from_secs(30),
+    lookup_timeout: Duration::from_secs(5),
+  };
+
+  let resolver = MockResolver {
+    should_succeed: false,
+  };
+  let quality = DnsNetworkMonitor::check_dns(&config, &resolver).await;
+  assert_eq!(quality, NetworkQuality::Offline);
+}

--- a/bd-network-quality/src/lib.rs
+++ b/bd-network-quality/src/lib.rs
@@ -14,6 +14,8 @@
   clippy::unwrap_used
 )]
 
+pub mod dns_monitor;
+
 //
 // NetworkQuality
 //


### PR DESCRIPTION
Adds a DNS-based network monitor that periodically attempts to resolve a well known name. Failure to resolve the name indicates that the network is unavailable