### PR TITLE
[Android] [ANR] Remove prefix for  _app_exit_detail

### DIFF
--- a/bd-report-parsers/src/android.rs
+++ b/bd-report-parsers/src/android.rs
@@ -76,7 +76,9 @@ pub fn build_anr<'a, 'fbb>(
     let abi = builder.create_string(abi);
     builder.create_vector(&[abi])
   });
-  let description = app_exit_description.or(subject.as_deref());
+  let description = app_exit_description
+    .map(|d| d.split_once(": ").map_or(d, |(_, rest)| rest))
+    .or(subject.as_deref());
   let error_args = v_1::ErrorArgs {
     name: Some(builder.create_string(anr_name(description))),
     reason: description.map(|d| builder.create_string(d)),

--- a/bd-report-parsers/src/android_tests.rs
+++ b/bd-report-parsers/src/android_tests.rs
@@ -438,12 +438,15 @@ fn build_anr_to_bytes(filename: &str, description: Option<&str>) -> Vec<u8> {
 #[test]
 fn build_anr_with_app_exit_description() {
   let description =
-    "bg anr: Input dispatching timed out (Application does not have a focused window)";
+    "user request after error: Input dispatching timed out (Application does not have a focused window)";
   let bytes = build_anr_to_bytes("anr1.txt", Some(description));
   let report = flatbuffers::root::<Report<'_>>(&bytes).unwrap();
   let error = report.errors().unwrap().get(0);
-  assert_eq!(error.name(), Some("Background ANR"));
-  assert_eq!(error.reason(), Some(description));
+  assert_eq!(error.name(), Some("User Perceived ANR"));
+  assert_eq!(
+    error.reason(),
+    Some("Input dispatching timed out (Application does not have a focused window)")
+  );
 }
 
 #[test]


### PR DESCRIPTION
## What

Follow up to https://github.com/bitdriftlabs/shared-core/pull/489, to keep stripping prefix text.

For example if we have for description of:

- `user request after error: Input dispatching timed out (a5f7202 acme/com.acme.MainActivity (server) is not responding. Waited 5001ms for FocusEvent(hasFocus=false))` 

This should become just (same as currently in main for non-failed parsed reported in ` _app_exit_details`:

- `Input dispatching timed out (a5f7202 acme/com.acme.MainActivity (server) is not responding. Waited 5001ms for FocusEvent(hasFocus=false))`

## Verification 

Unit tests and in the capture-sdk PR https://github.com/bitdriftlabs/capture-sdk/pull/983