### PR TITLE
logging: setup for otel tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -358,7 +358,7 @@ name = "bd-backoff"
 version = "1.0.0"
 dependencies = [
  "bd-workspace-hack",
- "rand 0.10.0",
+ "rand 0.10.1",
  "time",
 ]
 
@@ -682,7 +682,7 @@ dependencies = [
  "protobuf 4.0.0-alpha.0",
  "protobuf-codegen",
  "protobuf-json-mapping",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "snap",
@@ -779,13 +779,18 @@ dependencies = [
  "anyhow",
  "bd-time",
  "bd-workspace-hack",
+ "http",
  "log",
+ "opentelemetry 0.31.0",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk 0.31.0",
  "parking_lot",
  "time",
  "tokio",
  "tracing",
  "tracing-error",
  "tracing-log",
+ "tracing-opentelemetry 0.32.1",
  "tracing-subscriber",
 ]
 
@@ -828,7 +833,7 @@ dependencies = [
  "ordered-float",
  "pretty_assertions",
  "protobuf 4.0.0-alpha.0",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "tempfile",
  "time",
@@ -1109,7 +1114,7 @@ dependencies = [
  "memmap2",
  "protobuf 4.0.0-alpha.0",
  "rstest",
- "strum 0.28.0",
+ "strum",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -1181,7 +1186,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "prometheus",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "serde_yaml",
  "tempfile",
@@ -1359,7 +1364,7 @@ dependencies = [
  "bd-workspace-hack",
  "parking_lot",
  "protobuf 4.0.0-alpha.0",
- "rand 0.10.0",
+ "rand 0.10.1",
  "time",
  "tokio",
 ]
@@ -1416,7 +1421,7 @@ dependencies = [
 name = "bd-workspace-hack"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cc",
  "clap",
  "clap_builder",
@@ -1424,8 +1429,6 @@ dependencies = [
  "errno",
  "flate2",
  "futures-channel",
- "futures-executor",
- "futures-sink",
  "futures-task",
  "futures-util",
  "getrandom 0.2.17",
@@ -1448,11 +1451,12 @@ dependencies = [
  "serde",
  "serde_core",
  "serde_json",
- "slab",
  "smallvec",
  "syn",
  "sync_wrapper",
+ "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml_parser",
  "tower",
@@ -1497,7 +1501,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1519,9 +1523,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -1565,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1610,7 +1614,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1813,19 +1817,20 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
+checksum = "95d0d11eb38e7642efca359c3cf6eb7b2e528182d09110165de70192b0352775"
 dependencies = [
  "ctor-proc-macro",
  "dtor",
+ "link-section",
 ]
 
 [[package]]
 name = "ctor-proc-macro"
-version = "0.0.7"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+checksum = "a7ab264ea985f1bd27887d7b21ea2bb046728e05d11909ca138d700c494730db"
 
 [[package]]
 name = "cty"
@@ -1959,18 +1964,18 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dtor"
-version = "0.3.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+checksum = "17f72721db8027a4e96dd6fb50d2a1d32259c9d3da1b63dee612ccd981e14293"
 dependencies = [
  "dtor-proc-macro",
 ]
 
 [[package]]
 name = "dtor-proc-macro"
-version = "0.0.6"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+checksum = "8c98b077c7463d01d22dde8a24378ddf1ca7263dc687cffbed38819ea6c21131"
 
 [[package]]
 name = "dunce"
@@ -2055,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -2071,7 +2076,7 @@ version = "25.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b6620799e7340ebd9968d2e0708eb82cf1971e9a16821e2091b6d6e475eed5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "rustc_version",
 ]
 
@@ -2311,7 +2316,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2330,9 +2335,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gungraun"
-version = "0.17.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c1bbe46f51c63bc08a1fac0ee0c530a77c961613a86ecf828ab1b0ffc6687a"
+checksum = "2e2e7d17b75a18300d495a5e79970067b92d74e4858c28326e125f2d55b1b566"
 dependencies = [
  "bincode 1.3.3",
  "bindgen",
@@ -2344,14 +2349,14 @@ dependencies = [
  "gungraun-runner",
  "regex",
  "rustc_version",
- "strum 0.27.2",
+ "strum",
 ]
 
 [[package]]
 name = "gungraun-macros"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdccd089c36fb2ee66ef0eb7b1baa3ce7e7878a8eae682d9c8c368869ff6eca1"
+checksum = "e35c7fb6133421db1cf752b7a2838d9277a26810ccaeeca7aa449f96ad7c2b01"
 dependencies = [
  "derive_more",
  "proc-macro-error2",
@@ -2365,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "gungraun-runner"
-version = "0.17.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da6487203fa53ae6b1c8fead642fe79a3199464b0dd1337635594d675a9ac05"
+checksum = "c19bb4c552085f983300b11694022d7584810dca3500c220962ab2353327fb45"
 dependencies = [
  "serde",
 ]
@@ -2511,18 +2516,30 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -2708,7 +2725,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -2845,9 +2862,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2889,9 +2906,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2933,6 +2950,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468808413fa8bdf0edbe61c2bbc182dfc59885b94f496cf3fb42c9c96b1e0149"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2990,7 +3013,7 @@ dependencies = [
  "libc",
  "log",
  "parking_lot",
- "reqwest",
+ "reqwest 0.13.2",
  "rmcp",
  "serde",
  "serde_json",
@@ -3148,7 +3171,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3166,7 +3189,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3244,6 +3267,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry 0.31.0",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry 0.31.0",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk 0.31.0",
+ "prost",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry 0.31.0",
+ "opentelemetry_sdk 0.31.0",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,9 +3339,24 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.30.0",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.31.0",
+ "percent-encoding",
+ "rand 0.9.4",
  "thiserror 2.0.18",
 ]
 
@@ -3366,9 +3462,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -3496,6 +3592,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "protobuf"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3603,7 +3722,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3664,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3674,13 +3793,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3724,9 +3843,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -3734,7 +3853,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3794,6 +3913,38 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3848,9 +3999,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64",
@@ -3870,9 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3948,7 +4099,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3961,7 +4112,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -3970,9 +4121,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4034,9 +4185,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4112,7 +4263,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4393,7 +4544,7 @@ dependencies = [
  "bd-workspace-hack",
  "log",
  "protobuf 4.0.0-alpha.0",
- "rand 0.10.0",
+ "rand 0.10.1",
  "sha2",
  "tempfile",
  "time",
@@ -4409,32 +4560,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4492,7 +4622,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4517,7 +4647,7 @@ dependencies = [
  "fnv",
  "futures",
  "humantime",
- "opentelemetry",
+ "opentelemetry 0.30.0",
  "opentelemetry-semantic-conventions",
  "pin-project",
  "rand 0.8.5",
@@ -4529,7 +4659,7 @@ dependencies = [
  "tokio-serde",
  "tokio-util",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.31.0",
 ]
 
 [[package]]
@@ -4701,9 +4831,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -4850,6 +4980,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4857,9 +5024,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4872,7 +5042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4962,10 +5132,26 @@ checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.30.0",
+ "opentelemetry_sdk 0.30.0",
  "tracing",
  "tracing-core",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.31.0",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -5146,9 +5332,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5159,9 +5345,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5169,9 +5355,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5179,9 +5365,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5192,9 +5378,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -5227,7 +5413,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5235,9 +5421,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5679,7 +5865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ members = [
   "bd-runtime",
   "bd-runtime-config",
   "bd-server-stats",
-  "bd-state",
   "bd-stats-common",
   "bd-test-helpers",
   "bd-time",
@@ -67,7 +66,7 @@ assert_matches    = "1.5.0"
 assert_no_alloc   = "1.1.2"
 async-compression = { version = "0.4.41", features = ["tokio", "zlib"] }
 async-trait       = "0.1.89"
-axum              = { version = "0.8.8", features = ["http2", "macros"] }
+axum              = { version = "0.8.9", features = ["http2", "macros"] }
 base64            = "0.22.1"
 base64-url        = "3.0.3"
 base64ct          = { version = "1.8.3", features = ["alloc", "std"] }
@@ -81,13 +80,13 @@ bincode = { version = "=2.0.1", features = ["serde"] }
 bindgen         = "0.72.1"
 bytes           = "1.11.1"
 cbindgen        = "0.29.2"
-cc              = "1.2.59"
+cc              = "1.2.60"
 clap            = { version = "4.6.0", features = ["derive", "env"] }
 cmake           = "0.1.58"
 color-backtrace = "0.7.3"
 concat-string   = "1.0.1"
 crc32fast       = "1.5.0"
-ctor            = "0.8.0"
+ctor            = "0.10.0"
 dashmap         = "6.1.0"
 
 # Pinned due to https://github.com/google/flatbuffers/issues/8876
@@ -104,13 +103,13 @@ http                  = "1.4.0"
 http-body             = "1.0.1"
 http-body-util        = "0.1.3"
 hyper                 = "1.9.0"
-hyper-rustls          = { version = "0.27.7", default-features = false }
+hyper-rustls          = { version = "0.27.9", default-features = false }
 hyper-util            = { version = "0.1.20", features = ["client", "client-legacy"] }
 insta                 = "1.47.2"
 intrusive-collections = "0.10.0"
 itertools             = "0.14.0"
 jni                   = "0.22.4"
-libc                  = "0.2.184"
+libc                  = "0.2.185"
 libfuzzer-sys         = "0.4.12"
 log                   = "0.4.29"
 matches               = "0.1.10"
@@ -119,17 +118,27 @@ mockall               = "0.14.0"
 nom                   = "8.0.0"
 nom-language          = "0.1.0"
 notify                = "8.2.0"
-ordered-float         = { version = "5.3.0", features = ["serde"] }
-parameterized         = "2.1.0"
-parking_lot           = "0.12.5"
-pretty_assertions     = "1.4.1"
-prometheus            = "0.14.0"
-rmcp                  = { version = "1.3.0", features = ["transport-io"] }
-thread_local          = "1.1"
-tracing               = "0.1.44"
-tracing-log           = "0.2.0"
-tracing-subscriber    = { version = "0.3.23", features = ["env-filter"] }
-walkdir               = "2.5.0"
+opentelemetry         = "0.31.0"
+
+opentelemetry-otlp = { version = "0.31.1", default-features = false, features = [
+  "trace",
+  "http-proto",
+  "reqwest-client",
+  "grpc-tonic",
+] }
+
+opentelemetry_sdk  = { version = "0.31.0", features = ["trace"] }
+ordered-float      = { version = "5.3.0", features = ["serde"] }
+parameterized      = "2.1.0"
+parking_lot        = "0.12.5"
+pretty_assertions  = "1.4.1"
+prometheus         = "0.14.0"
+rmcp               = { version = "1.4.0", features = ["transport-io"] }
+thread_local       = "1.1"
+tracing            = "0.1.44"
+tracing-log        = "0.2.0"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+walkdir            = "2.5.0"
 
 protobuf = { git = "https://github.com/bitdriftlabs/rust-protobuf.git", branch = "patch-stack", features = [
   "bytes",
@@ -138,7 +147,7 @@ protobuf = { git = "https://github.com/bitdriftlabs/rust-protobuf.git", branch =
 protobuf-codegen = { git = "https://github.com/bitdriftlabs/rust-protobuf.git", branch = "patch-stack" }
 protobuf-json-mapping = { git = "https://github.com/bitdriftlabs/rust-protobuf.git", branch = "patch-stack" }
 
-rand         = "0.10.0"
+rand         = "0.10.1"
 regex        = "1.12.3"
 reqwest      = { version = "0.13.2", features = ["deflate", "json"] }
 rstest       = "0.26.1"
@@ -150,26 +159,27 @@ sha2         = "0.11.0"
 
 sketches-rust = { git = "https://github.com/mattklein123/sketches-rust.git", branch = "patch-stack2" }
 
-snap              = "1.1.1"
-sqlite            = "0.37.0"
-static_assertions = "1.1.0"
-strum             = { version = "0.28", features = ["derive"] }
-tarpc             = { version = "0.37.0", features = ["full"] }
-tempfile          = "3.27.0"
-termcolor         = "1.4.1"
-thiserror         = "2.0.18"
-tikv-jemalloc-ctl = "0.6.1"
-time              = { version = "0.3.47", features = ["serde-well-known", "macros", "parsing"] }
-tokio             = { version = "1.51.0", features = ["full", "test-util"] }
-tokio-rustls      = { version = "0.26.4", default-features = false }
-tokio-stream      = "0.1.18"
-tokio-test        = "0.4.5"
-tower             = { version = "0.5.3", features = ["retry", "util"] }
-tower-http        = { version = "0.6.8", features = ["compression-deflate"] }
-tracing-error     = "0.2.1"
-unwrap-infallible = "1.0.0"
-urlencoding       = "2.1.3"
-uuid              = { version = "1.23.0", features = ["v4"] }
+snap                  = "1.1.1"
+sqlite                = "0.37.0"
+static_assertions     = "1.1.0"
+strum                 = { version = "0.28", features = ["derive"] }
+tarpc                 = { version = "0.37.0", features = ["full"] }
+tempfile              = "3.27.0"
+termcolor             = "1.4.1"
+thiserror             = "2.0.18"
+tikv-jemalloc-ctl     = "0.6.1"
+time                  = { version = "0.3.47", features = ["serde-well-known", "macros", "parsing"] }
+tokio                 = { version = "1.52.0", features = ["full", "test-util"] }
+tokio-rustls          = { version = "0.26.4", default-features = false }
+tokio-stream          = "0.1.18"
+tokio-test            = "0.4.5"
+tower                 = { version = "0.5.3", features = ["retry", "util"] }
+tower-http            = { version = "0.6.8", features = ["compression-deflate"] }
+tracing-error         = "0.2.1"
+tracing-opentelemetry = "0.32.1"
+unwrap-infallible     = "1.0.0"
+urlencoding           = "2.1.3"
+uuid                  = { version = "1.23.0", features = ["v4"] }
 
 [profile.bench]
 debug = true

--- a/bd-log/Cargo.toml
+++ b/bd-log/Cargo.toml
@@ -9,16 +9,21 @@ version      = "1.0.0"
 doctest = false
 
 [dependencies]
-anyhow.workspace             = true
-bd-workspace-hack.workspace  = true
-log.workspace                = true
-parking_lot.workspace        = true
-time.workspace               = true
-tokio.workspace              = true
-tracing.workspace            = true
-tracing-error.workspace      = true
-tracing-log.workspace        = true
-tracing-subscriber.workspace = true
+anyhow.workspace                = true
+bd-workspace-hack.workspace     = true
+http.workspace                  = true
+log.workspace                   = true
+opentelemetry.workspace         = true
+opentelemetry-otlp.workspace    = true
+opentelemetry_sdk.workspace     = true
+parking_lot.workspace           = true
+time.workspace                  = true
+tokio.workspace                 = true
+tracing.workspace               = true
+tracing-error.workspace         = true
+tracing-log.workspace           = true
+tracing-opentelemetry.workspace = true
+tracing-subscriber.workspace    = true
 
 [dev-dependencies]
 bd-time = { path = "../bd-time" }

--- a/bd-log/src/lib.rs
+++ b/bd-log/src/lib.rs
@@ -5,17 +5,119 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
+//! `bd-log` installs a single `tracing` subscriber stack that can drive two different outputs:
+//! a local human-readable formatter and, when configured, an OTEL span exporter.
+//!
+//! The routing rules are easier to reason about if you separate them into three pieces:
+//!
+//! 1. The global filter, which comes from `RUST_LOG` by default or from [`LogConfig::log_filter`].
+//! 2. The local formatter layer, which writes compact logs to stderr by default or to stdout when
+//!    [`LogConfig::output`] is set to [`LogOutput::Stdout`].
+//! 3. The optional OTEL layer, which only receives spans and events emitted on [`OTEL_TARGET`].
+//!
+//! Ordinary `log` macros are bridged into `tracing` through `LogTracer`, so `log::info!`,
+//! ordinary `tracing` events, and `#[tracing::instrument]` spans all go through the same
+//! subscriber stack and are filtered by the same top-level rules.
+//!
+//! With the default configuration (`SwapLogger::initialize()`):
+//!
+//! - `RUST_LOG` controls which events reach the subscriber. If `RUST_LOG` is unset, the crate uses
+//!   `DEFAULT_FILTER_RULES`.
+//! - Output goes to stderr.
+//! - ANSI color is disabled unless `BD_LOG_ANSI` is set.
+//! - Set `BD_LOG_DEBUG_DIRECT_OTEL_SPANS=1` to emit local `new`/`close` span lifecycle lines for
+//!   OTEL-targeted spans. This is intended for local debugging and test runs.
+//! - No OTEL exporter is installed, so every event that passes the filter only goes to the local
+//!   formatter.
+//!
+//! With OTEL disabled, spans or events emitted with the helper macros in [`otel`] are not treated
+//! specially unless `BD_LOG_DEBUG_DIRECT_OTEL_SPANS` is set. They still use the dedicated target
+//! name, but they only follow the normal local output path and are filtered like any other target.
+//! When `BD_LOG_DEBUG_DIRECT_OTEL_SPANS` is set, `bd-log` also widens the global filter with
+//! `bd_log::otel=trace` so those spans are visible locally even if `RUST_LOG` would not normally
+//! match that target.
+//!
+//! With OTEL enabled (`LogConfig { otel: Some(..), .. }`):
+//!
+//! - The OTEL layer receives only items whose target is [`OTEL_TARGET`].
+//! - The global filter is widened with `bd_log::otel=trace` so direct-to-OTEL spans are not
+//!   accidentally dropped just because the ordinary `RUST_LOG` filter is narrower.
+//! - All non-OTEL-targeted logs still follow the normal `log_filter` rules and only go to the local
+//!   formatter.
+//!
+//! `mirror_to_output` controls whether OTEL-targeted items are also written to the local output:
+//!
+//! - `mirror_to_output = false`: direct-to-OTEL spans and events go only to the OTEL exporter and
+//!   are hidden from stdout or stderr.
+//! - `mirror_to_output = true`: direct-to-OTEL spans and events go to both the OTEL exporter and
+//!   the local formatter.
+//!
+//! `BD_LOG_DEBUG_DIRECT_OTEL_SPANS` is separate from `mirror_to_output`: it only prints OTEL-
+//! targeted span lifecycle records locally, and it works even when no OTEL exporter is configured.
+//!
+//! Initialization is intentionally two-stage. Call [`SwapLogger::initialize`] early if you want
+//! local stderr logging during startup, then call [`SwapLogger::initialize_with_config`] or
+//! [`SwapLogger::configure`] later once real config has loaded. The second call does not install a
+//! second global subscriber; it reloads the active filter and layer set in place so output routing
+//! can change from "local only" to "local plus OTEL" safely.
+//!
+//! [`SwapLogger::swap`] is narrower than reconfiguration: it only updates the active filter string.
+//! It does not change the output destination or attach or detach the OTEL exporter.
+
+#[cfg(test)]
+#[path = "./lib_test.rs"]
+mod tests;
+
+pub mod otel;
 pub mod rate_limit_log;
 
+use anyhow::anyhow;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+pub use otel::{LogConfig, LogOutput, OTEL_TARGET, OtelCollectorConfig, OtelCollectorProtocol};
 pub use parking_lot::Mutex as ParkingLotMutex;
+use std::fmt;
 use std::sync::Mutex;
 use tracing_error::ErrorLayer;
+use tracing_subscriber::field::RecordFields;
+use tracing_subscriber::filter::{LevelFilter, filter_fn};
+use tracing_subscriber::fmt::FormatFields;
+use tracing_subscriber::fmt::format::{DefaultFields, FmtSpan, Writer};
 use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::reload::Handle as ReloadHandle;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Layer, Registry};
 
 const DEFAULT_FILTER_RULES: &str = "info,aws_config=warn,aws_smithy_http_tower=warn";
+pub const DEBUG_DIRECT_OTEL_SPANS_ENV: &str = "BD_LOG_DEBUG_DIRECT_OTEL_SPANS";
+
+type RegistryLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
+type ReloadFilterFn = Box<dyn FnMut(EnvFilter) -> anyhow::Result<()> + Send>;
+type ReloadLayersFn = Box<dyn FnMut(Vec<RegistryLayer>) -> anyhow::Result<()> + Send>;
+
+// The local debug-only OTEL span view uses a second fmt layer alongside the normal output layer.
+// `tracing-subscriber` stores formatted span fields in extensions keyed by the formatter type, so
+// if both layers use `DefaultFields` they will append into the same stored field buffer. That is
+// what caused the duplicated `foo=... foo=...` output on synthesized close events. Give the debug
+// layer its own field formatter type so its cached fields are isolated from the normal fmt layer.
+#[derive(Debug, Default)]
+struct DirectOtelDebugFields(DefaultFields);
+
+impl<'writer> FormatFields<'writer> for DirectOtelDebugFields {
+  fn format_fields<R: RecordFields>(&self, writer: Writer<'writer>, fields: R) -> fmt::Result {
+    self.0.format_fields(writer, fields)
+  }
+}
+
+//
+// LoggerState
+//
+
+#[derive(Default)]
+struct LoggerState {
+  reload_filter: Option<ReloadFilterFn>,
+  reload_layers: Option<ReloadLayersFn>,
+  otel_provider: Option<SdkTracerProvider>,
+  direct_otel_enabled: bool,
+}
 
 //
 // SwapLogger
@@ -24,13 +126,18 @@ const DEFAULT_FILTER_RULES: &str = "info,aws_config=warn,aws_smithy_http_tower=w
 // An implementation of log:Log which allows for atomically swapping the underlying implementation.
 #[derive(Default)]
 pub struct SwapLogger {
-  handle: Mutex<Option<ReloadHandle<EnvFilter, Registry>>>,
+  state: Mutex<LoggerState>,
 }
 
 impl SwapLogger {
   const fn new() -> Self {
     Self {
-      handle: Mutex::new(None),
+      state: Mutex::new(LoggerState {
+        reload_filter: None,
+        reload_layers: None,
+        otel_provider: None,
+        direct_otel_enabled: false,
+      }),
     }
   }
 
@@ -44,47 +151,224 @@ impl SwapLogger {
   // Initialize the logger to the default. This can only be called once and should be called as
   // early as possible in the program.
   pub fn initialize() {
-    // Gate ANSI on whether BD_LOG_ANSI is set. This avoids using this feature by default (e.g.
-    // in k8s) but allows it to be enabled for local development should the user want it.
-    let stderr = tracing_subscriber::fmt::layer()
-      .with_writer(std::io::stderr)
-      .with_ansi(std::env::var("BD_LOG_ANSI").is_ok())
-      .with_line_number(true)
-      .with_thread_ids(true)
-      .compact();
+    let config = LogConfig::default();
+    Self::initialize_with_config(&config).unwrap();
+  }
 
-    let filter = EnvFilter::new(
-      std::env::var("RUST_LOG")
-        .as_deref()
-        .unwrap_or(DEFAULT_FILTER_RULES),
-    );
+  // Initialize the logger with explicit output and OTEL configuration. If the logger has already
+  // been installed, this reloads the active configuration in place so callers can initialize
+  // stderr logging early and attach OTEL later once config has loaded.
+  pub fn initialize_with_config(config: &LogConfig) -> anyhow::Result<()> {
+    Self::configure(config)
+  }
 
-    let (filter, reload_handle) = tracing_subscriber::reload::Layer::new(filter);
-    *Self::get().handle.lock().unwrap() = Some(reload_handle);
+  // Install the logger once, or reload the active configuration if it is already installed.
+  pub fn configure(config: &LogConfig) -> anyhow::Result<()> {
+    if Self::get().state.lock().unwrap().reload_filter.is_some() {
+      Self::reload_config(config)
+    } else {
+      Self::install(config)
+    }
+  }
+
+  fn install(config: &LogConfig) -> anyhow::Result<()> {
+    let direct_otel_enabled = direct_otel_output_enabled(config);
+    let (filter, reload_handle) = tracing_subscriber::reload::Layer::new(EnvFilter::new(
+      otel::global_filter_rules(&config.log_filter, direct_otel_enabled),
+    ));
+    let (layers, otel_provider) = build_registry_layers(config)?;
+    let (layers, layers_handle) = tracing_subscriber::reload::Layer::new(layers);
 
     Registry::default()
-      .with(filter)
+      .with(layers)
       .with(ErrorLayer::default())
-      .with(stderr)
-      .init();
+      .with(filter)
+      .try_init()?;
+
+    {
+      let mut state = Self::get().state.lock().unwrap();
+      state.reload_filter = Some(Box::new(move |filter| {
+        reload_handle.reload(filter)?;
+        Ok(())
+      }));
+      state.reload_layers = Some(Box::new(move |layers| {
+        layers_handle.reload(layers)?;
+        Ok(())
+      }));
+      state.otel_provider = otel_provider;
+      state.direct_otel_enabled = direct_otel_enabled;
+    }
+
+    Self::update_log_max_level(&config.log_filter);
+
+    Ok(())
+  }
+
+  fn reload_config(config: &LogConfig) -> anyhow::Result<()> {
+    let direct_otel_enabled = direct_otel_output_enabled(config);
+    let (layers, new_otel_provider) = build_registry_layers(config)?;
+    let filter = EnvFilter::new(otel::global_filter_rules(
+      &config.log_filter,
+      direct_otel_enabled,
+    ));
+
+    let old_otel_provider = {
+      let mut state = Self::get().state.lock().unwrap();
+      state
+        .reload_layers
+        .as_mut()
+        .ok_or_else(|| anyhow!("logger has not been initialized"))?(layers)?;
+      state
+        .reload_filter
+        .as_mut()
+        .ok_or_else(|| anyhow!("logger has not been initialized"))?(filter)?;
+
+      state.direct_otel_enabled = direct_otel_enabled;
+      std::mem::replace(&mut state.otel_provider, new_otel_provider)
+    };
+
+    Self::update_log_max_level(&config.log_filter);
+
+    if let Some(provider) = old_otel_provider {
+      provider.shutdown()?;
+    }
+
+    Ok(())
   }
 
   // Swap in a new logger with the provided RUST_LOG string.
   pub fn swap(new_rust_log: &str) -> anyhow::Result<()> {
-    Self::get()
-      .handle
-      .lock()
-      .unwrap()
-      .as_mut()
-      .unwrap()
-      .reload(new_rust_log)?;
-
-    // During init the log level is set based on the initial RUST_LOG value. We need to manually
-    // update it each time we reload the config as tracing_subscriber does not do this for us.
-    log::set_max_level(tracing_log::AsLog::as_log(
-      &tracing_subscriber::filter::LevelFilter::current(),
+    let mut state = Self::get().state.lock().unwrap();
+    let filter = EnvFilter::new(otel::global_filter_rules(
+      new_rust_log,
+      state.direct_otel_enabled,
     ));
+    state
+      .reload_filter
+      .as_mut()
+      .ok_or_else(|| anyhow!("logger has not been initialized"))?(filter)?;
+
+    Self::update_log_max_level(new_rust_log);
 
     Ok(())
+  }
+
+  // Flush and stop the OTEL exporter if one was installed.
+  pub fn shutdown() -> anyhow::Result<()> {
+    let provider = {
+      let mut state = Self::get().state.lock().unwrap();
+      state.otel_provider.take()
+    };
+
+    if let Some(provider) = provider {
+      provider.shutdown()?;
+    }
+
+    Ok(())
+  }
+
+  fn update_log_max_level(filter_rules: &str) {
+    let filter = EnvFilter::new(filter_rules);
+    let max_level = filter.max_level_hint().unwrap_or(LevelFilter::TRACE);
+    log::set_max_level(tracing_log::AsLog::as_log(&max_level));
+  }
+}
+
+#[must_use]
+pub fn direct_otel_span_debug_enabled() -> bool {
+  std::env::var_os(DEBUG_DIRECT_OTEL_SPANS_ENV).is_some()
+}
+
+fn direct_otel_output_enabled(config: &LogConfig) -> bool {
+  config.otel.is_some() || direct_otel_span_debug_enabled()
+}
+
+fn build_registry_layers(
+  config: &LogConfig,
+) -> anyhow::Result<(Vec<RegistryLayer>, Option<SdkTracerProvider>)> {
+  let mut layers = vec![build_output_layer(config)];
+  if direct_otel_span_debug_enabled() {
+    layers.push(build_direct_otel_debug_layer(config));
+  }
+  let otel_provider = match config.otel.as_ref() {
+    Some(otel_config) => {
+      let (layer, provider) = otel::build_otel_layer(otel_config)?;
+      layers.push(layer);
+      Some(provider)
+    },
+    None => None,
+  };
+
+  Ok((layers, otel_provider))
+}
+
+fn build_direct_otel_debug_layer(config: &LogConfig) -> RegistryLayer {
+  match config.output {
+    LogOutput::Stdout => tracing_subscriber::fmt::layer()
+      // This debug layer intentionally reuses the compact human-readable format, but it must not
+      // reuse the normal layer's `DefaultFields` storage or close events will print duplicated
+      // span attributes when both fmt layers observe the same OTEL-targeted span.
+      .fmt_fields(DirectOtelDebugFields::default())
+      .with_writer(std::io::stdout)
+      .with_ansi(config.ansi)
+      .with_line_number(true)
+      .with_thread_ids(true)
+      .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+      .compact()
+      .with_filter(filter_fn(otel::is_direct_otel_target))
+      .boxed(),
+    LogOutput::Stderr => tracing_subscriber::fmt::layer()
+      // Keep the debug-only span view isolated from the ordinary output layer for the same reason
+      // as the stdout path above: separate cached field storage avoids duplicated attributes in the
+      // synthesized `new`/`close` events.
+      .fmt_fields(DirectOtelDebugFields::default())
+      .with_writer(std::io::stderr)
+      .with_ansi(config.ansi)
+      .with_line_number(true)
+      .with_thread_ids(true)
+      .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+      .compact()
+      .with_filter(filter_fn(otel::is_direct_otel_target))
+      .boxed(),
+  }
+}
+
+fn build_output_layer(config: &LogConfig) -> RegistryLayer {
+  let exclude_direct_otel = config
+    .otel
+    .as_ref()
+    .is_some_and(|otel| !otel.mirror_to_output);
+
+  match (config.output, exclude_direct_otel) {
+    (LogOutput::Stdout, true) => tracing_subscriber::fmt::layer()
+      .with_writer(std::io::stdout)
+      .with_ansi(config.ansi)
+      .with_line_number(true)
+      .with_thread_ids(true)
+      .compact()
+      .with_filter(filter_fn(otel::is_not_direct_otel_target))
+      .boxed(),
+    (LogOutput::Stdout, false) => tracing_subscriber::fmt::layer()
+      .with_writer(std::io::stdout)
+      .with_ansi(config.ansi)
+      .with_line_number(true)
+      .with_thread_ids(true)
+      .compact()
+      .boxed(),
+    (LogOutput::Stderr, true) => tracing_subscriber::fmt::layer()
+      .with_writer(std::io::stderr)
+      .with_ansi(config.ansi)
+      .with_line_number(true)
+      .with_thread_ids(true)
+      .compact()
+      .with_filter(filter_fn(otel::is_not_direct_otel_target))
+      .boxed(),
+    (LogOutput::Stderr, false) => tracing_subscriber::fmt::layer()
+      .with_writer(std::io::stderr)
+      .with_ansi(config.ansi)
+      .with_line_number(true)
+      .with_thread_ids(true)
+      .compact()
+      .boxed(),
   }
 }

--- a/bd-log/src/lib_test.rs
+++ b/bd-log/src/lib_test.rs
@@ -1,0 +1,277 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use crate::{DEBUG_DIRECT_OTEL_SPANS_ENV, LogConfig, LogOutput, OTEL_TARGET, otel};
+use std::collections::BTreeMap;
+use std::io;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tracing::span::{Attributes, Id};
+use tracing::{Event, Subscriber, field};
+use tracing_subscriber::filter::filter_fn;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::fmt::writer::MakeWriter;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{Layer, Registry};
+
+//
+// TargetCaptureLayer
+//
+
+#[derive(Clone, Default)]
+struct TargetCaptureLayer {
+  spans: Arc<Mutex<Vec<String>>>,
+  events: Arc<Mutex<Vec<String>>>,
+}
+
+impl TargetCaptureLayer {
+  fn recorded_spans(&self) -> Vec<String> {
+    self.spans.lock().unwrap().clone()
+  }
+
+  fn recorded_events(&self) -> Vec<String> {
+    self.events.lock().unwrap().clone()
+  }
+}
+
+impl<S> Layer<S> for TargetCaptureLayer
+where
+  S: Subscriber + for<'span> LookupSpan<'span>,
+{
+  fn on_new_span(&self, attrs: &Attributes<'_>, _: &Id, _: Context<'_, S>) {
+    self
+      .spans
+      .lock()
+      .unwrap()
+      .push(attrs.metadata().target().to_string());
+  }
+
+  fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
+    self
+      .events
+      .lock()
+      .unwrap()
+      .push(event.metadata().target().to_string());
+  }
+}
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Clone, Default)]
+struct CapturedWriter {
+  output: Arc<Mutex<Vec<u8>>>,
+}
+
+impl CapturedWriter {
+  fn contents(&self) -> String {
+    String::from_utf8(self.output.lock().unwrap().clone()).unwrap()
+  }
+}
+
+struct CapturedWriterGuard {
+  output: Arc<Mutex<Vec<u8>>>,
+}
+
+impl io::Write for CapturedWriterGuard {
+  fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    self.output.lock().unwrap().extend_from_slice(buf);
+    Ok(buf.len())
+  }
+
+  fn flush(&mut self) -> io::Result<()> {
+    Ok(())
+  }
+}
+
+impl<'a> MakeWriter<'a> for CapturedWriter {
+  type Writer = CapturedWriterGuard;
+
+  fn make_writer(&'a self) -> Self::Writer {
+    CapturedWriterGuard {
+      output: self.output.clone(),
+    }
+  }
+}
+
+fn with_direct_otel_span_debug_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+  let _guard = ENV_LOCK.lock().unwrap();
+  let previous = std::env::var_os(DEBUG_DIRECT_OTEL_SPANS_ENV);
+
+  // Rust 2024 makes process environment mutation unsafe; serialize it for these tests.
+  unsafe {
+    match value {
+      Some(value) => std::env::set_var(DEBUG_DIRECT_OTEL_SPANS_ENV, value),
+      None => std::env::remove_var(DEBUG_DIRECT_OTEL_SPANS_ENV),
+    }
+  }
+
+  let result = f();
+
+  // Restore the original process environment before releasing the lock.
+  unsafe {
+    match previous {
+      Some(value) => std::env::set_var(DEBUG_DIRECT_OTEL_SPANS_ENV, value),
+      None => std::env::remove_var(DEBUG_DIRECT_OTEL_SPANS_ENV),
+    }
+  }
+
+  result
+}
+
+#[test]
+fn default_log_config_matches_existing_behavior() {
+  with_direct_otel_span_debug_env(None, || {
+    let config = LogConfig::default();
+
+    assert_eq!(config.output, LogOutput::Stderr);
+  });
+}
+
+#[test]
+fn global_filter_rules_force_the_direct_otel_target() {
+  let filter = otel::global_filter_rules("info", true);
+
+  assert_eq!(filter, format!("info,{OTEL_TARGET}=trace"));
+}
+
+#[test]
+fn build_registry_layers_supports_dual_stage_configuration() {
+  with_direct_otel_span_debug_env(None, || {
+    let early_config = LogConfig::default();
+    let (early_layers, early_provider) = crate::build_registry_layers(&early_config).unwrap();
+
+    assert_eq!(early_layers.len(), 1);
+    assert!(early_provider.is_none());
+
+    let later_config = LogConfig {
+      otel: Some(crate::OtelCollectorConfig {
+        endpoint: "http://127.0.0.1:4317".to_string(),
+        protocol: crate::OtelCollectorProtocol::Grpc,
+        service_name: "bd-log-test".to_string(),
+        tracer_name: "bd-log-test".to_string(),
+        headers: BTreeMap::default(),
+        resource_attributes: BTreeMap::default(),
+        timeout: Duration::from_secs(1),
+        mirror_to_output: false,
+        max_attributes_per_span: 16,
+        max_events_per_span: 64,
+      }),
+      ..LogConfig::default()
+    };
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let (later_layers, later_provider) = runtime
+      .block_on(async {
+        let _entered = runtime.handle().enter();
+        crate::build_registry_layers(&later_config)
+      })
+      .unwrap();
+
+    assert_eq!(later_layers.len(), 2);
+    assert!(later_provider.is_some());
+  });
+}
+
+#[test]
+fn build_registry_layers_supports_local_direct_otel_span_debugging() {
+  with_direct_otel_span_debug_env(Some("1"), || {
+    let config = LogConfig::default();
+    let (layers, provider) = crate::build_registry_layers(&config).unwrap();
+
+    assert_eq!(layers.len(), 2);
+    assert!(provider.is_none());
+    assert!(crate::direct_otel_span_debug_enabled());
+  });
+}
+
+#[test]
+fn direct_otel_debug_formatter_does_not_duplicate_close_fields_with_two_fmt_layers() {
+  let output_capture = CapturedWriter::default();
+  let debug_capture = CapturedWriter::default();
+  let subscriber = Registry::default()
+    .with(
+      tracing_subscriber::fmt::layer()
+        .with_writer(output_capture)
+        .with_ansi(false)
+        .with_level(false)
+        .with_target(false)
+        .with_thread_ids(false)
+        .without_time(),
+    )
+    .with(
+      tracing_subscriber::fmt::layer()
+        .fmt_fields(crate::DirectOtelDebugFields::default())
+        .with_writer(debug_capture.clone())
+        .with_ansi(false)
+        .with_level(false)
+        .with_target(false)
+        .with_thread_ids(false)
+        .without_time()
+        .with_span_events(FmtSpan::CLOSE)
+        .compact()
+        .with_filter(filter_fn(otel::is_direct_otel_target)),
+    );
+
+  tracing::subscriber::with_default(subscriber, || {
+    let span = crate::otel_info_span!(
+      "clickhouse.query",
+      clickhouse.retry_count = field::Empty,
+      clickhouse.row_count = field::Empty,
+      clickhouse.duration_ms = field::Empty,
+      otel.status_code = field::Empty,
+    );
+    let _entered = span.enter();
+    span.record("clickhouse.retry_count", 0);
+    span.record("clickhouse.row_count", 0);
+    span.record("clickhouse.duration_ms", 9);
+    span.record("otel.status_code", "OK");
+  });
+
+  let output = debug_capture.contents();
+
+  assert_eq!(output.matches("clickhouse.retry_count=0").count(), 1);
+  assert_eq!(output.matches("clickhouse.row_count=0").count(), 1);
+  assert_eq!(output.matches("clickhouse.duration_ms=9").count(), 1);
+  assert_eq!(output.matches("otel.status_code=\"OK\"").count(), 1);
+}
+
+#[test]
+fn otel_helper_macros_emit_the_direct_target() {
+  let capture = TargetCaptureLayer::default();
+  let subscriber = Registry::default().with(capture.clone());
+
+  tracing::subscriber::with_default(subscriber, || {
+    let span = crate::otel_info_span!("collector_span", otel.kind = "client");
+    let _entered = span.enter();
+
+    crate::otel_info!(message = "collector_event");
+  });
+
+  assert_eq!(capture.recorded_spans(), vec![OTEL_TARGET.to_string()]);
+  assert_eq!(capture.recorded_events(), vec![OTEL_TARGET.to_string()]);
+}
+
+#[test]
+fn otel_instrument_wraps_an_async_future_in_the_direct_target() {
+  let capture = TargetCaptureLayer::default();
+  let subscriber = Registry::default().with(capture.clone());
+  let runtime = tokio::runtime::Runtime::new().unwrap();
+
+  tracing::subscriber::with_default(subscriber, || {
+    runtime.block_on(crate::otel_instrument!(
+      async {
+        crate::otel_info!(message = "inside_future");
+      },
+      tracing::Level::INFO,
+      "collector_future",
+      otel.kind = "internal"
+    ));
+  });
+
+  assert_eq!(capture.recorded_spans(), vec![OTEL_TARGET.to_string()]);
+  assert_eq!(capture.recorded_events(), vec![OTEL_TARGET.to_string()]);
+}

--- a/bd-log/src/otel.rs
+++ b/bd-log/src/otel.rs
@@ -1,0 +1,339 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use crate::{DEFAULT_FILTER_RULES, RegistryLayer};
+use anyhow::anyhow;
+use http::{HeaderMap, HeaderName, HeaderValue};
+use opentelemetry::KeyValue;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::tonic_types::metadata::MetadataMap;
+use opentelemetry_otlp::{
+  Protocol,
+  SpanExporter,
+  WithExportConfig,
+  WithHttpConfig,
+  WithTonicConfig,
+};
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+use std::collections::{BTreeMap, HashMap};
+use std::time::Duration;
+use tracing_subscriber::Layer;
+use tracing_subscriber::filter::filter_fn;
+
+pub const OTEL_TARGET: &str = "bd_log::otel";
+
+//
+// LogOutput
+//
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum LogOutput {
+  Stdout,
+  #[default]
+  Stderr,
+}
+
+//
+// LogConfig
+//
+
+#[derive(Clone, Debug)]
+pub struct LogConfig {
+  pub log_filter: String,
+  pub output: LogOutput,
+  pub ansi: bool,
+  pub otel: Option<OtelCollectorConfig>,
+}
+
+impl Default for LogConfig {
+  fn default() -> Self {
+    Self {
+      log_filter: std::env::var("RUST_LOG").unwrap_or_else(|_| DEFAULT_FILTER_RULES.to_string()),
+      output: LogOutput::Stderr,
+      ansi: std::env::var("BD_LOG_ANSI").is_ok(),
+      otel: None,
+    }
+  }
+}
+
+//
+// OtelCollectorProtocol
+//
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum OtelCollectorProtocol {
+  #[default]
+  Grpc,
+  HttpBinary,
+  HttpJson,
+}
+
+impl OtelCollectorProtocol {
+  fn export_protocol(self) -> Protocol {
+    match self {
+      Self::Grpc => Protocol::Grpc,
+      Self::HttpBinary => Protocol::HttpBinary,
+      Self::HttpJson => Protocol::HttpJson,
+    }
+  }
+}
+
+//
+// OtelCollectorConfig
+//
+
+#[derive(Clone, Debug)]
+pub struct OtelCollectorConfig {
+  pub endpoint: String,
+  pub protocol: OtelCollectorProtocol,
+  pub service_name: String,
+  pub tracer_name: String,
+  pub headers: BTreeMap<String, String>,
+  pub resource_attributes: BTreeMap<String, String>,
+  pub timeout: Duration,
+  pub mirror_to_output: bool,
+  pub max_attributes_per_span: u32,
+  pub max_events_per_span: u32,
+}
+
+impl OtelCollectorConfig {
+  pub fn new(service_name: impl Into<String>, endpoint: impl Into<String>) -> Self {
+    let service_name = service_name.into();
+
+    Self {
+      endpoint: endpoint.into(),
+      protocol: OtelCollectorProtocol::Grpc,
+      tracer_name: service_name.clone(),
+      service_name,
+      headers: BTreeMap::new(),
+      resource_attributes: BTreeMap::new(),
+      timeout: Duration::from_secs(3),
+      mirror_to_output: false,
+      max_attributes_per_span: 16,
+      max_events_per_span: 64,
+    }
+  }
+}
+
+pub(crate) fn is_direct_otel_target(metadata: &tracing::Metadata<'_>) -> bool {
+  metadata.target() == OTEL_TARGET
+}
+
+pub(crate) fn is_not_direct_otel_target(metadata: &tracing::Metadata<'_>) -> bool {
+  !is_direct_otel_target(metadata)
+}
+
+pub(crate) fn global_filter_rules(base_rules: &str, enable_direct_otel: bool) -> String {
+  if !enable_direct_otel {
+    return base_rules.to_string();
+  }
+
+  if base_rules.is_empty() {
+    format!("{OTEL_TARGET}=trace")
+  } else {
+    // Force the dedicated OTEL target through the global gate so it reaches the collector even
+    // when the ordinary log filter is narrower.
+    format!("{base_rules},{OTEL_TARGET}=trace")
+  }
+}
+
+pub(crate) fn build_otel_layer(
+  config: &OtelCollectorConfig,
+) -> anyhow::Result<(RegistryLayer, SdkTracerProvider)> {
+  let exporter = build_span_exporter(config)?;
+  let provider = SdkTracerProvider::builder()
+    .with_batch_exporter(exporter)
+    .with_sampler(Sampler::AlwaysOn)
+    .with_max_attributes_per_span(config.max_attributes_per_span)
+    .with_max_events_per_span(config.max_events_per_span)
+    .with_resource(build_resource(config))
+    .build();
+  let tracer = provider.tracer(config.tracer_name.clone());
+
+  let layer = tracing_opentelemetry::layer()
+    .with_tracer(tracer)
+    .with_level(true)
+    .with_filter(filter_fn(is_direct_otel_target))
+    .boxed();
+
+  Ok((layer, provider))
+}
+
+fn build_span_exporter(config: &OtelCollectorConfig) -> anyhow::Result<SpanExporter> {
+  match config.protocol {
+    OtelCollectorProtocol::Grpc => {
+      let mut builder = SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(config.endpoint.clone())
+        .with_timeout(config.timeout);
+
+      if !config.headers.is_empty() {
+        builder = builder.with_metadata(build_tonic_metadata(&config.headers)?);
+      }
+
+      builder.build().map_err(Into::into)
+    },
+    OtelCollectorProtocol::HttpBinary | OtelCollectorProtocol::HttpJson => SpanExporter::builder()
+      .with_http()
+      .with_protocol(config.protocol.export_protocol())
+      .with_endpoint(config.endpoint.clone())
+      .with_timeout(config.timeout)
+      .with_headers(
+        config
+          .headers
+          .clone()
+          .into_iter()
+          .collect::<HashMap<_, _>>(),
+      )
+      .build()
+      .map_err(Into::into),
+  }
+}
+
+fn build_resource(config: &OtelCollectorConfig) -> Resource {
+  let mut attributes = Vec::with_capacity(config.resource_attributes.len() + 1);
+  attributes.push(KeyValue::new("service.name", config.service_name.clone()));
+  attributes.extend(
+    config
+      .resource_attributes
+      .iter()
+      .map(|(key, value)| KeyValue::new(key.clone(), value.clone())),
+  );
+
+  Resource::builder_empty()
+    .with_attributes(attributes)
+    .build()
+}
+
+fn build_tonic_metadata(headers: &BTreeMap<String, String>) -> anyhow::Result<MetadataMap> {
+  let mut header_map = HeaderMap::with_capacity(headers.len());
+
+  for (key, value) in headers {
+    let header_name = HeaderName::from_bytes(key.as_bytes())
+      .map_err(|error| anyhow!("invalid OTEL header name {key}: {error}"))?;
+    let header_value = HeaderValue::from_str(value)
+      .map_err(|error| anyhow!("invalid OTEL header value for {key}: {error}"))?;
+    header_map.insert(header_name, header_value);
+  }
+
+  Ok(MetadataMap::from_headers(header_map))
+}
+
+#[macro_export]
+macro_rules! otel_span {
+  ($level:expr, $name:expr) => {
+    tracing::span!(target: $crate::OTEL_TARGET, $level, $name)
+  };
+  ($level:expr, $name:expr, $($fields:tt)*) => {
+    tracing::span!(target: $crate::OTEL_TARGET, $level, $name, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_trace_span {
+  ($name:expr) => {
+    $crate::otel_span!(tracing::Level::TRACE, $name)
+  };
+  ($name:expr, $($fields:tt)*) => {
+    $crate::otel_span!(tracing::Level::TRACE, $name, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_debug_span {
+  ($name:expr) => {
+    $crate::otel_span!(tracing::Level::DEBUG, $name)
+  };
+  ($name:expr, $($fields:tt)*) => {
+    $crate::otel_span!(tracing::Level::DEBUG, $name, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_info_span {
+  ($name:expr) => {
+    $crate::otel_span!(tracing::Level::INFO, $name)
+  };
+  ($name:expr, $($fields:tt)*) => {
+    $crate::otel_span!(tracing::Level::INFO, $name, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_warn_span {
+  ($name:expr) => {
+    $crate::otel_span!(tracing::Level::WARN, $name)
+  };
+  ($name:expr, $($fields:tt)*) => {
+    $crate::otel_span!(tracing::Level::WARN, $name, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_error_span {
+  ($name:expr) => {
+    $crate::otel_span!(tracing::Level::ERROR, $name)
+  };
+  ($name:expr, $($fields:tt)*) => {
+    $crate::otel_span!(tracing::Level::ERROR, $name, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_event {
+  ($level:expr, $($fields:tt)*) => {
+    tracing::event!(target: $crate::OTEL_TARGET, $level, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_trace {
+  ($($fields:tt)*) => {
+    $crate::otel_event!(tracing::Level::TRACE, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_debug {
+  ($($fields:tt)*) => {
+    $crate::otel_event!(tracing::Level::DEBUG, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_info {
+  ($($fields:tt)*) => {
+    $crate::otel_event!(tracing::Level::INFO, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_warn {
+  ($($fields:tt)*) => {
+    $crate::otel_event!(tracing::Level::WARN, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_error {
+  ($($fields:tt)*) => {
+    $crate::otel_event!(tracing::Level::ERROR, $($fields)*)
+  };
+}
+
+#[macro_export]
+macro_rules! otel_instrument {
+  ($future:expr, $level:expr, $name:expr) => {{
+    use tracing::Instrument as _;
+    ($future).instrument($crate::otel_span!($level, $name))
+  }};
+  ($future:expr, $level:expr, $name:expr, $($fields:tt)*) => {{
+    use tracing::Instrument as _;
+    ($future).instrument($crate::otel_span!($level, $name, $($fields)*))
+  }};
+}

--- a/bd-workflows/Cargo.toml
+++ b/bd-workflows/Cargo.toml
@@ -57,7 +57,7 @@ tempfile.workspace          = true
 tokio-test.workspace        = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-gungraun  = { version = "0.17.2", features = ["client_requests"] }
+gungraun  = { version = "0.18.1", features = ["client_requests"] }
 simplelog = "0.12.2"
 
 [[bench]]

--- a/bd-workspace-hack/Cargo.toml
+++ b/bd-workspace-hack/Cargo.toml
@@ -25,8 +25,6 @@ clap_builder = { version = "4", default-features = false, features = ["color", "
 either = { version = "1", features = ["use_std"] }
 flate2 = { version = "1", features = ["zlib", "zlib-ng"] }
 futures-channel = { version = "0.3", features = ["sink"] }
-futures-executor = { version = "0.3" }
-futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
@@ -45,12 +43,13 @@ rustls-webpki = { version = "0.103", default-features = false, features = ["aws-
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1", features = ["alloc", "rc"] }
 serde_json = { version = "1", features = ["alloc", "raw_value"] }
-slab = { version = "0.4" }
 smallvec = { version = "1", default-features = false, features = ["const_new"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+thiserror = { version = "2" }
 tokio = { version = "1", features = ["full", "test-util"] }
+tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7", features = ["codec", "io", "time"] }
-tower = { version = "0.5", default-features = false, features = ["log", "make", "retry"] }
+tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "log", "retry"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
 
@@ -62,8 +61,6 @@ clap_builder = { version = "4", default-features = false, features = ["color", "
 either = { version = "1", features = ["use_std"] }
 flate2 = { version = "1", features = ["zlib", "zlib-ng"] }
 futures-channel = { version = "0.3", features = ["sink"] }
-futures-executor = { version = "0.3" }
-futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
@@ -83,14 +80,15 @@ rustls-webpki = { version = "0.103", default-features = false, features = ["aws-
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_core = { version = "1", features = ["alloc", "rc"] }
 serde_json = { version = "1", features = ["alloc", "raw_value"] }
-slab = { version = "0.4" }
 smallvec = { version = "1", default-features = false, features = ["const_new"] }
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
+thiserror = { version = "2" }
 tokio = { version = "1", features = ["full", "test-util"] }
+tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7", features = ["codec", "io", "time"] }
 toml_parser = { version = "1" }
-tower = { version = "0.5", default-features = false, features = ["log", "make", "retry"] }
+tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "log", "retry"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
 winnow = { version = "1" }

--- a/logger-cli/src/bin/mcp.rs
+++ b/logger-cli/src/bin/mcp.rs
@@ -89,6 +89,10 @@ struct SetFeatureFlagParameters {
 }
 
 struct Tool {
+  #[expect(
+    dead_code,
+    reason = "Stored for tool_router macro-generated registrations"
+  )]
   tool_router: ToolRouter<Self>,
 
   host: String,


### PR DESCRIPTION
## Summary
- add OTEL collector configuration and direct-OTEL helper macros to `bd-log`
- refactor logger initialization so local output can start early and OTEL can be attached or reloaded later
- add local debug rendering for direct OTEL spans, including the fix for duplicated debug attributes and regression coverage
- update shared workspace dependency plumbing needed for the new logging stack