### PR TITLE
[Android] Fix incorrect ANR "unknown" reason/Undetermined ANR

### DIFF
--- a/bd-report-parsers/src/android.rs
+++ b/bd-report-parsers/src/android.rs
@@ -57,6 +57,7 @@ pub fn build_anr<'a, 'fbb>(
   app_info: &mut v_1::AppMetricsArgs<'fbb>,
   device_info: &mut v_1::DeviceMetricsArgs<'fbb>,
   input: MemmapView<'a>,
+  app_exit_description: Option<&str>,
 ) -> IResult<MemmapView<'a>, WIPOffset<v_1::Report<'fbb>>, nom::error::Error<MemmapView<'a>>> {
   let (remainder, (subject, (pid, _timestamp), metrics, _attached_count, stacks)) = (
     subject_parser,
@@ -75,9 +76,10 @@ pub fn build_anr<'a, 'fbb>(
     let abi = builder.create_string(abi);
     builder.create_vector(&[abi])
   });
+  let description = app_exit_description.or(subject.as_deref());
   let error_args = v_1::ErrorArgs {
-    name: Some(builder.create_string(anr_name(subject.as_deref()))),
-    reason: subject.map(|sub| builder.create_string(&sub)),
+    name: Some(builder.create_string(anr_name(description))),
+    reason: description.map(|d| builder.create_string(d)),
     stack_trace: stacks.main_stack,
     ..Default::default()
   };

--- a/bd-report-parsers/src/android_tests.rs
+++ b/bd-report-parsers/src/android_tests.rs
@@ -309,7 +309,7 @@ macro_rules! assert_parsed_anr_eq {
       time: Some(&Timestamp::new(1756987272, 357156958)),
       ..Default::default()
     };
-    match build_anr(&mut builder, &mut app_info, &mut device_info, input) {
+    match build_anr(&mut builder, &mut app_info, &mut device_info, input, None) {
       Ok((_, offset)) => {
         let report = get_table!(Report, builder, offset);
         insta::assert_debug_snapshot!(report);
@@ -407,4 +407,65 @@ fn anr_sleep_main_thread_test() {
 #[test]
 fn anr_latency_test() {
   assert_parsed_anr_eq!("anr_latency_test.txt");
+}
+
+fn build_anr_to_bytes(filename: &str, description: Option<&str>) -> Vec<u8> {
+  let mut builder = FlatBufferBuilder::new();
+  let file = open_fixture(filename);
+  let mmap = unsafe { memmap2::Mmap::map(&file).unwrap() };
+  let input = MemmapView::new(&mmap);
+  let mut app_info = AppMetricsArgs {
+    app_id: Some(builder.create_string("com.example.MyApp")),
+    ..Default::default()
+  };
+  let mut device_info = DeviceMetricsArgs {
+    model: Some(builder.create_string("Monaco")),
+    time: Some(&Timestamp::new(1756987272, 357156958)),
+    ..Default::default()
+  };
+  let (_, offset) = build_anr(
+    &mut builder,
+    &mut app_info,
+    &mut device_info,
+    input,
+    description,
+  )
+  .unwrap();
+  builder.finish(offset, None);
+  builder.finished_data().to_vec()
+}
+
+#[test]
+fn build_anr_with_app_exit_description() {
+  let description =
+    "bg anr: Input dispatching timed out (Application does not have a focused window)";
+  let bytes = build_anr_to_bytes("anr1.txt", Some(description));
+  let report = flatbuffers::root::<Report<'_>>(&bytes).unwrap();
+  let error = report.errors().unwrap().get(0);
+  assert_eq!(error.name(), Some("Background ANR"));
+  assert_eq!(error.reason(), Some(description));
+}
+
+#[test]
+fn build_anr_without_description_uses_subject() {
+  let bytes = build_anr_to_bytes("anr_broadcast_receiver.txt", None);
+  let report = flatbuffers::root::<Report<'_>>(&bytes).unwrap();
+  let error = report.errors().unwrap().get(0);
+  assert_eq!(error.name(), Some("User Perceived ANR"));
+  assert!(error.reason().is_some());
+  assert!(
+    error
+      .reason()
+      .unwrap()
+      .contains("Input dispatching timed out")
+  );
+}
+
+#[test]
+fn build_anr_without_description_or_subject() {
+  let bytes = build_anr_to_bytes("anr1.txt", None);
+  let report = flatbuffers::root::<Report<'_>>(&bytes).unwrap();
+  let error = report.errors().unwrap().get(0);
+  assert_eq!(error.name(), Some("Undetermined ANR"));
+  assert_eq!(error.reason(), None);
 }

--- a/bd-report-parsers/src/android_tests.rs
+++ b/bd-report-parsers/src/android_tests.rs
@@ -306,7 +306,7 @@ macro_rules! assert_parsed_anr_eq {
     };
     let mut device_info = DeviceMetricsArgs {
       model: Some(builder.create_string("Monaco")),
-      time: Some(&Timestamp::new(1756987272, 357156958)),
+      time: Some(&Timestamp::new(1_756_987_272, 357_156_958)),
       ..Default::default()
     };
     match build_anr(&mut builder, &mut app_info, &mut device_info, input, None) {
@@ -420,7 +420,7 @@ fn build_anr_to_bytes(filename: &str, description: Option<&str>) -> Vec<u8> {
   };
   let mut device_info = DeviceMetricsArgs {
     model: Some(builder.create_string("Monaco")),
-    time: Some(&Timestamp::new(1756987272, 357156958)),
+    time: Some(&Timestamp::new(1_756_987_272, 357_156_958)),
     ..Default::default()
   };
   let (_, offset) = build_anr(


### PR DESCRIPTION
## What

Part of BIT-8285

Fixes incorrect "unknown" reason and Undetermined ANR classification for ANR reports that have a valid description. This was introduced in a refactor to move the ANR parsing logic to the [rust layer](https://github.com/bitdriftlabs/shared-core/pull/227) and the fix is to have the logic closer to the original parsing done in the Android layer in https://github.com/bitdriftlabs/capture-sdk/pull/382 to not trim relevant info from app exit description.

Also on this PR if for some reason we get a None description will use the current logic on main for extracting it from the raw report "Subject:" 

## Verification

Verified in the [capture-sdk integration PR](https://github.com/bitdriftlabs/capture-sdk/pull/983) via gradle-test-app
