### PR TITLE
Fix incorrect background state for AppExits

### DIFF
--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -266,7 +266,7 @@ impl Monitor {
     ]);
 
     if let Some(running_state) = report.app_metrics().and_then(|app| app.running_state()) {
-      let is_foreground = running_state.starts_with("foreground");
+      let is_foreground = running_state == "foreground";
       fields.insert(
         "foreground".into(),
         if is_foreground { "1" } else { "0" }.into(),

--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -265,20 +265,24 @@ impl Monitor {
       ),
     ]);
 
-    if let Some(running_state) = report.app_metrics().and_then(|app| app.running_state()) {
-      let is_foreground = running_state == "foreground";
-      fields.insert(
-        "foreground".into(),
-        if is_foreground { "1" } else { "0" }.into(),
-      );
-    }
-
     if let Some(app_id) = app_id {
       fields.insert("app_id".into(), app_id.into());
     }
 
     match platform {
       Platform::Android => {
+        // Override foreground field using running_state from the FBS report when available.
+        // On Android, running_state maps to ActivityManager.RunningAppProcessInfo importance:
+        // https://developer.android.com/reference/android/app/ActivityManager.RunningAppProcessInfo
+        // Only exact "foreground" importance maps to foreground=1.
+        if let Some(running_state) = report.app_metrics().and_then(|app| app.running_state()) {
+          let is_foreground = running_state == "foreground";
+          fields.insert(
+            "foreground".into(),
+            if is_foreground { "1" } else { "0" }.into(),
+          );
+        }
+
         let version_code =
           build_number.map_or_else(|| "unknown".to_string(), |b| b.version_code().to_string());
         fields.insert("_app_version_code".into(), version_code.into());

--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -265,6 +265,14 @@ impl Monitor {
       ),
     ]);
 
+    if let Some(running_state) = report.app_metrics().and_then(|app| app.running_state()) {
+      let is_foreground = running_state.starts_with("foreground");
+      fields.insert(
+        "foreground".into(),
+        if is_foreground { "1" } else { "0" }.into(),
+      );
+    }
+
     if let Some(app_id) = app_id {
       fields.insert("app_id".into(), app_id.into());
     }

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -134,15 +134,16 @@ impl CrashReportBuilder {
     error.reason = self.reason;
     error.relation_to_next = ErrorRelation::CausedBy;
 
-    let app_metrics = if self.app_id.is_some() || self.app_version.is_some() || self.running_state.is_some() {
-      let mut metrics = AppMetricsT::default();
-      metrics.app_id = self.app_id;
-      metrics.version = self.app_version;
-      metrics.running_state = self.running_state;
-      Some(Box::new(metrics))
-    } else {
-      None
-    };
+    let app_metrics =
+      if self.app_id.is_some() || self.app_version.is_some() || self.running_state.is_some() {
+        let mut metrics = AppMetricsT::default();
+        metrics.app_id = self.app_id;
+        metrics.version = self.app_version;
+        metrics.running_state = self.running_state;
+        Some(Box::new(metrics))
+      } else {
+        None
+      };
 
     let device_metrics = {
       let mut metrics = DeviceMetricsT::default();

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -68,6 +68,7 @@ struct CrashReportBuilder {
   app_version: Option<String>,
   timestamp: Option<OffsetDateTime>,
   running_state: Option<String>,
+  platform: Platform,
 }
 
 impl CrashReportBuilder {
@@ -80,6 +81,7 @@ impl CrashReportBuilder {
       app_version: None,
       timestamp: None,
       running_state: None,
+      platform: Platform::Unknown,
     }
   }
 
@@ -113,6 +115,11 @@ impl CrashReportBuilder {
     self
   }
 
+  fn platform(mut self, platform: Platform) -> Self {
+    self.platform = platform;
+    self
+  }
+
   fn build(self) -> Vec<u8> {
     use bd_proto::flatbuffers::report::bitdrift_public::fbs::issue_reporting::v_1::{
       AppMetricsT,
@@ -137,14 +144,17 @@ impl CrashReportBuilder {
       None
     };
 
-    let device_metrics = self.timestamp.map(|ts| {
+    let device_metrics = {
       let mut metrics = DeviceMetricsT::default();
-      metrics.time = Some(TimestampT {
-        seconds: ts.unix_timestamp().try_into().unwrap(),
-        nanos: 0,
-      });
-      Box::new(metrics)
-    });
+      metrics.platform = self.platform;
+      if let Some(ts) = self.timestamp {
+        metrics.time = Some(TimestampT {
+          seconds: ts.unix_timestamp().try_into().unwrap(),
+          nanos: 0,
+        });
+      }
+      Some(Box::new(metrics))
+    };
 
     let mut report_t = ReportT::default();
     report_t.type_ = self.report_type;
@@ -1014,6 +1024,7 @@ async fn assert_running_state_maps_to_foreground(running_state: &str, expected_f
   let data = CrashReportBuilder::new("SIGSEGV")
     .reason("segfault")
     .running_state(running_state)
+    .platform(Platform::Android)
     .build();
 
   let mut setup = Setup::new(None, false, None).await;

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -67,6 +67,7 @@ struct CrashReportBuilder {
   app_id: Option<String>,
   app_version: Option<String>,
   timestamp: Option<OffsetDateTime>,
+  running_state: Option<String>,
 }
 
 impl CrashReportBuilder {
@@ -78,6 +79,7 @@ impl CrashReportBuilder {
       app_id: None,
       app_version: None,
       timestamp: None,
+      running_state: None,
     }
   }
 
@@ -106,6 +108,11 @@ impl CrashReportBuilder {
     self
   }
 
+  fn running_state(mut self, state: impl Into<String>) -> Self {
+    self.running_state = Some(state.into());
+    self
+  }
+
   fn build(self) -> Vec<u8> {
     use bd_proto::flatbuffers::report::bitdrift_public::fbs::issue_reporting::v_1::{
       AppMetricsT,
@@ -120,10 +127,11 @@ impl CrashReportBuilder {
     error.reason = self.reason;
     error.relation_to_next = ErrorRelation::CausedBy;
 
-    let app_metrics = if self.app_id.is_some() || self.app_version.is_some() {
+    let app_metrics = if self.app_id.is_some() || self.app_version.is_some() || self.running_state.is_some() {
       let mut metrics = AppMetricsT::default();
       metrics.app_id = self.app_id;
       metrics.version = self.app_version;
+      metrics.running_state = self.running_state;
       Some(Box::new(metrics))
     } else {
       None
@@ -1000,4 +1008,65 @@ async fn crash_report_hook_is_invoked_with_correct_info() {
   assert!(!captured[0].fields.contains_key("reason"));
   assert!(!captured[0].fields.contains_key("detail"));
   assert!(!captured[0].fields.contains_key("session_id"));
+}
+
+async fn assert_running_state_maps_to_foreground(running_state: &str, expected_foreground: &str) {
+  let data = CrashReportBuilder::new("SIGSEGV")
+    .reason("segfault")
+    .running_state(running_state)
+    .build();
+
+  let mut setup = Setup::new(None, false, None).await;
+  setup.make_crash("report.cap", &data);
+
+  let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".parse().unwrap();
+  make_mut(&mut setup.upload_client)
+    .expect_enqueue_upload()
+    .returning(move |_, _, _, _, _, _, _| Ok(uuid));
+
+  let logs = setup.process_all_pending_reports().await;
+  assert_eq!(1, logs.len());
+  assert_eq!(
+    expected_foreground,
+    logs[0]["foreground"].value.as_str().unwrap()
+  );
+}
+
+#[tokio::test]
+async fn running_state_foreground_sets_foreground_field_to_one() {
+  assert_running_state_maps_to_foreground("foreground", "1").await;
+}
+
+#[tokio::test]
+async fn running_state_cached_sets_foreground_field_to_zero() {
+  assert_running_state_maps_to_foreground("cached", "0").await;
+}
+
+#[tokio::test]
+async fn running_state_foreground_service_sets_foreground_field_to_zero() {
+  assert_running_state_maps_to_foreground("foreground_service", "0").await;
+}
+
+#[tokio::test]
+async fn no_running_state_does_not_override_foreground() {
+  let data = CrashReportBuilder::new("SIGSEGV")
+    .reason("segfault")
+    .build();
+
+  let mut setup = Setup::new(
+    Some([("foreground".into(), "1".into())].into()),
+    false,
+    None,
+  )
+  .await;
+  setup.make_crash("report.cap", &data);
+
+  let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".parse().unwrap();
+  make_mut(&mut setup.upload_client)
+    .expect_enqueue_upload()
+    .returning(move |_, _, _, _, _, _, _| Ok(uuid));
+
+  let logs = setup.process_all_pending_reports().await;
+  assert_eq!(1, logs.len());
+  assert_eq!("1", logs[0]["foreground"].value.as_str().unwrap());
 }

--- a/bd-logger/src/metadata.rs
+++ b/bd-logger/src/metadata.rs
@@ -65,6 +65,10 @@ impl MetadataCollector {
   }
 
   /// Creates metadata from log fields without interpolating provider fields
+  /// Returns metadata for logs from the previous run (e.g. crash/exit logs).
+  /// Log OOTB fields take precedence over previous global state so that
+  /// callers can override potentially stale persisted values when a more
+  /// accurate source is available (e.g. foreground state from `ApplicationExitInfo`).
   pub(crate) fn metadata_from_fields_with_previous_global_state(
     &self,
     fields: AnnotatedLogFields,
@@ -78,10 +82,10 @@ impl MetadataCollector {
     {
       let log_fields = partition_fields(fields);
 
-      log_fields
-        .ootb
+      previous_global_state_fields
+        .clone()
         .into_iter()
-        .chain(previous_global_state_fields.clone())
+        .chain(log_fields.ootb)
         .chain(log_fields.custom)
         .collect()
     } else {

--- a/bd-logger/src/metadata.rs
+++ b/bd-logger/src/metadata.rs
@@ -64,11 +64,12 @@ impl MetadataCollector {
     }
   }
 
-  /// Creates metadata from log fields without interpolating provider fields
-  /// Returns metadata for logs from the previous run (e.g. crash/exit logs).
-  /// Log OOTB fields take precedence over previous global state so that
-  /// callers can override potentially stale persisted values when a more
-  /// accurate source is available (e.g. foreground state from `ApplicationExitInfo`).
+  /// Returns log metadata using the last active global state at the end of the last process run.
+  /// Log fields take precedence over persisted global state fields to allow the caller to
+  /// override values in global state, e.g. when the crash handler knows that the event happened
+  /// in the background.
+  /// Does *not* invoke the field providers as these would incorrectly reflect the state of the
+  /// current process.
   pub(crate) fn metadata_from_fields_with_previous_global_state(
     &self,
     fields: AnnotatedLogFields,
@@ -80,13 +81,10 @@ impl MetadataCollector {
     let fields = if let Some(previous_global_state_fields) =
       global_state_reader.previous_global_state_fields()
     {
-      let log_fields = partition_fields(fields);
-
       previous_global_state_fields
         .clone()
         .into_iter()
-        .chain(log_fields.ootb)
-        .chain(log_fields.custom)
+        .chain(fields.into_iter().map(|(k, v)| (k, v.value)))
         .collect()
     } else {
       fields.into_iter().map(|(k, v)| (k, v.value)).collect()

--- a/bd-logger/src/metadata_test.rs
+++ b/bd-logger/src/metadata_test.rs
@@ -301,17 +301,20 @@ fn metadata_from_fields_with_previous_global_state_includes_global_fields() {
   );
 
   // 3. Precedence check:
-  // Order: OOTB -> Global -> Custom
+  // Order: Global -> OOTB -> Custom
+  // Global state provides the baseline for previous run fields.
+  // Log OOTB fields can override global state when a more accurate
+  // source is available (e.g. foreground from ApplicationExitInfo).
 
   // shared_ootb_key: OOTB ("local_value") vs Global ("global_value")
-  // Global comes AFTER OOTB in chain, so Global should win.
+  // Log field overrides stale global state.
   assert_eq!(
-    "global_value",
+    "local_value",
     expected_field_value(&metadata.fields, "shared_ootb_key").unwrap()
   );
 
   // shared_custom_key: Custom ("local_value") vs Global ("global_value")
-  // Custom comes AFTER Global in chain, so Custom should win.
+  // Custom field overrides global state.
   assert_eq!(
     "local_value",
     expected_field_value(&metadata.fields, "shared_custom_key").unwrap()

--- a/bd-logger/src/metadata_test.rs
+++ b/bd-logger/src/metadata_test.rs
@@ -257,8 +257,7 @@ fn metadata_from_fields_with_previous_global_state_includes_global_fields() {
   // Setup global state
   let global_fields = [
     ("global_key".into(), "global_value".into()),
-    ("shared_custom_key".into(), "global_value".into()),
-    ("shared_ootb_key".into(), "global_value".into()),
+    ("shared_key".into(), "global_value".into()),
   ]
   .into();
   tracker.maybe_update_global_state(&global_fields);
@@ -267,14 +266,10 @@ fn metadata_from_fields_with_previous_global_state_includes_global_fields() {
   let input_fields = [
     (
       "local_key".into(),
-      AnnotatedLogField::new_custom("local_value"),
+      AnnotatedLogField::new_ootb("local_value"),
     ),
     (
-      "shared_custom_key".into(),
-      AnnotatedLogField::new_custom("local_value"),
-    ),
-    (
-      "shared_ootb_key".into(),
+      "shared_key".into(),
       AnnotatedLogField::new_ootb("local_value"),
     ),
   ]
@@ -288,35 +283,22 @@ fn metadata_from_fields_with_previous_global_state_includes_global_fields() {
 
   // Verify fields
 
-  // 1. Unique global field should be present
+  // Unique global field should be present
   assert_eq!(
     "global_value",
     expected_field_value(&metadata.fields, "global_key").unwrap()
   );
 
-  // 2. Unique local field should be present
+  // Unique local field should be present
   assert_eq!(
     "local_value",
     expected_field_value(&metadata.fields, "local_key").unwrap()
   );
 
-  // 3. Precedence check:
-  // Order: Global -> OOTB -> Custom
-  // Global state provides the baseline for previous run fields.
-  // Log OOTB fields can override global state when a more accurate
-  // source is available (e.g. foreground from ApplicationExitInfo).
-
-  // shared_ootb_key: OOTB ("local_value") vs Global ("global_value")
-  // Log field overrides stale global state.
+  // Log fields override global state, allowing callers to provide
+  // authoritative values (e.g. foreground from ApplicationExitInfo).
   assert_eq!(
     "local_value",
-    expected_field_value(&metadata.fields, "shared_ootb_key").unwrap()
-  );
-
-  // shared_custom_key: Custom ("local_value") vs Global ("global_value")
-  // Custom field overrides global state.
-  assert_eq!(
-    "local_value",
-    expected_field_value(&metadata.fields, "shared_custom_key").unwrap()
+    expected_field_value(&metadata.fields, "shared_key").unwrap()
   );
 }


### PR DESCRIPTION
## What

Resolves BIT-8093

Fix precedence of log fields over stale global state for previous run logs. This resolves incorrect "foreground" state shown in background app terminations

Also use the report field "running state" to infer the last app state at the moment of termination

## Verification

Further fix and verification at https://github.com/bitdriftlabs/capture-sdk/pull/978
