### PR TITLE
feature flags: emit logs on each feature flag operation 

### DIFF
--- a/bd-logger/src/async_log_buffer/feature_flags.rs
+++ b/bd-logger/src/async_log_buffer/feature_flags.rs
@@ -47,7 +47,7 @@ impl FeatureFlagsHolder {
   pub async fn set(&mut self, flag: String, variant: Option<&str>) -> LogLine {
     if let Some(feature_flags) = self.maybe_initialize_feature_flags().await {
       feature_flags
-        .set(flag.clone(), variant.as_deref())
+        .set(flag.clone(), variant)
         .unwrap_or_else(|e| {
           log::warn!("failed to set feature flag: {e}");
         });
@@ -89,7 +89,7 @@ impl FeatureFlagsHolder {
         .into_iter()
         .map(|(flag, variant)| {
           (
-            format!("_set_flag_{}", flag).into(),
+            format!("_set_flag_{flag}").into(),
             AnnotatedLogField::new_ootb(variant.unwrap_or("none".to_string())),
           )
         })

--- a/bd-logger/src/async_log_buffer/feature_flags.rs
+++ b/bd-logger/src/async_log_buffer/feature_flags.rs
@@ -1,3 +1,10 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 //! Lazy initialization wrapper for feature flags in the async log buffer.
 //!
 //! This module provides a holder type that defers feature flag initialization until first use,

--- a/bd-logger/src/async_log_buffer/feature_flags.rs
+++ b/bd-logger/src/async_log_buffer/feature_flags.rs
@@ -90,7 +90,7 @@ impl FeatureFlagsHolder {
         .map(|(flag, variant)| {
           (
             format!("_set_flag_{flag}").into(),
-            AnnotatedLogField::new_ootb(variant.unwrap_or("none".to_string())),
+            AnnotatedLogField::new_ootb(variant.unwrap_or_else(|| "none".to_string())),
           )
         })
         .collect(),

--- a/bd-logger/src/async_log_buffer/feature_flags.rs
+++ b/bd-logger/src/async_log_buffer/feature_flags.rs
@@ -1,0 +1,172 @@
+//! Lazy initialization wrapper for feature flags in the async log buffer.
+//!
+//! This module provides a holder type that defers feature flag initialization until first use,
+//! avoiding blocking operations during log buffer creation.
+
+use crate::async_log_buffer::LogLine;
+use bd_error_reporter::reporter::handle_unexpected_error_with_details;
+use bd_feature_flags::FeatureFlagsBuilder;
+use bd_log::warn_every;
+use bd_log_primitives::{AnnotatedLogField, LogType, log_level};
+use time::ext::NumericalDuration;
+
+/// A holder for feature flags that supports lazy initialization.
+///
+/// This enum manages the lifecycle of feature flags, starting in a pending state with just a
+/// builder and transitioning to an initialized state on first access. Initialization is deferred
+/// to avoid blocking operations during construction.
+pub enum FeatureFlagsHolder {
+  /// Feature flags have not been initialized yet, only the builder is available.
+  Pending(FeatureFlagsBuilder),
+  /// Feature flags have been initialized. Contains `None` if initialization failed.
+  Initialized(Option<bd_feature_flags::FeatureFlags>),
+}
+
+impl FeatureFlagsHolder {
+  /// Creates a new holder in the pending state with the given builder.
+  ///
+  /// Feature flags will not be initialized until the first call to a method that requires them.
+  pub fn new(builder: FeatureFlagsBuilder) -> Self {
+    Self::Pending(builder)
+  }
+
+  /// Returns a reference to the feature flags if they have been initialized.
+  ///
+  /// Returns `None` if the flags are still pending or if initialization failed.
+  pub fn get(&self) -> Option<&bd_feature_flags::FeatureFlags> {
+    match self {
+      Self::Pending(_) => None,
+      Self::Initialized(flags_option) => flags_option.as_ref(),
+    }
+  }
+
+  /// Sets a feature flag to the specified variant.
+  ///
+  /// This will trigger initialization if the flags are still pending. If initialization fails,
+  /// this operation will be a no-op.
+  pub async fn set(&mut self, flag: String, variant: Option<&str>) -> LogLine {
+    if let Some(feature_flags) = self.maybe_initialize_feature_flags().await {
+      feature_flags
+        .set(flag.clone(), variant.as_deref())
+        .unwrap_or_else(|e| {
+          log::warn!("failed to set feature flag: {e}");
+        });
+    }
+
+    LogLine::new_with_fields(
+      log_level::INFO,
+      LogType::Device,
+      "Set feature flag".into(),
+      [
+        ("_set_flag".into(), AnnotatedLogField::new_ootb(flag)),
+        (
+          "_set_variant".into(),
+          AnnotatedLogField::new_ootb(variant.unwrap_or("none").to_string()),
+        ),
+      ]
+      .into(),
+    )
+  }
+
+  /// Sets multiple feature flags at once.
+  ///
+  /// This will trigger initialization if the flags are still pending. If initialization fails,
+  /// this operation will be a no-op.
+  pub async fn set_multiple(&mut self, flags: Vec<(String, Option<String>)>) -> LogLine {
+    if let Some(feature_flags) = self.maybe_initialize_feature_flags().await {
+      feature_flags
+        .set_multiple(flags.clone())
+        .unwrap_or_else(|e| {
+          log::warn!("failed to set feature flags: {e}");
+        });
+    }
+
+    LogLine::new_with_fields(
+      log_level::INFO,
+      LogType::Device,
+      "Set multiple feature flags".into(),
+      flags
+        .into_iter()
+        .map(|(flag, variant)| {
+          (
+            format!("_set_flag_{}", flag).into(),
+            AnnotatedLogField::new_ootb(variant.unwrap_or("none".to_string())),
+          )
+        })
+        .collect(),
+    )
+  }
+
+  /// Removes a feature flag by name.
+  ///
+  /// This will trigger initialization if the flags are still pending. If initialization fails,
+  /// this operation will be a no-op.
+  pub async fn remove(&mut self, flag: String) -> LogLine {
+    if let Some(feature_flags) = self.maybe_initialize_feature_flags().await {
+      feature_flags.remove(&flag).unwrap_or_else(|e| {
+        log::warn!("failed to remove feature flag: {e}");
+      });
+    }
+
+    LogLine::new_with_fields(
+      log_level::INFO,
+      LogType::Device,
+      "Removed feature flag".into(),
+      [("_removed_flag".into(), AnnotatedLogField::new_ootb(flag))].into(),
+    )
+  }
+
+  /// Clears all feature flags.
+  ///
+  /// This will trigger initialization if the flags are still pending. If initialization fails,
+  /// this operation will be a no-op.
+  pub async fn clear(&mut self) -> LogLine {
+    if let Some(feature_flags) = self.maybe_initialize_feature_flags().await {
+      feature_flags.clear().unwrap_or_else(|e| {
+        log::warn!("failed to clear feature flags: {e}");
+      });
+    }
+
+    LogLine::new_simple(
+      log_level::INFO,
+      LogType::Device,
+      "Cleared all feature flags".into(),
+    )
+  }
+
+  /// Lazily initializes the feature flags if they have not been initialized yet.
+  async fn maybe_initialize_feature_flags(
+    &mut self,
+  ) -> Option<&mut bd_feature_flags::FeatureFlags> {
+    if let Self::Pending(builder) = &self {
+      let builder = builder.clone();
+      let feature_flags = tokio::task::spawn_blocking(move || {
+        // This should never fail unless there's a serious filesystem issue.
+        // Treat this as an unexpected error so we get visibility into it.
+        // If this keeps happening for normal reasons we can remove this later.
+        builder
+          .current_feature_flags()
+          .map_err(|e| {
+            handle_unexpected_error_with_details(e, "feature flag initialization", || None);
+          })
+          .ok()
+      })
+      .await
+      .ok()
+      .flatten();
+
+      *self = Self::Initialized(feature_flags);
+    }
+
+    // TODO(snowp): Instead of failing permanently we should fall back to in-memory only.
+    if let Self::Initialized(feature_flags) = self {
+      feature_flags.as_mut()
+    } else {
+      warn_every!(
+        30.seconds(),
+        "feature flags failed to initialize, will not be available"
+      );
+      None
+    }
+  }
+}

--- a/bd-logger/src/async_log_buffer/feature_flags.rs
+++ b/bd-logger/src/async_log_buffer/feature_flags.rs
@@ -53,6 +53,9 @@ impl FeatureFlagsHolder {
         });
     }
 
+    // TODO(snowp): For all these calls we need to make sure that the timestamp on the long matches
+    // the timestamp on the feature flag update.
+
     LogLine::new_with_fields(
       log_level::INFO,
       LogType::Device,

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -689,6 +689,13 @@ async fn logs_resource_utilization_log() {
 
 #[tokio::test]
 async fn feature_flag_logs() {
+  struct TestCase {
+    name: &'static str,
+    message: AsyncLogBufferMessage,
+    expected_log: &'static str,
+    expected_fields: LogFields,
+  }
+
   let setup = Setup::new();
 
   let (config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
@@ -707,14 +714,7 @@ async fn feature_flag_logs() {
     .await
     .unwrap();
 
-  struct TestCase {
-    name: &'static str,
-    message: AsyncLogBufferMessage,
-    expected_log: &'static str,
-    expected_fields: LogFields,
-  }
-
-  for test_case in vec![
+  for test_case in [
     TestCase {
       name: "SetFeatureFlag with variant",
       message: AsyncLogBufferMessage::SetFeatureFlag(

--- a/logger-cli/src/cli.rs
+++ b/logger-cli/src/cli.rs
@@ -63,6 +63,23 @@ pub enum Command {
 
   /// Toggle sleep mode
   SetSleepMode(SleepModeCommand),
+
+  /// Sets a feature flag with an optional variant.
+  SetFeatureFlag {
+    /// Feature flag name
+    name: String,
+
+    /// Feature flag variant
+    #[clap(required = false)]
+    variant: Option<String>,
+  },
+
+  /// Sets a feature flag with an optional variant.
+  SetMultipleFeatureFlag {
+    /// Feature flag key/value pairs
+    #[clap(long, num_args=2, value_names=["key", "value"], action=ArgAction::Append)]
+    flags: Vec<String>,
+  },
 }
 
 #[derive(Args, Debug)]

--- a/logger-cli/src/logger.rs
+++ b/logger-cli/src/logger.rs
@@ -81,6 +81,21 @@ impl LoggerHolder {
     handle.start_new_session();
   }
 
+  pub fn set_feature_flag(&self, name: String, variant: Option<String>) {
+    let handle = self.logger.lock().new_logger_handle();
+    handle.set_feature_flag(name.into(), variant.map(|v| v.into()));
+  }
+
+  pub fn set_feature_flags(&self, flags: Vec<(String, String)>) {
+    let handle = self.logger.lock().new_logger_handle();
+    handle.set_feature_flags(
+      flags
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect(),
+    );
+  }
+
   pub fn set_sleep_mode(&self, enabled: bool) {
     let handle = self.logger.lock().new_logger_handle();
     handle.transition_sleep_mode(enabled);

--- a/logger-cli/src/logger.rs
+++ b/logger-cli/src/logger.rs
@@ -83,7 +83,7 @@ impl LoggerHolder {
 
   pub fn set_feature_flag(&self, name: String, variant: Option<String>) {
     let handle = self.logger.lock().new_logger_handle();
-    handle.set_feature_flag(name.into(), variant.map(|v| v.into()));
+    handle.set_feature_flag(name, variant);
   }
 
   pub fn set_feature_flags(&self, flags: Vec<(String, String)>) {
@@ -91,7 +91,7 @@ impl LoggerHolder {
     handle.set_feature_flags(
       flags
         .into_iter()
-        .map(|(k, v)| (k.into(), v.into()))
+        .map(|(k, v)| (k, v.into()))
         .collect(),
     );
   }

--- a/logger-cli/src/main.rs
+++ b/logger-cli/src/main.rs
@@ -136,6 +136,33 @@ async fn main() -> anyhow::Result<()> {
 
       client.stop(context::current()).await?;
     },
+    Command::SetFeatureFlag {
+      ref name,
+      ref variant,
+    } => {
+      with_logger(&args, async |logger| {
+        logger
+          .set_feature_flag(context::current(), name.clone(), variant.clone())
+          .await?;
+        Ok(())
+      })
+      .await?;
+    },
+    Command::SetMultipleFeatureFlag { ref flags } => {
+      with_logger(&args, async |logger| {
+        logger
+          .set_feature_flags(
+            context::current(),
+            flags
+              .chunks_exact(2)
+              .map(|pair| (pair[0].clone(), pair[1].clone()))
+              .collect(),
+          )
+          .await?;
+        Ok(())
+      })
+      .await?;
+    },
   }
 
   Ok(())

--- a/logger-cli/src/service.rs
+++ b/logger-cli/src/service.rs
@@ -32,6 +32,8 @@ pub trait Remote {
   async fn get_api_url() -> String;
   async fn start_new_session();
   async fn set_sleep_mode(enabled: bool);
+  async fn set_feature_flag(name: String, variant: Option<String>);
+  async fn set_feature_flags(flags: Vec<(String, String)>);
 }
 
 #[derive(Clone)]
@@ -142,6 +144,23 @@ impl Remote for Server {
   async fn start_new_session(self, _: ::tarpc::context::Context) {
     if let Some(logger) = &*LOGGER.lock() {
       logger.start_new_session();
+    }
+  }
+
+  async fn set_feature_flag(
+    self,
+    _: ::tarpc::context::Context,
+    name: String,
+    variant: Option<String>,
+  ) {
+    if let Some(logger) = &*LOGGER.lock() {
+      logger.set_feature_flag(name, variant);
+    }
+  }
+
+  async fn set_feature_flags(self, _: ::tarpc::context::Context, flags: Vec<(String, String)>) {
+    if let Some(logger) = &*LOGGER.lock() {
+      logger.set_feature_flags(flags);
     }
   }
 }


### PR DESCRIPTION
This emits a log every time one of the feature flag operations are performed, allowing for workflows to match on these events

Currently the log format is a bit of a strawman proposal, subject to change as we discuss 