### PR TITLE
[Battery Level Change] Allow window configuration

### DIFF
--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -381,9 +381,10 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
       Arc::new(SystemTimeProvider),
       log_network_quality_monitor,
     ));
-    let battery_drain_tracker = Arc::new(battery::BatteryDrainTracker::new(Arc::new(
-      SystemTimeProvider,
-    )));
+    let battery_drain_tracker = Arc::new(battery::BatteryDrainTracker::new(
+      Arc::new(SystemTimeProvider),
+      runtime_loader,
+    ));
     let network_quality_interceptor =
       Arc::new(NetworkQualityInterceptor::new(network_quality_resolver));
     let device_id_interceptor = Arc::new(DeviceIdInterceptor::new(device_id));

--- a/bd-logger/src/battery.rs
+++ b/bd-logger/src/battery.rs
@@ -19,23 +19,37 @@ use bd_log_primitives::{
   LogMessage,
 };
 use bd_proto::protos::logging::payload::LogType;
+use bd_runtime::runtime::resource_utilization::BatteryLevelChangeWindowFlag;
+use bd_runtime::runtime::{ConfigLoader, Watch};
 use std::collections::VecDeque;
 use std::sync::Arc;
-use time::ext::NumericalDuration;
 
 //
 // BatteryDrainTracker
 //
 
 /// Tracks battery level changes over time by monitoring battery level changes in RESOURCE logs.
-/// Calculates the percentage point change per minute and adds it to resource logs.
+/// Calculates the percentage point change over a configurable window and adds it to resource logs.
 pub struct BatteryDrainTracker {
+  battery_level_change_window: Watch<time::Duration, BatteryLevelChangeWindowFlag>,
   container: parking_lot::Mutex<BatteryMetricsContainer>,
 }
 
 impl BatteryDrainTracker {
-  pub fn new(time_provider: Arc<dyn TimeProvider>) -> Self {
+  pub fn new(time_provider: Arc<dyn TimeProvider>, runtime: &ConfigLoader) -> Self {
     Self {
+      battery_level_change_window: runtime.register_duration_watch(),
+      container: parking_lot::Mutex::new(BatteryMetricsContainer::new(time_provider)),
+    }
+  }
+
+  #[cfg(test)]
+  fn new_with_window(
+    time_provider: Arc<dyn TimeProvider>,
+    battery_level_change_window: time::Duration,
+  ) -> Self {
+    Self {
+      battery_level_change_window: Watch::new_for_testing(battery_level_change_window),
       container: parking_lot::Mutex::new(BatteryMetricsContainer::new(time_provider)),
     }
   }
@@ -44,6 +58,7 @@ impl BatteryDrainTracker {
 impl BatteryDrainTracker {
   fn process_resource_log(&self, fields: &mut AnnotatedLogFields) {
     let battery_level = get_field_as_i32(fields, "_battery_level");
+    let battery_level_change_window = *self.battery_level_change_window.read();
 
     let mut guard = self.container.lock();
 
@@ -51,10 +66,10 @@ impl BatteryDrainTracker {
       guard.add_sample(battery_level);
     }
 
-    if let Some(drain_rate) = guard.get_level_change_per_minute() {
+    if let Some(battery_level_change) = guard.get_level_change(battery_level_change_window) {
       fields.insert(
-        "_battery_level_change_per_min".into(),
-        AnnotatedLogField::new_ootb(format!("{drain_rate:.4}")),
+        "_battery_level_change".into(),
+        AnnotatedLogField::new_ootb(format!("{battery_level_change:.4}")),
       );
     }
   }
@@ -103,14 +118,14 @@ impl BatteryMetricsContainer {
     });
   }
 
-  fn get_level_change_per_minute(&mut self) -> Option<f64> {
+  fn get_level_change(&mut self, battery_level_change_window: time::Duration) -> Option<f64> {
     let now = self.time_provider.now();
     let count_before = self.samples.len();
 
     while self
       .samples
       .front()
-      .is_some_and(|sample| now.duration_since(sample.timestamp) > 1.minutes())
+      .is_some_and(|sample| now.duration_since(sample.timestamp) > battery_level_change_window)
     {
       self.samples.pop_front();
     }

--- a/bd-logger/src/battery_test.rs
+++ b/bd-logger/src/battery_test.rs
@@ -20,6 +20,7 @@ use bd_proto::protos::logging::payload::LogType;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use time::ext::NumericalDuration;
 
 struct MockTimeProvider {
   now: Mutex<Instant>,
@@ -65,7 +66,7 @@ fn process_resource_log(tracker: &BatteryDrainTracker, fields: &mut AnnotatedLog
 
 fn get_drain_rate(fields: &AnnotatedLogFields) -> Option<f64> {
   fields
-    .get("_battery_level_change_per_min")
+    .get("_battery_level_change")
     .and_then(|f| match &f.value {
       bd_log_primitives::DataValue::String(s) => s.parse().ok(),
       _ => None,
@@ -75,114 +76,153 @@ fn get_drain_rate(fields: &AnnotatedLogFields) -> Option<f64> {
 #[test]
 fn does_not_report_before_window_is_full() {
   let time_provider = Arc::new(MockTimeProvider::new());
-  let tracker = BatteryDrainTracker::new(time_provider.clone());
+  let tracker = BatteryDrainTracker::new_with_window(time_provider.clone(), 1.minutes());
 
-  let mut fields = create_resource_log_fields(100);
-  process_resource_log(&tracker, &mut fields);
-  assert!(get_drain_rate(&fields).is_none());
+  assert!(process_battery_level(&tracker, 100).is_none());
 
   // 30s later — still under 1 minute.
-  time_provider.advance(Duration::from_secs(30));
-  let mut fields = create_resource_log_fields(99);
-  process_resource_log(&tracker, &mut fields);
-  assert!(get_drain_rate(&fields).is_none());
+  assert!(
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(30), 99)
+      .is_none()
+  );
 
   // 59s total — still under 1 minute.
-  time_provider.advance(Duration::from_secs(29));
-  let mut fields = create_resource_log_fields(98);
-  process_resource_log(&tracker, &mut fields);
-  assert!(get_drain_rate(&fields).is_none());
+  assert!(
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(29), 98)
+      .is_none()
+  );
 }
 
 #[test]
 fn reports_once_window_is_full() {
   let time_provider = Arc::new(MockTimeProvider::new());
-  let tracker = BatteryDrainTracker::new(time_provider.clone());
+  let tracker = BatteryDrainTracker::new_with_window(time_provider.clone(), 1.minutes());
 
-  let mut fields = create_resource_log_fields(100);
-  process_resource_log(&tracker, &mut fields);
+  process_battery_level(&tracker, 100);
 
-  time_provider.advance(Duration::from_secs(30));
-  let mut fields = create_resource_log_fields(99);
-  process_resource_log(&tracker, &mut fields);
+  advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(30), 99);
 
   // Cross the 1-minute boundary — first sample gets pruned.
-  time_provider.advance(Duration::from_secs(31));
-  let mut fields = create_resource_log_fields(98);
-  process_resource_log(&tracker, &mut fields);
+  let drain =
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(31), 98)
+      .unwrap();
 
   // Oldest remaining is 99, newest is 98 → delta = 1.
-  let drain = get_drain_rate(&fields).unwrap();
   assert!((drain - 1.0).abs() < 0.01);
+}
+
+#[test]
+fn does_not_report_before_two_minute_window_is_full() {
+  let time_provider = Arc::new(MockTimeProvider::new());
+  let tracker = BatteryDrainTracker::new_with_window(time_provider.clone(), 2.minutes());
+
+  assert!(process_battery_level(&tracker, 100).is_none());
+
+  assert!(
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(90), 97)
+      .is_none()
+  );
+
+  assert!(
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(29), 95)
+      .is_none()
+  );
+}
+
+#[test]
+fn reports_once_two_minute_window_is_full() {
+  let time_provider = Arc::new(MockTimeProvider::new());
+  let tracker = BatteryDrainTracker::new_with_window(time_provider.clone(), 2.minutes());
+
+  process_battery_level(&tracker, 100);
+
+  assert!(
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(70), 96)
+      .is_none()
+  );
+
+  let drain =
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(51), 92)
+      .unwrap();
+  assert!((drain - 4.0).abs() < 0.01);
+}
+
+#[test]
+fn five_minute_window_keeps_older_samples_longer() {
+  let time_provider = Arc::new(MockTimeProvider::new());
+  let tracker = BatteryDrainTracker::new_with_window(time_provider.clone(), 5.minutes());
+
+  process_battery_level(&tracker, 100);
+
+  assert!(
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(150), 94)
+      .is_none()
+  );
+
+  let drain =
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(151), 90)
+      .unwrap();
+  assert!((drain - 4.0).abs() < 0.01);
 }
 
 #[test]
 fn reports_negative_change_when_charging() {
   let time_provider = Arc::new(MockTimeProvider::new());
-  let tracker = BatteryDrainTracker::new(time_provider.clone());
+  let tracker = BatteryDrainTracker::new_with_window(time_provider.clone(), 1.minutes());
 
-  let mut fields = create_resource_log_fields(50);
-  process_resource_log(&tracker, &mut fields);
+  process_battery_level(&tracker, 50);
 
-  time_provider.advance(Duration::from_secs(30));
-  let mut fields = create_resource_log_fields(51);
-  process_resource_log(&tracker, &mut fields);
+  advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(30), 51);
 
-  time_provider.advance(Duration::from_secs(31));
-  let mut fields = create_resource_log_fields(52);
-  process_resource_log(&tracker, &mut fields);
+  let drain =
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(31), 52)
+      .unwrap();
 
   // Oldest remaining is 51, newest is 52 → delta = -1.
-  let drain = get_drain_rate(&fields).unwrap();
   assert!((drain - (-1.0)).abs() < 0.01);
 }
 
 #[test]
 fn large_jump_settles_after_window_rolls_over() {
   let time_provider = Arc::new(MockTimeProvider::new());
-  let tracker = BatteryDrainTracker::new(time_provider.clone());
+  let tracker = BatteryDrainTracker::new_with_window(time_provider.clone(), 1.minutes());
 
   // Build up samples at 100 for >1 minute so window becomes full.
   // First sample at t=6s, last at t=66s (11 samples).
   for _ in 0 .. 11 {
     time_provider.advance(Duration::from_secs(6));
-    let mut fields = create_resource_log_fields(100);
-    process_resource_log(&tracker, &mut fields);
+    process_battery_level(&tracker, 100);
   }
 
   // t=72s — first sample (t=6s) is now 66s old and gets pruned.
-  time_provider.advance(Duration::from_secs(6));
-  let mut fields = create_resource_log_fields(100);
-  process_resource_log(&tracker, &mut fields);
-  let drain = get_drain_rate(&fields).unwrap();
+  let drain =
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(6), 100)
+      .unwrap();
   assert!(drain.abs() < 0.01);
 
   // Jump to 20 on next tick (t=78s).
-  time_provider.advance(Duration::from_secs(6));
-  let mut fields = create_resource_log_fields(20);
-  process_resource_log(&tracker, &mut fields);
+  let drain =
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(6), 20)
+      .unwrap();
   // Oldest remaining is 100, newest is 20 → delta = 80.
-  let drain = get_drain_rate(&fields).unwrap();
   assert!((drain - 80.0).abs() < 0.01);
 
   // After the window fully rolls over with samples at 20, rate settles to 0.
   for _ in 0 .. 11 {
     time_provider.advance(Duration::from_secs(6));
-    let mut fields = create_resource_log_fields(20);
-    process_resource_log(&tracker, &mut fields);
+    process_battery_level(&tracker, 20);
   }
 
-  time_provider.advance(Duration::from_secs(6));
-  let mut fields = create_resource_log_fields(20);
-  process_resource_log(&tracker, &mut fields);
-  let drain = get_drain_rate(&fields).unwrap();
+  let drain =
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(6), 20)
+      .unwrap();
   assert!(drain.abs() < 0.01, "expected ~0, got {drain:.4}");
 }
 
 #[test]
 fn ignores_non_resource_logs() {
   let time_provider = Arc::new(MockTimeProvider::new());
-  let tracker = BatteryDrainTracker::new(time_provider);
+  let tracker = BatteryDrainTracker::new_with_window(time_provider, 1.minutes());
 
   let mut fields = create_resource_log_fields(75);
 
@@ -200,7 +240,7 @@ fn ignores_non_resource_logs() {
 #[test]
 fn handles_missing_battery_fields() {
   let time_provider = Arc::new(MockTimeProvider::new());
-  let tracker = BatteryDrainTracker::new(time_provider.clone());
+  let tracker = BatteryDrainTracker::new_with_window(time_provider.clone(), 1.minutes());
 
   let mut fields = AnnotatedLogFields::new();
   process_resource_log(&tracker, &mut fields);
@@ -216,22 +256,36 @@ fn handles_missing_battery_fields() {
 #[test]
 fn steady_drain_reports_correct_rate() {
   let time_provider = Arc::new(MockTimeProvider::new());
-  let tracker = BatteryDrainTracker::new(time_provider.clone());
+  let tracker = BatteryDrainTracker::new_with_window(time_provider.clone(), 1.minutes());
 
   // 1 point every 6 seconds for 66 seconds (11 ticks).
   for i in 0 .. 11 {
     time_provider.advance(Duration::from_secs(6));
-    let mut fields = create_resource_log_fields(100 - i);
-    process_resource_log(&tracker, &mut fields);
+    process_battery_level(&tracker, 100 - i);
   }
 
   // Cross the 1-minute mark.
-  time_provider.advance(Duration::from_secs(6));
-  let mut fields = create_resource_log_fields(89);
-  process_resource_log(&tracker, &mut fields);
+  let drain =
+    advance_and_process_battery_level(&time_provider, &tracker, Duration::from_secs(6), 89)
+      .unwrap();
 
   // Window spans ~60s of data, first sample (100) was pruned.
   // Oldest remaining is 99, newest is 89 → delta = 10.
-  let drain = get_drain_rate(&fields).unwrap();
   assert!((drain - 10.0).abs() < 0.5);
+}
+
+fn process_battery_level(tracker: &BatteryDrainTracker, battery_level: i32) -> Option<f64> {
+  let mut fields = create_resource_log_fields(battery_level);
+  process_resource_log(tracker, &mut fields);
+  get_drain_rate(&fields)
+}
+
+fn advance_and_process_battery_level(
+  time_provider: &MockTimeProvider,
+  tracker: &BatteryDrainTracker,
+  duration: Duration,
+  battery_level: i32,
+) -> Option<f64> {
+  time_provider.advance(duration);
+  process_battery_level(tracker, battery_level)
 }

--- a/bd-runtime/src/runtime.rs
+++ b/bd-runtime/src/runtime.rs
@@ -795,6 +795,12 @@ pub mod resource_utilization {
     "resource_utilization.reporting_interval_ms",
     6.seconds()
   );
+
+  duration_feature_flag!(
+    BatteryLevelChangeWindowFlag,
+    "resource_utilization.battery_level_change_window_ms",
+    1.minutes()
+  );
 }
 
 pub mod session_replay {


### PR DESCRIPTION
## What

Part of BIT-7976

- Updating the `Battery Level Change` window to be configurable (now it's hardcoded to 1 minute)
- Keep window default as 1 minute

## Verification

Verified with emulator session

## Follow-up

Frontend will be updated to handle the new field name