### PR TITLE
Implement bd-state uploads with persistent storage default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,17 @@
    ```
    This should be placed at the top of the test file, after the license header and before imports.
 
+## Formatting
+
+- **ONLY** use `cargo +nightly fmt` to format code. This command automatically picks up `rustfmt.toml` from the repo root.
+- **NEVER** use any of these alternatives - they may not use the correct config:
+  - `cargo fmt` (stable rustfmt lacks required features)
+  - `rustfmt <file>` (may not find config)
+  - `cargo +nightly fmt -- <args> .` (using `.` as path can break config discovery)
+  - Any editor/IDE auto-format (may use wrong rustfmt version or config)
+- If you see unexpected whitespace-only changes across many files after formatting, STOP and investigate - the wrong formatter was likely used.
+- The repo uses `edition = "2024"` and `imports_layout = "HorizontalVertical"` in rustfmt.toml - imports should be vertical (one per line), not horizontal.
+
 ## Code Quality Checks
 - After generating or modifying code, always run clippy to check for static lint violations:
   `cargo clippy --workspace --bins --examples --tests -- --no-deps`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/bd-api/src/api.rs
+++ b/bd-api/src/api.rs
@@ -79,7 +79,6 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::watch;
 use tokio::time::{Instant, Sleep, sleep};
 
-
 //
 // StreamClosureInfo
 //

--- a/bd-api/src/api.rs
+++ b/bd-api/src/api.rs
@@ -79,6 +79,7 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::watch;
 use tokio::time::{Instant, Sleep, sleep};
 
+
 //
 // StreamClosureInfo
 //

--- a/bd-api/src/lib.rs
+++ b/bd-api/src/lib.rs
@@ -105,7 +105,6 @@ impl TriggerUpload {
   }
 }
 
-
 //
 // StreamEvent
 //

--- a/bd-api/src/lib.rs
+++ b/bd-api/src/lib.rs
@@ -105,6 +105,7 @@ impl TriggerUpload {
   }
 }
 
+
 //
 // StreamEvent
 //

--- a/bd-artifact-upload/src/uploader_test.rs
+++ b/bd-artifact-upload/src/uploader_test.rs
@@ -165,6 +165,8 @@ async fn basic_flow() {
       Some(timestamp),
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
 
@@ -226,6 +228,8 @@ async fn feature_flags() {
         ),
         SnappedFeatureFlag::new("key2".to_string(), None, timestamp - 2.std_seconds()),
       ],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
 
@@ -239,7 +243,6 @@ async fn feature_flags() {
           uuid: intent.uuid,
           decision: bd_api::upload::IntentDecision::UploadImmediately }).unwrap();
   });
-
 
   let upload = setup.data_upload_rx.recv().await.unwrap();
   assert_matches!(upload, DataUpload::ArtifactUpload(upload) => {
@@ -294,6 +297,8 @@ async fn pending_upload_limit() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -309,6 +314,8 @@ async fn pending_upload_limit() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -323,6 +330,8 @@ async fn pending_upload_limit() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -390,6 +399,8 @@ async fn inconsistent_state_missing_file() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -404,6 +415,8 @@ async fn inconsistent_state_missing_file() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -446,6 +459,8 @@ async fn inconsistent_state_extra_file() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -516,6 +531,8 @@ async fn disk_persistence() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -562,6 +579,8 @@ async fn inconsistent_state_missing_index() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -585,6 +604,8 @@ async fn inconsistent_state_missing_index() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -630,6 +651,8 @@ async fn new_entry_disk_full() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -658,6 +681,8 @@ async fn new_entry_disk_full_after_received() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -698,6 +723,8 @@ async fn intent_retries() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -732,6 +759,8 @@ async fn intent_drop() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(
@@ -768,6 +797,8 @@ async fn upload_retries() {
       None,
       "session_id".to_string(),
       vec![],
+      "client_report".to_string(),
+      false,
     )
     .unwrap();
   assert_eq!(

--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -487,6 +487,8 @@ impl Monitor {
       timestamp,
       session_id.clone(),
       reporting_feature_flags.clone(),
+      "client_report".to_string(),
+      false, // Don't skip intent negotiation for crash reports
     ) else {
       log::warn!(
         "Failed to enqueue issue report for upload: {}",

--- a/bd-logger/Cargo.toml
+++ b/bd-logger/Cargo.toml
@@ -60,6 +60,7 @@ tokio.workspace              = true
 tower.workspace              = true
 tracing.workspace            = true
 unwrap-infallible.workspace  = true
+uuid.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace    = true

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -339,6 +339,7 @@ impl LoggerBuilder {
           Some(retention_registry),
           Some(Arc::new(state_store.clone())),
           snapshot_creation_interval_ms,
+          time_provider.clone(),
           &scope,
         )
         .await,

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -13,6 +13,7 @@ use crate::internal::InternalLogger;
 use crate::log_replay::LoggerReplay;
 use crate::logger::Logger;
 use crate::logging_state::UninitializedLoggingContext;
+use crate::state_upload::StateLogCorrelator;
 use crate::{InitParams, LogAttributesOverrides};
 use bd_api::{
   AggregatedNetworkQualityProvider,
@@ -301,7 +302,8 @@ impl LoggerBuilder {
       )
       .await;
 
-      let (state_store, previous_run_state) = (result.store, result.previous_state);
+      let (state_store, previous_run_state, retention_registry) =
+        (result.store, result.previous_state, result.retention_registry);
 
       if result.fallback_occurred {
         handle_unexpected(
@@ -312,6 +314,24 @@ impl LoggerBuilder {
         );
       }
 
+      // Create state-log correlator for uploading state snapshots alongside logs
+      let state_correlator = Arc::new(
+        StateLogCorrelator::new(
+          Some(state_directory.clone()),
+          self.params.sdk_directory.clone(),
+          Arc::new(RealFileSystem::new(self.params.sdk_directory.clone())),
+          Some(retention_registry),
+          &scope,
+        )
+        .await,
+      );
+
+      // Set up state change listener to notify correlator when state changes
+      let correlator_for_listener = state_correlator.clone();
+      state_store.set_change_listener(Arc::new(move |timestamp| {
+        correlator_for_listener.on_state_change(timestamp);
+      }));
+
       let (artifact_uploader, artifact_client) = bd_artifact_upload::Uploader::new(
         Arc::new(RealFileSystem::new(self.params.sdk_directory.clone())),
         data_upload_tx_clone.clone(),
@@ -320,11 +340,12 @@ impl LoggerBuilder {
         &collector_clone,
         shutdown_handle.make_shutdown(),
       );
+      let artifact_client: Arc<dyn bd_artifact_upload::Client> = Arc::new(artifact_client);
 
       let crash_monitor = Monitor::new(
         &self.params.sdk_directory,
         self.params.store.clone(),
-        Arc::new(artifact_client),
+        artifact_client.clone(),
         self.params.session_strategy.clone(),
         &init_lifecycle,
         state_store.clone(),
@@ -348,6 +369,7 @@ impl LoggerBuilder {
       let buffer_directory = Logger::initialize_buffer_directory(&self.params.sdk_directory)?;
       let (buffer_manager, buffer_event_rx) =
         bd_buffer::Manager::new(buffer_directory, &scope, &runtime_loader);
+      let session_strategy_for_uploader = self.params.session_strategy.clone();
       let buffer_uploader = BufferUploadManager::new(
         data_upload_tx_clone.clone(),
         &runtime_loader,
@@ -356,6 +378,9 @@ impl LoggerBuilder {
         trigger_upload_rx,
         &scope,
         log.clone(),
+        Some(state_correlator),
+        artifact_client,
+        Arc::new(move || session_strategy_for_uploader.session_id()),
       );
 
       let updater = Arc::new(client_config::Config::new(

--- a/bd-logger/src/lib.rs
+++ b/bd-logger/src/lib.rs
@@ -34,7 +34,7 @@ mod pre_config_buffer;
 mod service;
 mod state_upload;
 
-pub use state_upload::{SnapshotRef, StateLogCorrelator};
+pub use state_upload::{SnapshotCreator, SnapshotRef, StateLogCorrelator};
 
 #[cfg(test)]
 mod test;

--- a/bd-logger/src/lib.rs
+++ b/bd-logger/src/lib.rs
@@ -32,6 +32,9 @@ mod network;
 mod ordered_receiver;
 mod pre_config_buffer;
 mod service;
+mod state_upload;
+
+pub use state_upload::{SnapshotRef, StateLogCorrelator};
 
 #[cfg(test)]
 mod test;

--- a/bd-logger/src/logger_test.rs
+++ b/bd-logger/src/logger_test.rs
@@ -17,6 +17,7 @@ use bd_session::fixed::{self, UUIDCallbacks};
 use bd_test_helpers::session::in_memory_store;
 use futures_util::poll;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use tokio::pin;
 use tokio::sync::watch;
 use tokio_test::assert_pending;
@@ -39,6 +40,7 @@ async fn thread_local_logger_guard() {
     sdk_version: "1.0.0".into(),
     app_version_repo: Repository::new(store),
     sleep_mode_active: watch::channel(false).0,
+    state_storage_fallback: Arc::new(AtomicBool::new(false)),
   };
 
   with_thread_local_logger_guard(|| {

--- a/bd-logger/src/state_upload.rs
+++ b/bd-logger/src/state_upload.rs
@@ -1,0 +1,415 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+//! State snapshot upload coordination for log uploads.
+//!
+//! This module provides the [`StateLogCorrelator`] which tracks the correlation between log uploads
+//! and state snapshots. The server correlates logs with state by timestamp - logs at time T use the
+//! most recent state snapshot uploaded before time T.
+//!
+//! The correlator ensures that:
+//! - State snapshots are uploaded before logs that depend on them
+//! - Duplicate snapshot uploads are avoided across multiple buffers
+//! - Snapshot coverage is tracked across process restarts via persistence
+
+#[cfg(test)]
+#[path = "./state_upload_test.rs"]
+mod tests;
+
+use bd_artifact_upload::Client as ArtifactClient;
+use bd_client_common::file::{read_checksummed_data, write_checksummed_data};
+use bd_client_common::file_system::FileSystem;
+use bd_client_stats_store::{Counter, Scope};
+use bd_log_primitives::LogFields;
+use bd_state::{RetentionHandle, RetentionRegistry};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use time::OffsetDateTime;
+use tokio::sync::RwLock;
+
+/// Directory for storing state upload index.
+const STATE_UPLOAD_DIR: &str = "state_upload";
+
+/// Index file name for tracking uploaded snapshots.
+const STATE_UPLOAD_INDEX_FILE: &str = "upload_index.bin";
+
+/// A reference to a state snapshot that should be uploaded.
+#[derive(Debug, Clone)]
+pub struct SnapshotRef {
+  /// The timestamp of the snapshot (microseconds since epoch).
+  pub timestamp_micros: u64,
+  /// The generation number of the snapshot file.
+  pub generation: u64,
+  /// Path to the snapshot file.
+  pub path: PathBuf,
+}
+
+/// Statistics for state upload operations.
+struct Stats {
+  snapshots_uploaded: Counter,
+  snapshots_skipped: Counter,
+  upload_failures: Counter,
+}
+
+impl Stats {
+  fn new(scope: &Scope) -> Self {
+    Self {
+      snapshots_uploaded: scope.counter("snapshots_uploaded"),
+      snapshots_skipped: scope.counter("snapshots_skipped"),
+      upload_failures: scope.counter("upload_failures"),
+    }
+  }
+}
+
+/// Tracks correlation between log uploads and state snapshot coverage.
+///
+/// This correlator coordinates state snapshot uploads with log uploads to ensure the server has
+/// the state context needed to hydrate logs. It tracks:
+/// - The timestamp of the most recent state change
+/// - The timestamp through which state has been uploaded to the server
+///
+/// The correlator is shared across all buffer uploaders to avoid duplicate uploads.
+pub struct StateLogCorrelator {
+  /// Timestamp of the most recent state change (microseconds since epoch).
+  last_state_change_micros: AtomicU64,
+
+  /// Timestamp through which state has been uploaded to server (microseconds since epoch).
+  /// Any logs with timestamps before this value have their state coverage already uploaded.
+  state_uploaded_through_micros: AtomicU64,
+
+  /// Path to the state store directory (for finding snapshot files).
+  state_store_path: Option<PathBuf>,
+
+  /// Path to the SDK directory (for persisting upload index).
+  sdk_directory: PathBuf,
+
+  /// File system for persistence operations.
+  file_system: Arc<dyn FileSystem>,
+
+  /// Lock for persisting the upload index.
+  persist_lock: RwLock<()>,
+
+  /// Retention handle for preventing snapshot cleanup. Updated as state is uploaded to allow
+  /// cleanup of old snapshots that have already been uploaded.
+  retention_handle: Option<RetentionHandle>,
+
+  /// Statistics.
+  stats: Stats,
+}
+
+impl StateLogCorrelator {
+  /// Creates a new correlator.
+  ///
+  /// # Arguments
+  /// * `state_store_path` - Path to the state store directory containing snapshot files
+  /// * `sdk_directory` - Path to the SDK directory for persisting the upload index
+  /// * `file_system` - File system for persistence operations
+  /// * `retention_registry` - Registry for managing snapshot retention to prevent cleanup
+  /// * `stats_scope` - Stats scope for metrics
+  pub async fn new(
+    state_store_path: Option<PathBuf>,
+    sdk_directory: PathBuf,
+    file_system: Arc<dyn FileSystem>,
+    retention_registry: Option<Arc<RetentionRegistry>>,
+    stats_scope: &Scope,
+  ) -> Self {
+    let stats = Stats::new(&stats_scope.scope("state_upload"));
+
+    // Create a retention handle to prevent snapshot cleanup while we have pending uploads.
+    // The handle starts at timestamp 0, meaning "retain everything". We'll update it after
+    // loading persisted state and when state is uploaded.
+    let retention_handle = match &retention_registry {
+      Some(registry) => Some(registry.create_handle().await),
+      None => None,
+    };
+
+    let correlator = Self {
+      last_state_change_micros: AtomicU64::new(0),
+      state_uploaded_through_micros: AtomicU64::new(0),
+      state_store_path,
+      sdk_directory,
+      file_system,
+      persist_lock: RwLock::new(()),
+      retention_handle,
+      stats,
+    };
+
+    // Try to load persisted state
+    correlator.load_persisted_state().await;
+
+    // Update retention handle to match loaded state (if any)
+    if let Some(handle) = &correlator.retention_handle {
+      let uploaded_through = correlator.state_uploaded_through_micros.load(Ordering::Relaxed);
+      if uploaded_through > 0 {
+        handle.update_retention_micros(uploaded_through);
+      }
+    }
+
+    correlator
+  }
+
+  /// Called when state changes. Updates the tracked last state change timestamp.
+  ///
+  /// This should be called from the state store's change listener to notify the correlator that
+  /// state has changed and a new snapshot may need to be uploaded.
+  pub fn on_state_change(&self, timestamp: OffsetDateTime) {
+    let timestamp_micros =
+      timestamp.unix_timestamp().cast_unsigned() * 1_000_000 + u64::from(timestamp.microsecond());
+    self
+      .last_state_change_micros
+      .fetch_max(timestamp_micros, Ordering::Relaxed);
+  }
+
+  /// Checks if a state snapshot upload is needed before uploading a batch of logs.
+  ///
+  /// Returns `Some(SnapshotRef)` if a snapshot should be uploaded before the logs, or `None` if
+  /// the server already has sufficient state coverage for the log timestamps.
+  ///
+  /// # Arguments
+  /// * `batch_oldest_micros` - Timestamp of the oldest log in the batch (microseconds)
+  /// * `_batch_newest_micros` - Timestamp of the newest log in the batch (microseconds)
+  #[must_use]
+  pub fn should_upload_state(
+    &self,
+    batch_oldest_micros: u64,
+    _batch_newest_micros: u64,
+  ) -> Option<SnapshotRef> {
+    let state_uploaded_through = self.state_uploaded_through_micros.load(Ordering::Relaxed);
+    let last_state_change = self.last_state_change_micros.load(Ordering::Relaxed);
+
+    // If we've never seen any state changes, no upload needed
+    if last_state_change == 0 {
+      return None;
+    }
+
+    // If we've already uploaded state that covers this batch, no upload needed
+    if state_uploaded_through >= batch_oldest_micros {
+      self.stats.snapshots_skipped.inc();
+      return None;
+    }
+
+    // Find the most recent snapshot that covers the batch
+    self.find_snapshot_for_timestamp(batch_oldest_micros)
+  }
+
+  /// Called after a state snapshot has been successfully uploaded.
+  ///
+  /// Updates the coverage tracking so future log batches won't trigger redundant uploads.
+  pub async fn on_state_uploaded(&self, snapshot_timestamp_micros: u64) {
+    self
+      .state_uploaded_through_micros
+      .fetch_max(snapshot_timestamp_micros, Ordering::Relaxed);
+    self.stats.snapshots_uploaded.inc();
+
+    // Update retention handle to allow cleanup of snapshots older than what we've uploaded
+    if let Some(handle) = &self.retention_handle {
+      handle.update_retention_micros(snapshot_timestamp_micros);
+    }
+
+    // Persist the updated coverage
+    self.persist_state().await;
+  }
+
+  /// Records that an upload attempt failed.
+  pub fn on_upload_failed(&self) {
+    self.stats.upload_failures.inc();
+  }
+
+  /// Uploads a state snapshot if needed before uploading logs.
+  ///
+  /// This method checks if a state snapshot upload is needed for the given log batch timestamps,
+  /// and if so, enqueues the snapshot file for upload via the artifact uploader.
+  ///
+  /// The artifact uploader handles the actual upload asynchronously with retries.
+  pub async fn upload_state_if_needed(
+    &self,
+    batch_oldest_micros: u64,
+    batch_newest_micros: u64,
+    artifact_client: &dyn ArtifactClient,
+    session_id: &str,
+  ) {
+    let Some(snapshot_ref) = self.should_upload_state(batch_oldest_micros, batch_newest_micros)
+    else {
+      return;
+    };
+
+    log::debug!(
+      "uploading state snapshot {} for log batch (oldest={}, newest={})",
+      snapshot_ref.timestamp_micros,
+      batch_oldest_micros,
+      batch_newest_micros
+    );
+
+    // Open the snapshot file
+    let file = match File::open(&snapshot_ref.path) {
+      Ok(f) => f,
+      Err(e) => {
+        log::warn!(
+          "failed to open snapshot file {}: {e}",
+          snapshot_ref.path.display()
+        );
+        self.on_upload_failed();
+        return;
+      },
+    };
+
+    // Convert timestamp from microseconds to OffsetDateTime
+    let timestamp =
+      OffsetDateTime::from_unix_timestamp_nanos(i128::from(snapshot_ref.timestamp_micros) * 1000)
+        .ok();
+
+    // Enqueue the upload via artifact uploader
+    // skip_intent=true since we want to upload immediately without negotiation
+    match artifact_client.enqueue_upload(
+      file,
+      LogFields::new(),
+      timestamp,
+      session_id.to_string(),
+      vec![],
+      "state_snapshot".to_string(),
+      true, // skip_intent - upload immediately
+    ) {
+      Ok(_uuid) => {
+        log::debug!(
+          "state snapshot upload enqueued for timestamp {}",
+          snapshot_ref.timestamp_micros
+        );
+        // Mark as uploaded - the artifact uploader will handle retries
+        self.on_state_uploaded(snapshot_ref.timestamp_micros).await;
+      },
+      Err(e) => {
+        log::warn!("failed to enqueue state snapshot upload: {e}");
+        self.on_upload_failed();
+      },
+    }
+  }
+
+  /// Returns the path to the state store directory, if configured.
+  #[must_use]
+  pub fn state_store_path(&self) -> Option<&Path> {
+    self.state_store_path.as_deref()
+  }
+
+  /// Finds a snapshot file that covers the given timestamp.
+  ///
+  /// Looks for .zz snapshot files in the state store's snapshot directory and returns the most
+  /// recent one that was created before the given timestamp.
+  fn find_snapshot_for_timestamp(&self, timestamp_micros: u64) -> Option<SnapshotRef> {
+    let state_path = self.state_store_path.as_ref()?;
+    let snapshots_dir = state_path.join("snapshots");
+
+    // List snapshot files and find the most recent one before the timestamp
+    let entries = std::fs::read_dir(&snapshots_dir).ok()?;
+
+    let mut best_match: Option<SnapshotRef> = None;
+
+    for entry in entries.flatten() {
+      let path = entry.path();
+      if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
+        // Parse filename like "state.jrn.g{generation}.t{timestamp}.zz"
+        if let Some((generation, file_timestamp)) = parse_snapshot_filename(filename) {
+          // Only consider snapshots created before the log batch
+          if file_timestamp <= timestamp_micros
+            && best_match
+              .as_ref()
+              .is_none_or(|b| file_timestamp > b.timestamp_micros)
+          {
+            best_match = Some(SnapshotRef {
+              timestamp_micros: file_timestamp,
+              generation,
+              path,
+            });
+          }
+        }
+      }
+    }
+
+    best_match
+  }
+
+  /// Loads persisted state from disk.
+  async fn load_persisted_state(&self) {
+    let index_path = self
+      .sdk_directory
+      .join(STATE_UPLOAD_DIR)
+      .join(STATE_UPLOAD_INDEX_FILE);
+
+    let Ok(contents) = self.file_system.read_file(&index_path).await else {
+      return;
+    };
+
+    let Ok(data) = read_checksummed_data(&contents) else {
+      log::debug!("state upload index checksum validation failed, starting fresh");
+      return;
+    };
+
+    // Simple binary format: just a u64 for state_uploaded_through_micros
+    if data.len() >= 8 {
+      let uploaded_through = u64::from_le_bytes(data[.. 8].try_into().unwrap_or_default());
+      self
+        .state_uploaded_through_micros
+        .store(uploaded_through, Ordering::Relaxed);
+      log::debug!("loaded state upload coverage through {uploaded_through}");
+    }
+  }
+
+  /// Persists state to disk.
+  async fn persist_state(&self) {
+    let _lock = self.persist_lock.write().await;
+
+    let dir_path = self.sdk_directory.join(STATE_UPLOAD_DIR);
+    let index_path = dir_path.join(STATE_UPLOAD_INDEX_FILE);
+
+    // Ensure directory exists
+    if let Err(e) = self.file_system.create_dir(&dir_path).await {
+      log::debug!("failed to create state upload directory: {e}");
+      return;
+    }
+
+    // Simple binary format: just a u64 for state_uploaded_through_micros
+    let uploaded_through = self.state_uploaded_through_micros.load(Ordering::Relaxed);
+    let data = uploaded_through.to_le_bytes().to_vec();
+
+    let checksummed = write_checksummed_data(&data);
+
+    if let Err(e) = self.file_system.write_file(&index_path, &checksummed).await {
+      log::debug!("failed to persist state upload index: {e}");
+    }
+  }
+}
+
+/// Parses a snapshot filename to extract generation and timestamp.
+///
+/// Expected format: "state.jrn.g{generation}.t{timestamp}.zz"
+/// Returns (generation, `timestamp_micros`) if successful.
+fn parse_snapshot_filename(filename: &str) -> Option<(u64, u64)> {
+  // Check for expected prefix and suffix
+  if !filename.starts_with("state.jrn.g")
+    || !std::path::Path::new(filename)
+      .extension()
+      .is_some_and(|ext| ext.eq_ignore_ascii_case("zz"))
+  {
+    return None;
+  }
+
+  // Extract the middle part: "{generation}.t{timestamp}"
+  let middle = filename.strip_prefix("state.jrn.g")?.strip_suffix(".zz")?;
+
+  // Split by ".t" to get generation and timestamp
+  let mut parts = middle.split(".t");
+  let generation: u64 = parts.next()?.parse().ok()?;
+  let timestamp: u64 = parts.next()?.parse().ok()?;
+
+  // Ensure no more parts
+  if parts.next().is_some() {
+    return None;
+  }
+
+  Some((generation, timestamp))
+}

--- a/bd-logger/src/state_upload_test.rs
+++ b/bd-logger/src/state_upload_test.rs
@@ -1,0 +1,92 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+#![allow(clippy::unwrap_used)]
+
+use super::*;
+use bd_client_common::file_system::RealFileSystem;
+use std::sync::atomic::Ordering;
+use time::OffsetDateTime;
+
+#[test]
+fn parse_snapshot_filename_valid() {
+  let (generation, ts) = parse_snapshot_filename("state.jrn.g0.t1704067200000000.zz").unwrap();
+  assert_eq!(generation, 0);
+  assert_eq!(ts, 1_704_067_200_000_000);
+
+  let (generation, ts) = parse_snapshot_filename("state.jrn.g42.t9999999999999999.zz").unwrap();
+  assert_eq!(generation, 42);
+  assert_eq!(ts, 9_999_999_999_999_999);
+}
+
+#[test]
+fn parse_snapshot_filename_invalid() {
+  assert!(parse_snapshot_filename("invalid.zz").is_none());
+  assert!(parse_snapshot_filename("state.jrn.g0.zz").is_none());
+  assert!(parse_snapshot_filename("state.jrn.t123.zz").is_none());
+  assert!(parse_snapshot_filename("state.jrn.g0.t123").is_none());
+  assert!(parse_snapshot_filename("other.jrn.g0.t123.zz").is_none());
+}
+
+#[tokio::test]
+async fn correlator_no_state_changes() {
+  let temp_dir = tempfile::tempdir().unwrap();
+  let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
+  let stats = bd_client_stats_store::Collector::default().scope("test");
+
+  let correlator =
+    StateLogCorrelator::new(None, temp_dir.path().to_path_buf(), file_system, None, &stats).await;
+
+  // No state changes yet, should not need to upload
+  assert!(
+    correlator
+      .should_upload_state(1_000_000, 2_000_000)
+      .is_none()
+  );
+}
+
+#[tokio::test]
+async fn correlator_tracks_state_changes() {
+  let temp_dir = tempfile::tempdir().unwrap();
+  let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
+  let stats = bd_client_stats_store::Collector::default().scope("test");
+
+  let correlator =
+    StateLogCorrelator::new(None, temp_dir.path().to_path_buf(), file_system, None, &stats).await;
+
+  // Record a state change
+  let timestamp = OffsetDateTime::from_unix_timestamp(1_704_067_200).unwrap();
+  correlator.on_state_change(timestamp);
+
+  // The last_state_change should be updated
+  let last_change = correlator.last_state_change_micros.load(Ordering::Relaxed);
+  assert_eq!(last_change, 1_704_067_200_000_000);
+}
+
+#[tokio::test]
+async fn correlator_uploaded_coverage_prevents_reupload() {
+  let temp_dir = tempfile::tempdir().unwrap();
+  let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
+  let stats = bd_client_stats_store::Collector::default().scope("test");
+
+  let correlator =
+    StateLogCorrelator::new(None, temp_dir.path().to_path_buf(), file_system, None, &stats).await;
+
+  // Record a state change
+  let timestamp = OffsetDateTime::from_unix_timestamp(1_704_067_200).unwrap();
+  correlator.on_state_change(timestamp);
+
+  // Mark state as uploaded through a later timestamp
+  correlator.on_state_uploaded(1_704_067_300_000_000).await;
+
+  // Batch with timestamp before uploaded_through should not need upload
+  assert!(
+    correlator
+      .should_upload_state(1_704_067_100_000_000, 1_704_067_200_000_000)
+      .is_none()
+  );
+}

--- a/bd-logger/src/state_upload_test.rs
+++ b/bd-logger/src/state_upload_test.rs
@@ -9,27 +9,64 @@
 
 use super::*;
 use bd_client_common::file_system::RealFileSystem;
+use bd_resilient_kv::SnapshotFilename;
 use std::sync::atomic::Ordering;
 use time::OffsetDateTime;
 
+struct MockSnapshotCreator {
+  snapshot_dir: PathBuf,
+  call_count: AtomicU64,
+}
+
+impl MockSnapshotCreator {
+  fn new(snapshot_dir: PathBuf) -> Self {
+    std::fs::create_dir_all(&snapshot_dir).unwrap();
+    Self {
+      snapshot_dir,
+      call_count: AtomicU64::new(0),
+    }
+  }
+
+  fn call_count(&self) -> u64 {
+    self.call_count.load(Ordering::Relaxed)
+  }
+}
+
+#[async_trait::async_trait]
+impl SnapshotCreator for MockSnapshotCreator {
+  async fn create_snapshot(&self) -> Option<PathBuf> {
+    let count = self.call_count.fetch_add(1, Ordering::Relaxed);
+    let now = OffsetDateTime::now_utc();
+    let timestamp_micros =
+      now.unix_timestamp().cast_unsigned() * 1_000_000 + u64::from(now.microsecond());
+    let filename = format!("state.jrn.g{count}.t{timestamp_micros}.zz");
+    let path = self.snapshot_dir.join(&filename);
+    std::fs::write(&path, b"mock snapshot data").unwrap();
+    Some(path)
+  }
+}
+
 #[test]
 fn parse_snapshot_filename_valid() {
-  let (generation, ts) = parse_snapshot_filename("state.jrn.g0.t1704067200000000.zz").unwrap();
-  assert_eq!(generation, 0);
-  assert_eq!(ts, 1_704_067_200_000_000);
+  let parsed = SnapshotFilename::parse("state.jrn.g0.t1704067200000000.zz").unwrap();
+  assert_eq!(parsed.generation, 0);
+  assert_eq!(parsed.timestamp_micros, 1_704_067_200_000_000);
 
-  let (generation, ts) = parse_snapshot_filename("state.jrn.g42.t9999999999999999.zz").unwrap();
-  assert_eq!(generation, 42);
-  assert_eq!(ts, 9_999_999_999_999_999);
+  let parsed = SnapshotFilename::parse("state.jrn.g42.t9999999999999999.zz").unwrap();
+  assert_eq!(parsed.generation, 42);
+  assert_eq!(parsed.timestamp_micros, 9_999_999_999_999_999);
+
+  let parsed = SnapshotFilename::parse("other.jrn.g5.t123456.zz").unwrap();
+  assert_eq!(parsed.generation, 5);
+  assert_eq!(parsed.timestamp_micros, 123_456);
 }
 
 #[test]
 fn parse_snapshot_filename_invalid() {
-  assert!(parse_snapshot_filename("invalid.zz").is_none());
-  assert!(parse_snapshot_filename("state.jrn.g0.zz").is_none());
-  assert!(parse_snapshot_filename("state.jrn.t123.zz").is_none());
-  assert!(parse_snapshot_filename("state.jrn.g0.t123").is_none());
-  assert!(parse_snapshot_filename("other.jrn.g0.t123.zz").is_none());
+  assert!(SnapshotFilename::parse("invalid.zz").is_none());
+  assert!(SnapshotFilename::parse("state.jrn.g0.zz").is_none());
+  assert!(SnapshotFilename::parse("state.jrn.t123.zz").is_none());
+  assert!(SnapshotFilename::parse("state.jrn.g0.t123").is_none());
 }
 
 #[tokio::test]
@@ -38,10 +75,17 @@ async fn correlator_no_state_changes() {
   let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
   let stats = bd_client_stats_store::Collector::default().scope("test");
 
-  let correlator =
-    StateLogCorrelator::new(None, temp_dir.path().to_path_buf(), file_system, None, &stats).await;
+  let correlator = StateLogCorrelator::new(
+    None,
+    temp_dir.path().to_path_buf(),
+    file_system,
+    None,
+    None,
+    0,
+    &stats,
+  )
+  .await;
 
-  // No state changes yet, should not need to upload
   assert!(
     correlator
       .should_upload_state(1_000_000, 2_000_000)
@@ -55,14 +99,20 @@ async fn correlator_tracks_state_changes() {
   let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
   let stats = bd_client_stats_store::Collector::default().scope("test");
 
-  let correlator =
-    StateLogCorrelator::new(None, temp_dir.path().to_path_buf(), file_system, None, &stats).await;
+  let correlator = StateLogCorrelator::new(
+    None,
+    temp_dir.path().to_path_buf(),
+    file_system,
+    None,
+    None,
+    0,
+    &stats,
+  )
+  .await;
 
-  // Record a state change
   let timestamp = OffsetDateTime::from_unix_timestamp(1_704_067_200).unwrap();
   correlator.on_state_change(timestamp);
 
-  // The last_state_change should be updated
   let last_change = correlator.last_state_change_micros.load(Ordering::Relaxed);
   assert_eq!(last_change, 1_704_067_200_000_000);
 }
@@ -73,20 +123,288 @@ async fn correlator_uploaded_coverage_prevents_reupload() {
   let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
   let stats = bd_client_stats_store::Collector::default().scope("test");
 
-  let correlator =
-    StateLogCorrelator::new(None, temp_dir.path().to_path_buf(), file_system, None, &stats).await;
+  let correlator = StateLogCorrelator::new(
+    None,
+    temp_dir.path().to_path_buf(),
+    file_system,
+    None,
+    None,
+    0,
+    &stats,
+  )
+  .await;
 
-  // Record a state change
   let timestamp = OffsetDateTime::from_unix_timestamp(1_704_067_200).unwrap();
   correlator.on_state_change(timestamp);
 
-  // Mark state as uploaded through a later timestamp
   correlator.on_state_uploaded(1_704_067_300_000_000).await;
 
-  // Batch with timestamp before uploaded_through should not need upload
   assert!(
     correlator
       .should_upload_state(1_704_067_100_000_000, 1_704_067_200_000_000)
       .is_none()
+  );
+}
+
+#[tokio::test]
+async fn cooldown_prevents_rapid_snapshot_creation() {
+  let temp_dir = tempfile::tempdir().unwrap();
+  let state_dir = temp_dir.path().join("state");
+  let snapshots_dir = state_dir.join("snapshots");
+  let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
+  let stats = bd_client_stats_store::Collector::default().scope("test");
+
+  let mock_creator = Arc::new(MockSnapshotCreator::new(snapshots_dir));
+
+  let correlator = StateLogCorrelator::new(
+    Some(state_dir),
+    temp_dir.path().to_path_buf(),
+    file_system,
+    None,
+    Some(mock_creator.clone()),
+    1000,
+    &stats,
+  )
+  .await;
+
+  correlator.on_state_change(OffsetDateTime::now_utc());
+
+  let batch_ts =
+    OffsetDateTime::now_utc().unix_timestamp().cast_unsigned() * 1_000_000 + u64::MAX / 2;
+
+  let snapshot1 = correlator.get_or_create_snapshot(batch_ts).await;
+  assert!(snapshot1.is_some(), "first snapshot should be created");
+  assert_eq!(mock_creator.call_count(), 1);
+
+  let snapshot2 = correlator.get_or_create_snapshot(batch_ts + 1000).await;
+  assert!(
+    snapshot2.is_some(),
+    "second call should return existing snapshot"
+  );
+  assert_eq!(
+    mock_creator.call_count(),
+    1,
+    "should not create new snapshot due to cooldown"
+  );
+}
+
+#[tokio::test]
+async fn cooldown_allows_snapshot_after_interval() {
+  let temp_dir = tempfile::tempdir().unwrap();
+  let state_dir = temp_dir.path().join("state");
+  let snapshots_dir = state_dir.join("snapshots");
+  let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
+  let stats = bd_client_stats_store::Collector::default().scope("test");
+
+  let mock_creator = Arc::new(MockSnapshotCreator::new(snapshots_dir.clone()));
+
+  let correlator = StateLogCorrelator::new(
+    Some(state_dir),
+    temp_dir.path().to_path_buf(),
+    file_system,
+    None,
+    Some(mock_creator.clone()),
+    1,
+    &stats,
+  )
+  .await;
+
+  correlator.on_state_change(OffsetDateTime::now_utc());
+
+  let batch_ts =
+    OffsetDateTime::now_utc().unix_timestamp().cast_unsigned() * 1_000_000 + u64::MAX / 2;
+
+  let snapshot1 = correlator.get_or_create_snapshot(batch_ts).await;
+  assert!(snapshot1.is_some());
+  assert_eq!(mock_creator.call_count(), 1);
+
+  std::thread::sleep(std::time::Duration::from_millis(2));
+
+  // Clear the first snapshot so the second call must create a new one.
+  for entry in std::fs::read_dir(&snapshots_dir).unwrap() {
+    let entry = entry.unwrap();
+    std::fs::remove_file(entry.path()).unwrap();
+  }
+
+  let future_batch_ts = batch_ts + 10_000_000;
+  let snapshot2 = correlator.get_or_create_snapshot(future_batch_ts).await;
+  assert!(snapshot2.is_some());
+  assert_eq!(
+    mock_creator.call_count(),
+    2,
+    "should create new snapshot after cooldown expires"
+  );
+}
+
+#[tokio::test]
+async fn zero_cooldown_allows_immediate_snapshot_creation() {
+  let temp_dir = tempfile::tempdir().unwrap();
+  let state_dir = temp_dir.path().join("state");
+  let snapshots_dir = state_dir.join("snapshots");
+  let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
+  let stats = bd_client_stats_store::Collector::default().scope("test");
+
+  let mock_creator = Arc::new(MockSnapshotCreator::new(snapshots_dir.clone()));
+
+  let correlator = StateLogCorrelator::new(
+    Some(state_dir),
+    temp_dir.path().to_path_buf(),
+    file_system,
+    None,
+    Some(mock_creator.clone()),
+    0,
+    &stats,
+  )
+  .await;
+
+  correlator.on_state_change(OffsetDateTime::now_utc());
+
+  let base_ts =
+    OffsetDateTime::now_utc().unix_timestamp().cast_unsigned() * 1_000_000 + u64::MAX / 2;
+
+  for i in 0 .. 3 {
+    // Clear snapshots so each iteration forces a new creation.
+    for entry in std::fs::read_dir(&snapshots_dir).unwrap() {
+      let entry = entry.unwrap();
+      std::fs::remove_file(entry.path()).unwrap();
+    }
+
+    let snapshot = correlator
+      .get_or_create_snapshot(base_ts + i * 10_000_000)
+      .await;
+    assert!(snapshot.is_some());
+  }
+
+  assert_eq!(
+    mock_creator.call_count(),
+    3,
+    "all snapshots should be created with zero cooldown"
+  );
+}
+
+#[tokio::test]
+async fn uses_existing_snapshot_from_normal_rotation() {
+  let temp_dir = tempfile::tempdir().unwrap();
+  let state_dir = temp_dir.path().join("state");
+  let snapshots_dir = state_dir.join("snapshots");
+  std::fs::create_dir_all(&snapshots_dir).unwrap();
+  let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
+  let stats = bd_client_stats_store::Collector::default().scope("test");
+
+  let mock_creator = Arc::new(MockSnapshotCreator::new(snapshots_dir.clone()));
+
+  let existing_timestamp = 1_700_000_000_000_000u64;
+  let existing_snapshot = snapshots_dir.join(format!("state.jrn.g0.t{existing_timestamp}.zz"));
+  std::fs::write(&existing_snapshot, b"pre-existing snapshot from rotation").unwrap();
+
+  let correlator = StateLogCorrelator::new(
+    Some(state_dir),
+    temp_dir.path().to_path_buf(),
+    file_system,
+    None,
+    Some(mock_creator.clone()),
+    0,
+    &stats,
+  )
+  .await;
+
+  correlator.on_state_change(OffsetDateTime::now_utc());
+
+  let batch_ts = existing_timestamp + 1_000_000;
+  let snapshot = correlator.get_or_create_snapshot(batch_ts).await;
+
+  assert!(snapshot.is_some());
+  let snapshot_ref = snapshot.unwrap();
+  assert_eq!(snapshot_ref.timestamp_micros, existing_timestamp);
+  assert_eq!(snapshot_ref.generation, 0);
+  assert_eq!(
+    mock_creator.call_count(),
+    0,
+    "should not create new snapshot when existing one covers the batch"
+  );
+}
+
+#[tokio::test]
+async fn creates_on_demand_snapshot_when_none_exists() {
+  let temp_dir = tempfile::tempdir().unwrap();
+  let state_dir = temp_dir.path().join("state");
+  let snapshots_dir = state_dir.join("snapshots");
+  let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
+  let stats = bd_client_stats_store::Collector::default().scope("test");
+
+  let mock_creator = Arc::new(MockSnapshotCreator::new(snapshots_dir));
+
+  let correlator = StateLogCorrelator::new(
+    Some(state_dir),
+    temp_dir.path().to_path_buf(),
+    file_system,
+    None,
+    Some(mock_creator.clone()),
+    0,
+    &stats,
+  )
+  .await;
+
+  correlator.on_state_change(OffsetDateTime::now_utc());
+
+  let batch_ts =
+    OffsetDateTime::now_utc().unix_timestamp().cast_unsigned() * 1_000_000 + u64::MAX / 2;
+
+  let snapshot = correlator.get_or_create_snapshot(batch_ts).await;
+
+  assert!(snapshot.is_some());
+  assert_eq!(
+    mock_creator.call_count(),
+    1,
+    "should create new snapshot on-demand when none exists"
+  );
+}
+
+#[tokio::test]
+async fn prefers_existing_snapshot_over_on_demand_creation() {
+  let temp_dir = tempfile::tempdir().unwrap();
+  let state_dir = temp_dir.path().join("state");
+  let snapshots_dir = state_dir.join("snapshots");
+  std::fs::create_dir_all(&snapshots_dir).unwrap();
+  let file_system = Arc::new(RealFileSystem::new(temp_dir.path().to_path_buf()));
+  let stats = bd_client_stats_store::Collector::default().scope("test");
+
+  let mock_creator = Arc::new(MockSnapshotCreator::new(snapshots_dir.clone()));
+
+  let old_snapshot_ts = 1_700_000_000_000_000u64;
+  let old_snapshot = snapshots_dir.join(format!("state.jrn.g0.t{old_snapshot_ts}.zz"));
+  std::fs::write(&old_snapshot, b"old snapshot").unwrap();
+
+  let newer_snapshot_ts = 1_700_001_000_000_000u64;
+  let newer_snapshot = snapshots_dir.join(format!("state.jrn.g1.t{newer_snapshot_ts}.zz"));
+  std::fs::write(&newer_snapshot, b"newer snapshot").unwrap();
+
+  let correlator = StateLogCorrelator::new(
+    Some(state_dir),
+    temp_dir.path().to_path_buf(),
+    file_system,
+    None,
+    Some(mock_creator.clone()),
+    0,
+    &stats,
+  )
+  .await;
+
+  correlator.on_state_change(OffsetDateTime::now_utc());
+
+  let batch_ts = newer_snapshot_ts + 1_000_000;
+  let snapshot = correlator.get_or_create_snapshot(batch_ts).await;
+
+  assert!(snapshot.is_some());
+  let snapshot_ref = snapshot.unwrap();
+  assert_eq!(
+    snapshot_ref.timestamp_micros, newer_snapshot_ts,
+    "should select the most recent snapshot before the batch timestamp"
+  );
+  assert_eq!(snapshot_ref.generation, 1);
+  assert_eq!(
+    mock_creator.call_count(),
+    0,
+    "should not create snapshot when existing one is available"
   );
 }

--- a/bd-logger/src/test/mod.rs
+++ b/bd-logger/src/test/mod.rs
@@ -10,3 +10,4 @@ mod directory_lock_integration;
 mod embedded_logger_integration;
 mod logger_integration;
 mod setup;
+mod state_upload_integration;

--- a/bd-logger/src/test/setup.rs
+++ b/bd-logger/src/test/setup.rs
@@ -141,6 +141,24 @@ impl Setup {
     })
   }
 
+  /// Creates a Setup with runtime values pre-cached to disk.
+  ///
+  /// This starts a temporary logger to cache the runtime, then restarts with the cached config.
+  /// Use this when runtime values must be present at logger initialization time (e.g.,
+  /// `state.use_persistent_storage` which determines state store type at startup).
+  pub fn new_with_cached_runtime(options: SetupOptions) -> Self {
+    {
+      let _primer = Self::new_with_options(SetupOptions {
+        sdk_directory: options.sdk_directory.clone(),
+        disk_storage: options.disk_storage,
+        extra_runtime_values: options.extra_runtime_values.clone(),
+        ..Default::default()
+      });
+      std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    Self::new_with_options(options)
+  }
+
   pub fn new_with_options(options: SetupOptions) -> Self {
     let mut server = bd_test_helpers::test_api_server::start_server(false, None);
     let shutdown = ComponentShutdownTrigger::default();

--- a/bd-logger/src/test/state_upload_integration.rs
+++ b/bd-logger/src/test/state_upload_integration.rs
@@ -1,0 +1,319 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+//! Integration tests for state snapshot uploads alongside log uploads.
+//!
+//! These tests verify that:
+//! - State snapshots are uploaded before logs that depend on them
+//! - The continuous upload flow correctly coordinates state and log uploads
+//! - The trigger buffer flush flow uploads state before flushing logs
+
+#![allow(clippy::unwrap_used)]
+
+use super::setup::{Setup, SetupOptions};
+use crate::log_level;
+use bd_log_matcher::builder::message_equals;
+use bd_proto::protos::client::api::configuration_update::StateOfTheWorld;
+use bd_proto::protos::config::v1::config::{BufferConfigList, buffer_config};
+use bd_proto::protos::logging::payload::LogType;
+use bd_runtime::runtime::FeatureFlag as _;
+use bd_test_helpers::config_helper::{
+  ConfigurationUpdateParts,
+  configuration_update,
+  configuration_update_from_parts,
+  default_buffer_config,
+  make_buffer_matcher_matching_everything,
+  make_workflow_config_flushing_buffer,
+};
+use bd_test_helpers::runtime::ValueKind;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+/// Creates a mock snapshot file with the expected naming format.
+///
+/// The format is: `state.jrn.g{generation}.t{timestamp_micros}.zz`
+fn create_mock_snapshot(
+  sdk_directory: &std::path::Path,
+  generation: u64,
+  timestamp_micros: u64,
+) -> std::path::PathBuf {
+  let snapshots_dir = sdk_directory.join("state/snapshots");
+  std::fs::create_dir_all(&snapshots_dir).unwrap();
+
+  let filename = format!("state.jrn.g{generation}.t{timestamp_micros}.zz");
+  let path = snapshots_dir.join(&filename);
+
+  // Write some mock compressed content (just needs to be non-empty for the test)
+  std::fs::write(&path, b"mock snapshot data").unwrap();
+
+  path
+}
+
+/// Test that state snapshots are uploaded when logs are uploaded via continuous buffer.
+///
+/// Flow:
+/// 1. Create a mock snapshot file
+/// 2. Configure logger with a continuous buffer
+/// 3. Log messages to trigger upload
+/// 4. Verify artifact intent/upload for state snapshot occurs
+#[test]
+fn continuous_buffer_uploads_state_before_logs() {
+  let sdk_directory = Arc::new(TempDir::with_prefix("sdk").unwrap());
+
+  // Create a snapshot file with a timestamp that covers our logs
+  // Using a timestamp in the past so logs will need this snapshot
+  let snapshot_timestamp_micros = 1_704_067_200_000_000; // 2024-01-01 00:00:00 UTC
+  create_mock_snapshot(sdk_directory.path(), 0, snapshot_timestamp_micros);
+
+  let mut setup = Setup::new_with_options(SetupOptions {
+    sdk_directory,
+    disk_storage: true,
+    extra_runtime_values: vec![
+      (
+        bd_runtime::runtime::state::UsePersistentStorage::path(),
+        ValueKind::Bool(true),
+      ),
+      // Set small batch size to trigger uploads quickly
+      (
+        bd_runtime::runtime::log_upload::BatchSizeFlag::path(),
+        ValueKind::Int(1),
+      ),
+    ],
+    ..Default::default()
+  });
+
+  // Configure continuous buffer for all logs
+  setup.send_configuration_update(configuration_update(
+    "",
+    StateOfTheWorld {
+      buffer_config_list: Some(BufferConfigList {
+        buffer_config: vec![default_buffer_config(
+          buffer_config::Type::CONTINUOUS,
+          make_buffer_matcher_matching_everything().into(),
+        )],
+        ..Default::default()
+      })
+      .into(),
+      ..Default::default()
+    },
+  ));
+
+  // Record a state change to trigger the correlator to check for snapshots
+  // This simulates state changing before log upload
+  setup
+    .logger_handle
+    .set_feature_flag_exposure("test_flag".to_string(), Some("variant".to_string()));
+
+  // Log a message - this should trigger state upload check
+  setup.log(
+    log_level::INFO,
+    LogType::NORMAL,
+    "test message".into(),
+    [].into(),
+    [].into(),
+    None,
+  );
+
+  // Wait for log upload
+  let log_upload = setup.server.blocking_next_log_upload();
+  assert!(log_upload.is_some(), "expected log upload");
+
+  // Check if we got an artifact upload for the state snapshot
+  // Note: The artifact may be uploaded with skip_intent=true, so we might see
+  // direct upload without intent negotiation
+  let timeout = std::time::Duration::from_secs(2);
+  let start = std::time::Instant::now();
+
+  // Try to get artifact intent or upload (state snapshots use skip_intent=true)
+  while start.elapsed() < timeout {
+    if let Some(upload) = setup.server.blocking_next_artifact_upload() {
+      // Verify this is a state snapshot upload
+      assert!(
+        !upload.contents.is_empty(),
+        "state snapshot should have content"
+      );
+      return; // Test passed
+    }
+    std::thread::sleep(std::time::Duration::from_millis(100));
+  }
+
+  // If no artifact upload was found, the test still passes if logs were uploaded
+  // (state upload may have been skipped if coverage was already sufficient)
+  // This is expected behavior when the snapshot timestamp is older than
+  // the uploaded_through timestamp
+}
+
+/// Test that trigger buffer flush uploads state before logs.
+///
+/// Flow:
+/// 1. Create a mock snapshot file
+/// 2. Configure logger with a trigger buffer and a workflow that flushes on "flush" message
+/// 3. Write logs to the trigger buffer
+/// 4. Log "flush" to trigger the workflow flush
+/// 5. Verify logs are uploaded (state upload happens alongside)
+#[test]
+fn trigger_buffer_flush_uploads_state() {
+  let sdk_directory = Arc::new(TempDir::with_prefix("sdk").unwrap());
+
+  // Create a snapshot file
+  let snapshot_timestamp_micros = 1_704_067_200_000_000;
+  create_mock_snapshot(sdk_directory.path(), 0, snapshot_timestamp_micros);
+
+  let mut setup = Setup::new_with_options(SetupOptions {
+    sdk_directory,
+    disk_storage: true,
+    extra_runtime_values: vec![(
+      bd_runtime::runtime::state::UsePersistentStorage::path(),
+      ValueKind::Bool(true),
+    )],
+    ..Default::default()
+  });
+
+  // Configure a trigger buffer with a workflow that flushes on "flush" message
+  setup.send_configuration_update(configuration_update_from_parts(
+    "",
+    ConfigurationUpdateParts {
+      buffer_config: vec![default_buffer_config(
+        buffer_config::Type::TRIGGER,
+        make_buffer_matcher_matching_everything().into(),
+      )],
+      workflows: make_workflow_config_flushing_buffer("default", message_equals("flush")),
+      ..Default::default()
+    },
+  ));
+
+  // Record state change
+  setup
+    .logger_handle
+    .set_feature_flag_exposure("trigger_flag".to_string(), None);
+
+  // Log some messages to the trigger buffer
+  for i in 0 .. 3 {
+    setup.log(
+      log_level::INFO,
+      LogType::NORMAL,
+      format!("trigger log {i}").into(),
+      [].into(),
+      [].into(),
+      None,
+    );
+  }
+
+  // Log "flush" to trigger the workflow flush action
+  setup.log(
+    log_level::INFO,
+    LogType::NORMAL,
+    "flush".into(),
+    [].into(),
+    [].into(),
+    None,
+  );
+
+  // Wait for log upload from the trigger buffer flush
+  let log_upload = setup.server.blocking_next_log_upload();
+  assert!(
+    log_upload.is_some(),
+    "expected log upload from trigger buffer flush"
+  );
+
+  // Verify the upload contains our trigger logs
+  let upload = log_upload.unwrap();
+  let logs = upload.logs();
+  assert!(!logs.is_empty(), "expected logs in upload");
+}
+
+/// Test that state correlator tracks uploaded coverage and avoids duplicates.
+///
+/// Flow:
+/// 1. Create snapshot, upload logs (state should upload)
+/// 2. Upload more logs with same timestamp range
+/// 3. Verify state is NOT re-uploaded (coverage already satisfied)
+#[test]
+fn state_correlator_prevents_duplicate_uploads() {
+  let sdk_directory = Arc::new(TempDir::with_prefix("sdk").unwrap());
+
+  let snapshot_timestamp_micros = 1_704_067_200_000_000;
+  create_mock_snapshot(sdk_directory.path(), 0, snapshot_timestamp_micros);
+
+  let mut setup = Setup::new_with_options(SetupOptions {
+    sdk_directory,
+    disk_storage: true,
+    extra_runtime_values: vec![
+      (
+        bd_runtime::runtime::state::UsePersistentStorage::path(),
+        ValueKind::Bool(true),
+      ),
+      (
+        bd_runtime::runtime::log_upload::BatchSizeFlag::path(),
+        ValueKind::Int(1),
+      ),
+    ],
+    ..Default::default()
+  });
+
+  setup.configure_stream_all_logs();
+
+  // Record state change
+  setup
+    .logger_handle
+    .set_feature_flag_exposure("dup_test_flag".to_string(), None);
+
+  // First batch of logs
+  setup.log(
+    log_level::INFO,
+    LogType::NORMAL,
+    "first log".into(),
+    [].into(),
+    [].into(),
+    None,
+  );
+
+  // Wait for first upload
+  let _ = setup.server.blocking_next_log_upload();
+
+  // Count artifact uploads after first batch
+  let mut first_batch_artifacts = 0;
+  let timeout = std::time::Duration::from_millis(500);
+  let start = std::time::Instant::now();
+  while start.elapsed() < timeout {
+    if setup.server.blocking_next_artifact_upload().is_some() {
+      first_batch_artifacts += 1;
+    } else {
+      break;
+    }
+  }
+
+  // Second batch of logs (same timestamp range, should not re-upload state)
+  setup.log(
+    log_level::INFO,
+    LogType::NORMAL,
+    "second log".into(),
+    [].into(),
+    [].into(),
+    None,
+  );
+
+  let _ = setup.server.blocking_next_log_upload();
+
+  // Count artifact uploads after second batch
+  let mut second_batch_artifacts = 0;
+  let start = std::time::Instant::now();
+  while start.elapsed() < timeout {
+    if setup.server.blocking_next_artifact_upload().is_some() {
+      second_batch_artifacts += 1;
+    } else {
+      break;
+    }
+  }
+
+  // The second batch should have fewer or equal artifact uploads
+  // (state should not be re-uploaded if coverage is satisfied)
+  assert!(
+    second_batch_artifacts <= first_batch_artifacts,
+    "second batch should not upload more state than first batch"
+  );
+}

--- a/bd-logger/src/test/state_upload_integration.rs
+++ b/bd-logger/src/test/state_upload_integration.rs
@@ -72,8 +72,6 @@ fn continuous_buffer_creates_and_uploads_state_snapshot() {
     .logger_handle
     .set_feature_flag_exposure("another_flag".to_string(), Some("variant_b".to_string()));
 
-  std::thread::sleep(std::time::Duration::from_millis(100));
-
   setup.log(
     log_level::INFO,
     LogType::NORMAL,
@@ -149,8 +147,6 @@ fn trigger_buffer_flush_creates_snapshot() {
     .logger_handle
     .set_feature_flag_exposure("trigger_flag".to_string(), Some("enabled".to_string()));
 
-  std::thread::sleep(std::time::Duration::from_millis(100));
-
   for i in 0 .. 3 {
     setup.log(
       log_level::INFO,
@@ -207,6 +203,8 @@ fn trigger_buffer_flush_creates_snapshot() {
     }
     std::thread::sleep(std::time::Duration::from_millis(100));
   }
+
+  panic!("expected state snapshot upload within timeout");
 }
 
 #[test]
@@ -244,8 +242,6 @@ fn trigger_buffer_with_multiple_flushes_uploads_state_once() {
   setup
     .logger_handle
     .set_feature_flag_exposure("multi_flush_flag".to_string(), Some("value".to_string()));
-
-  std::thread::sleep(std::time::Duration::from_millis(100));
 
   setup.log(
     log_level::INFO,
@@ -343,8 +339,6 @@ fn state_correlator_prevents_duplicate_uploads() {
     .logger_handle
     .set_feature_flag_exposure("dup_test_flag".to_string(), Some("value".to_string()));
 
-  std::thread::sleep(std::time::Duration::from_millis(100));
-
   setup.log(
     log_level::INFO,
     LogType::NORMAL,
@@ -425,8 +419,6 @@ fn new_state_changes_trigger_new_snapshot() {
     .logger_handle
     .set_feature_flag_exposure("flag_v1".to_string(), Some("value1".to_string()));
 
-  std::thread::sleep(std::time::Duration::from_millis(100));
-
   setup.log(
     log_level::INFO,
     LogType::NORMAL,
@@ -449,8 +441,6 @@ fn new_state_changes_trigger_new_snapshot() {
   setup
     .logger_handle
     .set_feature_flag_exposure("flag_v2".to_string(), Some("value2".to_string()));
-
-  std::thread::sleep(std::time::Duration::from_millis(100));
 
   setup.log(
     log_level::INFO,
@@ -493,8 +483,6 @@ fn continuous_streaming_uploads_state_with_first_batch() {
   setup
     .logger_handle
     .set_feature_flag_exposure("streaming_flag".to_string(), Some("active".to_string()));
-
-  std::thread::sleep(std::time::Duration::from_millis(100));
 
   setup.log(
     log_level::INFO,
@@ -580,8 +568,6 @@ fn continuous_streaming_multiple_batches_single_state_upload() {
   setup
     .logger_handle
     .set_feature_flag_exposure("batch_flag".to_string(), Some("test".to_string()));
-
-  std::thread::sleep(std::time::Duration::from_millis(100));
 
   setup.log(
     log_level::INFO,

--- a/bd-report-convert/src/generated/mod.rs
+++ b/bd-report-convert/src/generated/mod.rs
@@ -21,7 +21,6 @@ pub const _DARWIN_FEATURE_ONLY_VERS_1050: u32 = 1;
 pub const _DARWIN_FEATURE_ONLY_UNIX_CONFORMANCE: u32 = 1;
 pub const _DARWIN_FEATURE_UNIX_CONFORMANCE: u32 = 3;
 pub const __has_ptrcheck: u32 = 0;
-pub const __has_bounds_safety_attributes: u32 = 0;
 pub const USE_CLANG_TYPES: u32 = 0;
 pub const __PTHREAD_SIZE__: u32 = 8176;
 pub const __PTHREAD_ATTR_SIZE__: u32 = 56;

--- a/bd-resilient-kv/src/lib.rs
+++ b/bd-resilient-kv/src/lib.rs
@@ -31,6 +31,7 @@ pub mod versioned_kv_journal;
 pub use bd_proto::protos::state::payload::StateValue;
 pub use bd_proto::protos::state::payload::state_value::Value_type;
 pub use scope::Scope;
+pub use versioned_kv_journal::filename::SnapshotFilename;
 pub use versioned_kv_journal::recovery::VersionedRecovery;
 pub use versioned_kv_journal::retention::{RetentionHandle, RetentionRegistry};
 pub use versioned_kv_journal::store::{DataLoss, ScopedMaps, VersionedKVStore};

--- a/bd-resilient-kv/src/versioned_kv_journal/filename.rs
+++ b/bd-resilient-kv/src/versioned_kv_journal/filename.rs
@@ -1,0 +1,138 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+//! Parsing for archived journal snapshot filenames: `{name}.jrn.g{generation}.t{timestamp}.zz`
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SnapshotFilename {
+  pub generation: u64,
+  pub timestamp_micros: u64,
+}
+
+impl SnapshotFilename {
+  /// Parses `{name}.jrn.g{generation}.t{timestamp}.zz` format.
+  #[must_use]
+  pub fn parse(filename: &str) -> Option<Self> {
+    if !std::path::Path::new(filename)
+      .extension()
+      .is_some_and(|ext| ext.eq_ignore_ascii_case("zz"))
+    {
+      return None;
+    }
+
+    let generation = filename
+      .split('.')
+      .find(|part| {
+        part.starts_with('g') && part.len() > 1 && part[1 ..].chars().all(|c| c.is_ascii_digit())
+      })
+      .and_then(|part| part.strip_prefix('g'))
+      .and_then(|g| g.parse::<u64>().ok())?;
+
+    let timestamp_micros = filename
+      .split('.')
+      .find(|part| {
+        part.starts_with('t') && part.len() > 1 && part[1 ..].chars().all(|c| c.is_ascii_digit())
+      })
+      .and_then(|part| part.strip_prefix('t'))
+      .and_then(|ts| ts.parse::<u64>().ok())?;
+
+    Some(Self {
+      generation,
+      timestamp_micros,
+    })
+  }
+
+  #[must_use]
+  pub fn extract_timestamp(filename: &str) -> Option<u64> {
+    Self::parse(filename).map(|sf| sf.timestamp_micros)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_valid_filename() {
+    let result = SnapshotFilename::parse("state.jrn.g1.t1234567890.zz");
+    assert_eq!(
+      result,
+      Some(SnapshotFilename {
+        generation: 1,
+        timestamp_micros: 1_234_567_890
+      })
+    );
+  }
+
+  #[test]
+  fn parse_large_values() {
+    let result = SnapshotFilename::parse("state.jrn.g999.t1737933600000000.zz");
+    assert_eq!(
+      result,
+      Some(SnapshotFilename {
+        generation: 999,
+        timestamp_micros: 1_737_933_600_000_000
+      })
+    );
+  }
+
+  #[test]
+  fn parse_different_journal_names() {
+    let result = SnapshotFilename::parse("other.jrn.g5.t999999.zz");
+    assert_eq!(
+      result,
+      Some(SnapshotFilename {
+        generation: 5,
+        timestamp_micros: 999_999
+      })
+    );
+  }
+
+  #[test]
+  fn parse_invalid_missing_zz_extension() {
+    assert_eq!(SnapshotFilename::parse("state.jrn.g1.t1234567890"), None);
+  }
+
+  #[test]
+  fn parse_invalid_missing_generation() {
+    assert_eq!(SnapshotFilename::parse("state.jrn.t1234567890.zz"), None);
+  }
+
+  #[test]
+  fn parse_invalid_missing_timestamp() {
+    assert_eq!(SnapshotFilename::parse("state.jrn.g1.zz"), None);
+  }
+
+  #[test]
+  fn parse_invalid_non_numeric_generation() {
+    assert_eq!(
+      SnapshotFilename::parse("state.jrn.gabc.t1234567890.zz"),
+      None
+    );
+  }
+
+  #[test]
+  fn parse_invalid_non_numeric_timestamp() {
+    assert_eq!(SnapshotFilename::parse("state.jrn.g1.tabc.zz"), None);
+  }
+
+  #[test]
+  fn parse_invalid_completely_wrong_format() {
+    assert_eq!(SnapshotFilename::parse("random_file.txt"), None);
+    assert_eq!(SnapshotFilename::parse(""), None);
+    assert_eq!(SnapshotFilename::parse(".zz"), None);
+  }
+
+  #[test]
+  fn extract_timestamp_works() {
+    assert_eq!(
+      SnapshotFilename::extract_timestamp("state.jrn.g1.t1234567890.zz"),
+      Some(1_234_567_890)
+    );
+    assert_eq!(SnapshotFilename::extract_timestamp("invalid.txt"), None);
+  }
+}

--- a/bd-resilient-kv/src/versioned_kv_journal/mod.rs
+++ b/bd-resilient-kv/src/versioned_kv_journal/mod.rs
@@ -10,6 +10,7 @@ use bd_proto::protos::state;
 
 pub mod cleanup;
 mod file_manager;
+pub mod filename;
 pub mod framing;
 mod journal;
 mod memmapped_journal;

--- a/bd-runtime/src/runtime.rs
+++ b/bd-runtime/src/runtime.rs
@@ -940,8 +940,8 @@ pub mod state {
   // When set to false, the state store operates in-memory only and does not persist
   // feature flags or global state to disk. When set to true, the state store will
   // attempt to use persistent storage, falling back to in-memory if initialization fails.
-  // Defaults to false for safety during crash loops.
-  bool_feature_flag!(UsePersistentStorage, "state.use_persistent_storage", false);
+  // Defaults to true; in-memory mode is only used as a fallback when persistent storage fails.
+  bool_feature_flag!(UsePersistentStorage, "state.use_persistent_storage", true);
 
   // Controls the initial buffer size for the persistent state store in bytes.
   // This determines the starting size of the memory-mapped file. The buffer will grow
@@ -956,4 +956,13 @@ pub mod state {
   // For persistent storage, this is the maximum file size. For in-memory storage,
   // this bounds the memory usage of the state store.
   int_feature_flag!(MaxCapacity, "state.max_capacity_bytes", 1024 * 1024);
+
+  // Minimum interval between state snapshot creations in milliseconds. This batching is primarily
+  // necessary for log streaming configurations where all logs are streamed rapidly. Defaults to
+  // 5000ms (5 seconds).
+  int_feature_flag!(
+    SnapshotCreationIntervalMs,
+    "state.snapshot_creation_interval_ms",
+    5000
+  );
 }

--- a/bd-test-helpers/src/runtime.rs
+++ b/bd-test-helpers/src/runtime.rs
@@ -11,6 +11,7 @@ use bd_proto::protos::client::runtime::runtime::{Value, value};
 
 /// A simple representation of a runtime value. This is used to provide better ergonomics than the
 /// protobuf enums.
+#[derive(Clone)]
 pub enum ValueKind {
   Bool(bool),
   Int(u32),


### PR DESCRIPTION
## Summary

- Implement state snapshot uploads to ensure logs can be correlated with state on the server
- Default `UsePersistentStorage` to `true` so persistent storage is used from first launch
- Track and report when state storage falls back to in-memory mode via `SDKConfigured` event

## Changes

### State Upload Implementation
- Add `StateUploadManager` to coordinate state snapshot uploads alongside log uploads
- Implement snapshot correlation: when logs reference a state sequence, upload the corresponding snapshot
- Add cooldown mechanism to prevent excessive on-demand snapshot creation
- Support both existing snapshots from normal rotation and on-demand snapshot creation

### Persistent Storage Default
- Change `UsePersistentStorage` runtime flag default from `false` to `true`
- New installs will now use persistent storage by default, enabling state uploads to work reliably

### Observability
- Add `state_storage_fallback` field to `Logger`/`LoggerHandle` to track in-memory fallback
- Include `_state_storage_fallback` in `SDKConfigured` event so server can observe fallback rate

### Infrastructure
- Add filename parsing utilities for snapshot files in `bd-resilient-kv`
- Comprehensive unit and integration tests for state upload functionality