### PR TITLE
Expose SDK status

### DIFF
--- a/bd-api/src/api.rs
+++ b/bd-api/src/api.rs
@@ -544,6 +544,7 @@ impl Api {
 
   async fn set_client_killed(&mut self) {
     self.client_killed = true;
+    self.sdk_status_tracker.record_disabled();
     UnexpectedErrorHandler::disable();
     // Make sure that we clear out cached config so that when we eventually come back online we
     // can accept new config if the server sends it.

--- a/bd-api/src/api.rs
+++ b/bd-api/src/api.rs
@@ -395,6 +395,8 @@ pub struct Api {
   disconnected_at: Option<Instant>,
   last_disconnect_reason: Option<String>,
 
+  sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
+
   #[cfg(test)]
   pub data_idle_timeout_test_hook: Option<tokio::sync::mpsc::Sender<()>>,
 }
@@ -417,6 +419,7 @@ impl Api {
     store: Arc<bd_key_value::Store>,
     session_strategy: Arc<bd_session::Strategy>,
     opaque_entity_updates: watch::Receiver<Option<String>>,
+    sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
   ) -> Self {
     let mut backoff_policy = RuntimeBackoffPolicy::new(runtime_loader.as_ref());
     let generic_kill_duration = runtime_loader.register_duration_watch();
@@ -460,6 +463,7 @@ impl Api {
       reconnect_state,
       disconnected_at: None,
       last_disconnect_reason: None,
+      sdk_status_tracker,
       #[cfg(test)]
       data_idle_timeout_test_hook: None,
     }
@@ -881,6 +885,9 @@ impl Api {
       .network_quality_monitor
       .set_network_quality(NetworkQuality::Online);
     self.reconnect_state.record_connectivity_event();
+    self
+      .sdk_status_tracker
+      .record_handshake(self.time_provider.now());
 
     self.disconnected_at = None;
 

--- a/bd-api/src/api_test.rs
+++ b/bd-api/src/api_test.rs
@@ -250,6 +250,7 @@ impl Setup {
       store.clone(),
       session_strategy.clone(),
       opaque_entity_updates_rx,
+      bd_client_common::sdk_status::SdkStatusTracker::new(),
     );
     api.data_idle_timeout_test_hook = idle_timeout_tx;
 
@@ -314,6 +315,7 @@ impl Setup {
       self.store.clone(),
       self.session_strategy.clone(),
       self.opaque_entity_updates.subscribe(),
+      bd_client_common::sdk_status::SdkStatusTracker::new(),
     );
 
     self.api_task = Some(tokio::task::spawn(api.start()));

--- a/bd-client-common/src/lib.rs
+++ b/bd-client-common/src/lib.rs
@@ -24,6 +24,7 @@ pub mod file_system;
 pub mod init_lifecycle;
 pub mod payload_conversion;
 pub mod safe_file_cache;
+pub mod sdk_status;
 pub mod test;
 
 #[cfg(test)]

--- a/bd-client-common/src/sdk_status.rs
+++ b/bd-client-common/src/sdk_status.rs
@@ -79,17 +79,13 @@ impl SdkStatusTracker {
   /// Called when a handshake with the backend completes successfully.
   pub fn record_handshake(&self, time: OffsetDateTime) {
     let mut status = self.inner.write();
-    if status.initialization_state == InitializationState::Running {
-      status.last_handshake_time = Some(time);
-    }
+    status.last_handshake_time = Some(time);
   }
 
   /// Called when a configuration update is successfully applied from the backend
   /// (not from cache).
   pub fn record_config_delivery(&self, time: OffsetDateTime) {
     let mut status = self.inner.write();
-    if status.initialization_state == InitializationState::Running {
-      status.last_config_delivery_time = Some(time);
-    }
+    status.last_config_delivery_time = Some(time);
   }
 }

--- a/bd-client-common/src/sdk_status.rs
+++ b/bd-client-common/src/sdk_status.rs
@@ -16,7 +16,7 @@ use time::OffsetDateTime;
 /// The SDK's initialization state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum SdkState {
+pub enum InitializationState {
   /// The SDK has not been started yet.
   NotStarted = 0,
   /// The SDK library has been loaded and the logger is being constructed,
@@ -30,7 +30,7 @@ pub enum SdkState {
 #[derive(Debug, Clone)]
 pub struct SdkStatus {
   /// The current initialization state of the SDK.
-  pub sdk_state: SdkState,
+  pub initialization_state: InitializationState,
 
   /// The wall-clock time of the last successful handshake, if any.
   pub last_handshake_time: Option<OffsetDateTime>,
@@ -57,7 +57,7 @@ impl SdkStatusTracker {
   pub fn new() -> Self {
     Self {
       inner: Arc::new(RwLock::new(SdkStatus {
-        sdk_state: SdkState::Loaded,
+        initialization_state: InitializationState::Loaded,
         last_handshake_time: None,
         last_config_delivery_time: None,
       })),
@@ -73,13 +73,13 @@ impl SdkStatusTracker {
   /// Called when the SDK is fully running (log processing started).
   pub fn record_running(&self) {
     let mut status = self.inner.write();
-    status.sdk_state = SdkState::Running;
+    status.initialization_state = InitializationState::Running;
   }
 
   /// Called when a handshake with the backend completes successfully.
   pub fn record_handshake(&self, time: OffsetDateTime) {
     let mut status = self.inner.write();
-    if status.sdk_state == SdkState::Running {
+    if status.initialization_state == InitializationState::Running {
       status.last_handshake_time = Some(time);
     }
   }
@@ -88,7 +88,7 @@ impl SdkStatusTracker {
   /// (not from cache).
   pub fn record_config_delivery(&self, time: OffsetDateTime) {
     let mut status = self.inner.write();
-    if status.sdk_state == SdkState::Running {
+    if status.initialization_state == InitializationState::Running {
       status.last_config_delivery_time = Some(time);
     }
   }

--- a/bd-client-common/src/sdk_status.rs
+++ b/bd-client-common/src/sdk_status.rs
@@ -21,9 +21,9 @@ pub enum SdkState {
   NotStarted = 0,
   /// The SDK library has been loaded and the logger is being constructed,
   /// but log processing has not yet begun.
-  Loaded = 1,
+  Loaded     = 1,
   /// The SDK is fully running and processing logs.
-  Running = 2,
+  Running    = 2,
 }
 
 /// A point-in-time snapshot of the SDK's operational status.

--- a/bd-client-common/src/sdk_status.rs
+++ b/bd-client-common/src/sdk_status.rs
@@ -1,0 +1,95 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+#[cfg(test)]
+#[path = "./sdk_status_test.rs"]
+mod tests;
+
+use parking_lot::RwLock;
+use std::sync::Arc;
+use time::OffsetDateTime;
+
+/// The SDK's initialization state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SdkState {
+  /// The SDK has not been started yet.
+  NotStarted = 0,
+  /// The SDK library has been loaded and the logger is being constructed,
+  /// but log processing has not yet begun.
+  Loaded = 1,
+  /// The SDK is fully running and processing logs.
+  Running = 2,
+}
+
+/// A point-in-time snapshot of the SDK's operational status.
+#[derive(Debug, Clone)]
+pub struct SdkStatus {
+  /// The current initialization state of the SDK.
+  pub sdk_state: SdkState,
+
+  /// The wall-clock time of the last successful handshake, if any.
+  pub last_handshake_time: Option<OffsetDateTime>,
+
+  /// The wall-clock time of the last successful config delivery from the backend, if any.
+  pub last_config_delivery_time: Option<OffsetDateTime>,
+}
+
+/// A thread-safe tracker that subsystems update as events occur.
+/// Callers can snapshot the current state at any time via [`get()`](Self::get).
+#[derive(Clone)]
+pub struct SdkStatusTracker {
+  inner: Arc<RwLock<SdkStatus>>,
+}
+
+impl Default for SdkStatusTracker {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl SdkStatusTracker {
+  #[must_use]
+  pub fn new() -> Self {
+    Self {
+      inner: Arc::new(RwLock::new(SdkStatus {
+        sdk_state: SdkState::Loaded,
+        last_handshake_time: None,
+        last_config_delivery_time: None,
+      })),
+    }
+  }
+
+  /// Returns a snapshot of the current SDK status.
+  #[must_use]
+  pub fn get(&self) -> SdkStatus {
+    self.inner.read().clone()
+  }
+
+  /// Called when the SDK is fully running (log processing started).
+  pub fn record_running(&self) {
+    let mut status = self.inner.write();
+    status.sdk_state = SdkState::Running;
+  }
+
+  /// Called when a handshake with the backend completes successfully.
+  pub fn record_handshake(&self, time: OffsetDateTime) {
+    let mut status = self.inner.write();
+    if status.sdk_state == SdkState::Running {
+      status.last_handshake_time = Some(time);
+    }
+  }
+
+  /// Called when a configuration update is successfully applied from the backend
+  /// (not from cache).
+  pub fn record_config_delivery(&self, time: OffsetDateTime) {
+    let mut status = self.inner.write();
+    if status.sdk_state == SdkState::Running {
+      status.last_config_delivery_time = Some(time);
+    }
+  }
+}

--- a/bd-client-common/src/sdk_status.rs
+++ b/bd-client-common/src/sdk_status.rs
@@ -24,6 +24,8 @@ pub enum InitializationState {
   Loaded     = 1,
   /// The SDK is fully running and processing logs.
   Running    = 2,
+  /// The SDK has been force-disabled by the server (e.g., authentication failure).
+  Disabled   = 3,
 }
 
 /// A point-in-time snapshot of the SDK's operational status.
@@ -80,6 +82,12 @@ impl SdkStatusTracker {
   pub fn record_handshake(&self, time: OffsetDateTime) {
     let mut status = self.inner.write();
     status.last_handshake_time = Some(time);
+  }
+
+  /// Called when the SDK has been force-disabled by the server.
+  pub fn record_disabled(&self) {
+    let mut status = self.inner.write();
+    status.initialization_state = InitializationState::Disabled;
   }
 
   /// Called when a configuration update is successfully applied from the backend

--- a/bd-client-common/src/sdk_status_test.rs
+++ b/bd-client-common/src/sdk_status_test.rs
@@ -1,0 +1,95 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use super::*;
+
+#[test]
+fn new_tracker_starts_as_loaded() {
+  let tracker = SdkStatusTracker::new();
+  let status = tracker.get();
+  assert_eq!(status.sdk_state, SdkState::Loaded);
+  assert!(status.last_handshake_time.is_none());
+  assert!(status.last_config_delivery_time.is_none());
+}
+
+#[test]
+fn record_running_transitions_to_running() {
+  let tracker = SdkStatusTracker::new();
+  tracker.record_running();
+  assert_eq!(tracker.get().sdk_state, SdkState::Running);
+}
+
+#[test]
+fn record_handshake_sets_timestamp() {
+  let tracker = SdkStatusTracker::new();
+  tracker.record_running();
+  let now = OffsetDateTime::now_utc();
+  tracker.record_handshake(now);
+
+  let status = tracker.get();
+  assert_eq!(status.last_handshake_time, Some(now));
+}
+
+#[test]
+fn record_config_delivery_updates_timestamp() {
+  let tracker = SdkStatusTracker::new();
+  tracker.record_running();
+  let now = OffsetDateTime::now_utc();
+  tracker.record_config_delivery(now);
+
+  let status = tracker.get();
+  assert_eq!(status.last_config_delivery_time, Some(now));
+}
+
+#[test]
+fn multiple_handshakes_keep_latest_time() {
+  let tracker = SdkStatusTracker::new();
+  tracker.record_running();
+  let t1 = OffsetDateTime::now_utc();
+  let t2 = t1 + time::Duration::seconds(10);
+
+  tracker.record_handshake(t1);
+  tracker.record_handshake(t2);
+
+  assert_eq!(tracker.get().last_handshake_time, Some(t2));
+}
+
+#[test]
+fn full_lifecycle() {
+  let tracker = SdkStatusTracker::new();
+
+  // Loaded.
+  assert_eq!(tracker.get().sdk_state, SdkState::Loaded);
+
+  // Running.
+  tracker.record_running();
+  assert_eq!(tracker.get().sdk_state, SdkState::Running);
+
+  // Handshake.
+  let t1 = OffsetDateTime::now_utc();
+  tracker.record_handshake(t1);
+  assert_eq!(tracker.get().last_handshake_time, Some(t1));
+
+  // Another handshake — timestamp updated.
+  let t2 = t1 + time::Duration::seconds(5);
+  tracker.record_handshake(t2);
+  assert_eq!(tracker.get().last_handshake_time, Some(t2));
+}
+
+#[test]
+fn timestamps_ignored_before_running() {
+  let tracker = SdkStatusTracker::new();
+
+  // These should be no-ops since the SDK is only Loaded, not Running.
+  tracker.record_handshake(OffsetDateTime::now_utc());
+  tracker.record_config_delivery(OffsetDateTime::now_utc());
+
+  let status = tracker.get();
+  assert_eq!(status.sdk_state, SdkState::Loaded);
+  assert!(status.last_handshake_time.is_none());
+  assert!(status.last_config_delivery_time.is_none());
+}

--- a/bd-client-common/src/sdk_status_test.rs
+++ b/bd-client-common/src/sdk_status_test.rs
@@ -20,7 +20,10 @@ fn new_tracker_starts_as_loaded() {
 fn record_running_transitions_to_running() {
   let tracker = SdkStatusTracker::new();
   tracker.record_running();
-  assert_eq!(tracker.get().initialization_state, InitializationState::Running);
+  assert_eq!(
+    tracker.get().initialization_state,
+    InitializationState::Running
+  );
 }
 
 #[test]
@@ -63,11 +66,17 @@ fn full_lifecycle() {
   let tracker = SdkStatusTracker::new();
 
   // Loaded.
-  assert_eq!(tracker.get().initialization_state, InitializationState::Loaded);
+  assert_eq!(
+    tracker.get().initialization_state,
+    InitializationState::Loaded
+  );
 
   // Running.
   tracker.record_running();
-  assert_eq!(tracker.get().initialization_state, InitializationState::Running);
+  assert_eq!(
+    tracker.get().initialization_state,
+    InitializationState::Running
+  );
 
   // Handshake.
   let t1 = OffsetDateTime::now_utc();

--- a/bd-client-common/src/sdk_status_test.rs
+++ b/bd-client-common/src/sdk_status_test.rs
@@ -104,3 +104,14 @@ fn timestamps_recorded_before_running() {
   assert_eq!(status.last_handshake_time, Some(now));
   assert_eq!(status.last_config_delivery_time, Some(now));
 }
+
+#[test]
+fn record_disabled_transitions_to_disabled() {
+  let tracker = SdkStatusTracker::new();
+  tracker.record_running();
+
+  tracker.record_disabled();
+
+  let status = tracker.get();
+  assert_eq!(status.initialization_state, InitializationState::Disabled);
+}

--- a/bd-client-common/src/sdk_status_test.rs
+++ b/bd-client-common/src/sdk_status_test.rs
@@ -11,7 +11,7 @@ use super::*;
 fn new_tracker_starts_as_loaded() {
   let tracker = SdkStatusTracker::new();
   let status = tracker.get();
-  assert_eq!(status.sdk_state, SdkState::Loaded);
+  assert_eq!(status.initialization_state, InitializationState::Loaded);
   assert!(status.last_handshake_time.is_none());
   assert!(status.last_config_delivery_time.is_none());
 }
@@ -20,7 +20,7 @@ fn new_tracker_starts_as_loaded() {
 fn record_running_transitions_to_running() {
   let tracker = SdkStatusTracker::new();
   tracker.record_running();
-  assert_eq!(tracker.get().sdk_state, SdkState::Running);
+  assert_eq!(tracker.get().initialization_state, InitializationState::Running);
 }
 
 #[test]
@@ -63,11 +63,11 @@ fn full_lifecycle() {
   let tracker = SdkStatusTracker::new();
 
   // Loaded.
-  assert_eq!(tracker.get().sdk_state, SdkState::Loaded);
+  assert_eq!(tracker.get().initialization_state, InitializationState::Loaded);
 
   // Running.
   tracker.record_running();
-  assert_eq!(tracker.get().sdk_state, SdkState::Running);
+  assert_eq!(tracker.get().initialization_state, InitializationState::Running);
 
   // Handshake.
   let t1 = OffsetDateTime::now_utc();
@@ -89,7 +89,7 @@ fn timestamps_ignored_before_running() {
   tracker.record_config_delivery(OffsetDateTime::now_utc());
 
   let status = tracker.get();
-  assert_eq!(status.sdk_state, SdkState::Loaded);
+  assert_eq!(status.initialization_state, InitializationState::Loaded);
   assert!(status.last_handshake_time.is_none());
   assert!(status.last_config_delivery_time.is_none());
 }

--- a/bd-client-common/src/sdk_status_test.rs
+++ b/bd-client-common/src/sdk_status_test.rs
@@ -90,15 +90,17 @@ fn full_lifecycle() {
 }
 
 #[test]
-fn timestamps_ignored_before_running() {
+fn timestamps_recorded_before_running() {
   let tracker = SdkStatusTracker::new();
 
-  // These should be no-ops since the SDK is only Loaded, not Running.
-  tracker.record_handshake(OffsetDateTime::now_utc());
-  tracker.record_config_delivery(OffsetDateTime::now_utc());
+  // Timestamps are recorded even when the SDK is still in the Loaded state
+  // (e.g., config loaded from cache before log processing starts).
+  let now = OffsetDateTime::now_utc();
+  tracker.record_handshake(now);
+  tracker.record_config_delivery(now);
 
   let status = tracker.get();
   assert_eq!(status.initialization_state, InitializationState::Loaded);
-  assert!(status.last_handshake_time.is_none());
-  assert!(status.last_config_delivery_time.is_none());
+  assert_eq!(status.last_handshake_time, Some(now));
+  assert_eq!(status.last_config_delivery_time, Some(now));
 }

--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -352,6 +352,7 @@ pub struct AsyncLogBuffer<R: LogReplay> {
   global_state_reader: global_state::Reader,
   time_provider: Arc<dyn TimeProvider>,
   lifecycle_state: InitLifecycleState,
+  sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
 
   pending_workflow_debug_state: HashMap<String, WorkflowDebugStateMap>,
   send_workflow_debug_state_delay: Option<Pin<Box<Sleep>>>,
@@ -377,6 +378,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
     store: &Arc<Store>,
     time_provider: Arc<dyn TimeProvider>,
     lifecycle_state: InitLifecycleState,
+    sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
     data_upload_tx: mpsc::Sender<DataUpload>,
   ) -> (Self, Sender) {
     let (log_tx, log_rx) = channel(
@@ -459,6 +461,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
         global_state_reader: global_state::Reader::new(store.clone()),
         time_provider,
         lifecycle_state,
+        sdk_status_tracker,
 
         pending_workflow_debug_state: HashMap::new(),
         send_workflow_debug_state_delay: None,
@@ -916,6 +919,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
           self = updated_self;
           if let Some(pre_config_buffer) = maybe_pre_config_buffer {
             self.lifecycle_state.set(InitLifecycle::LogProcessingStarted);
+            self.sdk_status_tracker.record_running();
             self
               .maybe_replay_pre_config_buffer(pre_config_buffer, &state_store)
               .await;

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -145,6 +145,7 @@ impl Setup {
       &self.store,
       Arc::new(SystemTimeProvider),
       InitLifecycleState::new(),
+      bd_client_common::sdk_status::SdkStatusTracker::new(),
       self.data_upload_tx.clone(),
     )
   }
@@ -173,6 +174,7 @@ impl Setup {
       &self.store,
       Arc::new(SystemTimeProvider),
       InitLifecycleState::new(),
+      bd_client_common::sdk_status::SdkStatusTracker::new(),
       self.data_upload_tx.clone(),
     )
   }

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -302,6 +302,8 @@ impl LoggerBuilder {
         log_network_quality_provider.clone(),
       ]));
 
+    let sdk_status_tracker = bd_client_common::sdk_status::SdkStatusTracker::new();
+
     let (async_log_buffer, async_log_buffer_communication_tx) = AsyncLogBuffer::<LoggerReplay>::new(
       UninitializedLoggingContext::new(
         &self.params.sdk_directory,
@@ -331,6 +333,7 @@ impl LoggerBuilder {
       &self.params.store,
       time_provider.clone(),
       init_lifecycle.clone(),
+      sdk_status_tracker.clone(),
       data_upload_tx.clone(),
     );
 
@@ -353,6 +356,7 @@ impl LoggerBuilder {
       pending_entity_id.clone(),
       sleep_mode_active_tx,
       is_tracing_active,
+      sdk_status_tracker.clone(),
     );
     let log = if self.internal_logger {
       Arc::new(InternalLogger::new(
@@ -510,6 +514,7 @@ impl LoggerBuilder {
           &scope.scope("config"),
         ),
         time_provider.clone(),
+        sdk_status_tracker.clone(),
       ));
 
       let api = bd_api::api::Api::new(
@@ -529,6 +534,7 @@ impl LoggerBuilder {
         self.params.store.clone(),
         self.params.session_strategy.clone(),
         opaque_entity_updates_rx,
+        sdk_status_tracker,
       );
 
       let mut config_writer = bd_crash_handler::ConfigWriter::new(

--- a/bd-logger/src/client_config.rs
+++ b/bd-logger/src/client_config.rs
@@ -85,6 +85,9 @@ pub struct Config<A: ApplyConfig> {
   // Delegate used to apply the configuration. This allows for easier testing.
   #[allow(clippy::struct_field_names)]
   apply_config: A,
+
+  time_provider: Arc<dyn TimeProvider>,
+  sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
 }
 
 impl<A: ApplyConfig> Config<A> {
@@ -94,6 +97,7 @@ impl<A: ApplyConfig> Config<A> {
       sdk_directory,
       apply_config,
       Arc::new(bd_time::SystemTimeProvider),
+      bd_client_common::sdk_status::SdkStatusTracker::new(),
     )
   }
 
@@ -101,11 +105,18 @@ impl<A: ApplyConfig> Config<A> {
     sdk_directory: &Path,
     apply_config: A,
     time_provider: Arc<dyn TimeProvider>,
+    sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
   ) -> Self {
     Self {
-      file_cache: SafeFileCache::new_with_time_provider("config", sdk_directory, time_provider),
+      file_cache: SafeFileCache::new_with_time_provider(
+        "config",
+        sdk_directory,
+        time_provider.clone(),
+      ),
       configuration_version_id: Mutex::default(),
       apply_config,
+      time_provider,
+      sdk_status_tracker,
     }
   }
 
@@ -148,12 +159,20 @@ impl<A: ApplyConfig> Config<A> {
     // TODO(snowp): Consider storing an intermediate format to avoid all the error checking
     // above on re-read.
     // If we fail writing to disk, move on. We'll continue to operate without disk caching.
-    self
+    let result = self
       .file_cache
       .cache_update(compressed_protobuf, &version_nonce, async move {
         self.process_configuration_update_inner(update, false).await
       })
-      .await
+      .await;
+
+    if result.is_ok() {
+      self
+        .sdk_status_tracker
+        .record_config_delivery(self.time_provider.now());
+    }
+
+    result
   }
 
   // Attempts to load persisted config and apply as if it was a newly received configuration.

--- a/bd-logger/src/client_config.rs
+++ b/bd-logger/src/client_config.rs
@@ -183,14 +183,6 @@ impl<A: ApplyConfig> Config<A> {
         .process_configuration_update_inner(configuration_update, true)
         .await;
 
-      if maybe_nack.is_ok() {
-        // Record config delivery so the SDK status reflects that we have
-        // a working config even if we never reach the server.
-        self
-          .sdk_status_tracker
-          .record_config_delivery(self.time_provider.now());
-      }
-
       // We should never persist config that results in a Nack, but if we do we effectively drop
       // the config on startup as the above function won't write it back.
       debug_assert!(maybe_nack.is_ok());
@@ -248,6 +240,9 @@ impl<A: ApplyConfig + Send + Sync> bd_client_common::ClientConfigurationUpdate f
   async fn on_handshake_complete(&self, configuration_update_status: u32) {
     if configuration_update_status & HANDSHAKE_FLAG_CONFIG_UP_TO_DATE != 0 {
       self.file_cache.mark_safe().await;
+      self
+        .sdk_status_tracker
+        .record_config_delivery(self.time_provider.now());
     }
   }
 

--- a/bd-logger/src/client_config.rs
+++ b/bd-logger/src/client_config.rs
@@ -183,6 +183,14 @@ impl<A: ApplyConfig> Config<A> {
         .process_configuration_update_inner(configuration_update, true)
         .await;
 
+      if maybe_nack.is_ok() {
+        // Record config delivery so the SDK status reflects that we have
+        // a working config even if we never reach the server.
+        self
+          .sdk_status_tracker
+          .record_config_delivery(self.time_provider.now());
+      }
+
       // We should never persist config that results in a Nack, but if we do we effectively drop
       // the config on startup as the above function won't write it back.
       debug_assert!(maybe_nack.is_ok());

--- a/bd-logger/src/client_config_test.rs
+++ b/bd-logger/src/client_config_test.rs
@@ -8,6 +8,7 @@
 use super::{Config, Configuration};
 use anyhow::anyhow;
 use bd_client_common::safe_file_cache::load_cache_retry_count_from_file;
+use bd_client_common::sdk_status::SdkStatusTracker;
 use bd_client_common::{ClientConfigurationUpdate, HANDSHAKE_FLAG_CONFIG_UP_TO_DATE};
 use bd_proto::protos::client::api::ConfigurationUpdate;
 use bd_proto::protos::client::api::configuration_update::{StateOfTheWorld, Update_type};
@@ -131,4 +132,39 @@ async fn load_malformed_file() {
 
   // Validate that we remove the file if it fails decoding.
   assert!(!config_file.exists());
+}
+
+#[tokio::test]
+async fn load_persisted_config_records_config_delivery() {
+  let directory = TempDir::with_prefix("sdk").unwrap();
+
+  // Persist a config to disk.
+  let (tx, _rx) = channel(2);
+  let config = Config::new(
+    directory.path(),
+    TestUpdate {
+      configuration_tx: tx,
+    },
+  );
+  config
+    .process_configuration_update(configuration_update())
+    .await
+    .unwrap();
+
+  // Simulate restart: fresh tracker, load from cache.
+  let (tx, _rx) = channel(2);
+  let tracker = SdkStatusTracker::new();
+  tracker.record_running();
+  let config = Config::new_with_time_provider(
+    directory.path(),
+    TestUpdate {
+      configuration_tx: tx,
+    },
+    std::sync::Arc::new(bd_time::SystemTimeProvider),
+    tracker.clone(),
+  );
+
+  assert!(tracker.get().last_config_delivery_time.is_none());
+  config.try_load_persisted_config_helper().await;
+  assert!(tracker.get().last_config_delivery_time.is_some());
 }

--- a/bd-logger/src/client_config_test.rs
+++ b/bd-logger/src/client_config_test.rs
@@ -135,7 +135,7 @@ async fn load_malformed_file() {
 }
 
 #[tokio::test]
-async fn load_persisted_config_records_config_delivery() {
+async fn load_persisted_config_does_not_record_config_delivery() {
   let directory = TempDir::with_prefix("sdk").unwrap();
 
   // Persist a config to disk.
@@ -166,5 +166,7 @@ async fn load_persisted_config_records_config_delivery() {
 
   assert!(tracker.get().last_config_delivery_time.is_none());
   config.try_load_persisted_config_helper().await;
-  assert!(tracker.get().last_config_delivery_time.is_some());
+  // Config delivery is only recorded when the server confirms via handshake
+  // or sends fresh config, not when loading from cache.
+  assert!(tracker.get().last_config_delivery_time.is_none());
 }

--- a/bd-logger/src/lib.rs
+++ b/bd-logger/src/lib.rs
@@ -45,6 +45,7 @@ pub use crate::logger::{ChannelPair, InitParams};
 pub use async_log_buffer::LogAttributesOverrides;
 pub use bd_api::{PlatformNetworkManager, PlatformNetworkStream};
 use bd_buffer::AbslCode;
+pub use bd_client_common::sdk_status::{SdkState, SdkStatus, SdkStatusTracker};
 pub use bd_device::Device;
 pub use bd_events::ListenerTarget as EventsListenerTarget;
 pub use bd_log_metadata::MetadataProvider;

--- a/bd-logger/src/lib.rs
+++ b/bd-logger/src/lib.rs
@@ -45,7 +45,7 @@ pub use crate::logger::{ChannelPair, InitParams};
 pub use async_log_buffer::LogAttributesOverrides;
 pub use bd_api::{PlatformNetworkManager, PlatformNetworkStream};
 use bd_buffer::AbslCode;
-pub use bd_client_common::sdk_status::{SdkState, SdkStatus, SdkStatusTracker};
+pub use bd_client_common::sdk_status::{InitializationState, SdkStatus, SdkStatusTracker};
 pub use bd_device::Device;
 pub use bd_events::ListenerTarget as EventsListenerTarget;
 pub use bd_log_metadata::MetadataProvider;

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -600,6 +600,8 @@ pub struct Logger {
 
   sleep_mode_active: watch::Sender<bool>,
   is_tracing_active: Arc<AtomicBool>,
+
+  sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
 }
 
 impl Logger {
@@ -617,6 +619,7 @@ impl Logger {
     pending_entity_id: Arc<Mutex<Option<PendingEntityIdUpdate>>>,
     sleep_mode_active: watch::Sender<bool>,
     is_tracing_active: Arc<AtomicBool>,
+    sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
   ) -> Self {
     let stats = Stats::new(&stats_scope);
 
@@ -638,7 +641,14 @@ impl Logger {
       pending_entity_id,
       sleep_mode_active,
       is_tracing_active,
+      sdk_status_tracker,
     }
+  }
+
+  /// Returns a point-in-time snapshot of the SDK's operational status.
+  #[must_use]
+  pub fn get_sdk_status(&self) -> bd_client_common::sdk_status::SdkStatus {
+    self.sdk_status_tracker.get()
   }
 
   /// Create the SDK and corresponding buffer directory if it doesn't already exist.


### PR DESCRIPTION
## What

Part of BIT-8084

Exposes an snapshopt of the sdk status containing :

```
/// The SDK's initialization state.
pub enum InitializationState {
  /// The SDK has not been started yet.
  NotStarted = 0,
  /// The SDK library has been loaded and the logger is being constructed,
  /// but log processing has not yet begun.
  Loaded     = 1,
  /// The SDK is fully running and processing logs.
  Running    = 2,
  /// The SDK has been force-disabled by the server (e.g., authentication failure).
  Disabled   = 3,
}

/// A point-in-time snapshot of the SDK's operational status.
pub struct SdkStatus {
  /// The current initialization state of the SDK.
  pub initialization_state: InitializationState,

  /// The wall-clock time of the last successful handshake, if any.
  pub last_handshake_time: Option<OffsetDateTime>,

  /// The wall-clock time of the last successful config delivery from the backend, if any.
  pub last_config_delivery_time: Option<OffsetDateTime>,
}
```

## Verification

Verified with sample apps (Android/iOS) in the integration PR https://github.com/bitdriftlabs/capture-sdk/pull/984