### PR TITLE
Fix bd-proto all-features build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build
 build: setup
-  SKIP_PROTO_GEN=1 cargo build --workspace
+	SKIP_PROTO_GEN=1 cargo build --workspace
+	# `bd-proto` has feature-gated generated module trees that the workspace build does not exercise.
+	SKIP_PROTO_GEN=1 cargo build -p bd-proto --all-features
 
 .PHONY: setup
 setup:

--- a/bd-proto/src/protos/public_api/explorations/mod.rs
+++ b/bd-proto/src/protos/public_api/explorations/mod.rs
@@ -8,4 +8,4 @@
 pub mod api;
 
 // Re-export proto dependencies referenced by generated code in this subdirectory.
-pub use super::{chart_metadata, common, validate, workflow};
+pub use super::{chart_metadata, common, time_series, validate, workflow};

--- a/bd-proto/src/protos/public_api_with_source/explorations/mod.rs
+++ b/bd-proto/src/protos/public_api_with_source/explorations/mod.rs
@@ -8,4 +8,4 @@
 pub mod api;
 
 // Re-export proto dependencies referenced by generated code in this subdirectory.
-pub use super::{chart_metadata, common, validate, workflow};
+pub use super::{chart_metadata, common, time_series, validate, workflow};


### PR DESCRIPTION
- add the missing time_series re-exports for the public API explorations modules so bd-proto builds with public-api and with-source-info enabled
- make build also compile bd-proto --all-features so feature-only generated-module breakages are caught earlier