### PR TITLE
Allow CRASH_LOOP_BYPASS_TIMEOUT_SECONDS to be configurable

### DIFF
--- a/bd-client-common/src/safe_file_cache.rs
+++ b/bd-client-common/src/safe_file_cache.rs
@@ -18,9 +18,11 @@ use protobuf::Message;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use time::Duration;
+use tokio::sync::watch;
 
 const MAX_RETRY_COUNT: u8 = 5;
-const CRASH_LOOP_BYPASS_TIMEOUT_SECONDS: i64 = 4 * 60 * 60;
+pub const DEFAULT_CRASH_LOOP_BYPASS_TIMEOUT_SECONDS: i64 = 4 * 60 * 60;
 
 #[bd_macros::proto_serializable]
 #[derive(Debug, Clone, Default)]
@@ -55,6 +57,7 @@ pub struct SafeFileCache<T> {
   locked_state: Mutex<LockedState>,
   name: &'static str,
   time_provider: Arc<dyn TimeProvider>,
+  crash_loop_bypass_timeout: watch::Receiver<Duration>,
   phantom: PhantomData<T>,
 }
 #[derive(Default)]
@@ -75,6 +78,21 @@ impl<T: Message> SafeFileCache<T> {
     sdk_directory: &Path,
     time_provider: Arc<dyn TimeProvider>,
   ) -> Self {
+    Self::new_with_time_provider_and_crash_loop_bypass_timeout(
+      name,
+      sdk_directory,
+      time_provider,
+      watch::channel(Duration::seconds(DEFAULT_CRASH_LOOP_BYPASS_TIMEOUT_SECONDS)).1,
+    )
+  }
+
+  #[must_use]
+  pub fn new_with_time_provider_and_crash_loop_bypass_timeout(
+    name: &'static str,
+    sdk_directory: &Path,
+    time_provider: Arc<dyn TimeProvider>,
+    crash_loop_bypass_timeout: watch::Receiver<Duration>,
+  ) -> Self {
     // Create the directory if it doesn't exist.
     let directory = sdk_directory.join(name);
     log::debug!(
@@ -88,6 +106,7 @@ impl<T: Message> SafeFileCache<T> {
       directory,
       locked_state: Mutex::default(),
       time_provider,
+      crash_loop_bypass_timeout,
       phantom: PhantomData,
     }
   }
@@ -272,8 +291,9 @@ impl<T: Message> SafeFileCache<T> {
     self.time_provider.now().unix_timestamp()
   }
 
-  fn is_bypass_elapsed(last_successful_cache_at: i64, now_unix_seconds: i64) -> bool {
-    now_unix_seconds.saturating_sub(last_successful_cache_at) >= CRASH_LOOP_BYPASS_TIMEOUT_SECONDS
+  fn is_bypass_elapsed(&self, last_successful_cache_at: i64, now_unix_seconds: i64) -> bool {
+    now_unix_seconds.saturating_sub(last_successful_cache_at)
+      >= self.crash_loop_bypass_timeout.borrow().whole_seconds()
   }
 
   pub async fn cache_update(
@@ -288,7 +308,7 @@ impl<T: Message> SafeFileCache<T> {
       let in_suspected_crash_loop = state.state.retry_count >= MAX_RETRY_COUNT.into();
       let same_nonce = state.state.last_nonce == version_nonce.as_bytes();
       let bypassed_due_to_elapsed =
-        Self::is_bypass_elapsed(state.state.last_successful_cache_at, now_unix_seconds);
+        self.is_bypass_elapsed(state.state.last_successful_cache_at, now_unix_seconds);
 
       (
         in_suspected_crash_loop && same_nonce && !bypassed_due_to_elapsed,

--- a/bd-client-common/src/safe_file_cache_test.rs
+++ b/bd-client-common/src/safe_file_cache_test.rs
@@ -7,8 +7,8 @@
 
 use crate::file::{read_checksummed_data, write_compressed_protobuf};
 use crate::safe_file_cache::{
-  CRASH_LOOP_BYPASS_TIMEOUT_SECONDS,
   CacheState,
+  DEFAULT_CRASH_LOOP_BYPASS_TIMEOUT_SECONDS,
   MAX_RETRY_COUNT,
   SafeFileCache,
 };
@@ -19,6 +19,7 @@ use protobuf::Message;
 use std::sync::Arc;
 use tempfile::tempdir;
 use time::{Duration, OffsetDateTime};
+use tokio::sync::watch;
 
 #[tokio::test]
 async fn basic_flow() {
@@ -124,7 +125,9 @@ async fn same_nonce_allowed_after_bypass_timeout() {
   assert!(cache.handle_cached_config().await.is_none());
 
   // Simulate enough wall-clock time passing since the last successful cache write.
-  time_provider.advance(Duration::seconds(CRASH_LOOP_BYPASS_TIMEOUT_SECONDS + 1));
+  time_provider.advance(Duration::seconds(
+    DEFAULT_CRASH_LOOP_BYPASS_TIMEOUT_SECONDS + 1,
+  ));
 
   let cache = SafeFileCache::<ClientKillFile>::new_with_time_provider(
     "test",
@@ -196,6 +199,73 @@ async fn same_nonce_allowed_after_bypass_timeout() {
       .to_string(),
     "refusing to cache config during suspected crash loop with no nonce change"
   );
+}
+
+#[tokio::test]
+async fn same_nonce_allowed_after_configured_bypass_timeout() {
+  let tempdir = tempdir().unwrap();
+  let time_provider = Arc::new(TestTimeProvider::new(OffsetDateTime::UNIX_EPOCH));
+  let (timeout_tx, timeout_rx) = watch::channel(Duration::minutes(10));
+  let cache = SafeFileCache::<ClientKillFile>::new_with_time_provider_and_crash_loop_bypass_timeout(
+    "test",
+    tempdir.path(),
+    time_provider.clone(),
+    timeout_rx.clone(),
+  );
+  cache
+    .cache_update(
+      write_compressed_protobuf(ClientKillFile::default_instance()).unwrap(),
+      "123",
+      async { Ok(()) },
+    )
+    .await
+    .unwrap();
+
+  for _i in 0 .. MAX_RETRY_COUNT {
+    let cache =
+      SafeFileCache::<ClientKillFile>::new_with_time_provider_and_crash_loop_bypass_timeout(
+        "test",
+        tempdir.path(),
+        time_provider.clone(),
+        timeout_rx.clone(),
+      );
+    assert_eq!(
+      ClientKillFile::default(),
+      cache.handle_cached_config().await.unwrap()
+    );
+  }
+
+  let cache = SafeFileCache::<ClientKillFile>::new_with_time_provider_and_crash_loop_bypass_timeout(
+    "test",
+    tempdir.path(),
+    time_provider.clone(),
+    timeout_rx,
+  );
+  assert!(cache.handle_cached_config().await.is_none());
+
+  time_provider.advance(Duration::minutes(9));
+  assert_eq!(
+    cache
+      .cache_update(
+        write_compressed_protobuf(ClientKillFile::default_instance()).unwrap(),
+        "123",
+        async { panic!() },
+      )
+      .await
+      .unwrap_err()
+      .to_string(),
+    "refusing to cache config during suspected crash loop with no nonce change"
+  );
+
+  timeout_tx.send_replace(Duration::minutes(5));
+  cache
+    .cache_update(
+      write_compressed_protobuf(ClientKillFile::default_instance()).unwrap(),
+      "123",
+      async { Ok(()) },
+    )
+    .await
+    .unwrap();
 }
 
 async fn load_cache_state(cache: &SafeFileCache<ClientKillFile>) -> CacheState {

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -551,6 +551,9 @@ impl LoggerBuilder {
         ),
         time_provider.clone(),
         sdk_status_tracker.clone(),
+        runtime_loader
+          .register_duration_watch::<bd_runtime::runtime::safe_file_cache::CrashLoopBypassTimeout>()
+          .into_inner(),
       ));
 
       let api = bd_api::api::Api::new(

--- a/bd-logger/src/client_config.rs
+++ b/bd-logger/src/client_config.rs
@@ -42,7 +42,9 @@ use parking_lot::Mutex;
 use protobuf::Chars;
 use std::path::Path;
 use std::sync::Arc;
+use time::Duration;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::watch;
 
 // Helper trait to make it easier to test the internals without having to broadcast to an actual
 // logger.
@@ -99,6 +101,10 @@ impl<A: ApplyConfig> Config<A> {
       apply_config,
       Arc::new(bd_time::SystemTimeProvider),
       bd_client_common::sdk_status::SdkStatusTracker::new(),
+      watch::channel(Duration::seconds(
+        bd_client_common::safe_file_cache::DEFAULT_CRASH_LOOP_BYPASS_TIMEOUT_SECONDS,
+      ))
+      .1,
     )
   }
 
@@ -107,12 +113,14 @@ impl<A: ApplyConfig> Config<A> {
     apply_config: A,
     time_provider: Arc<dyn TimeProvider>,
     sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
+    crash_loop_bypass_timeout: watch::Receiver<Duration>,
   ) -> Self {
     Self {
-      file_cache: SafeFileCache::new_with_time_provider(
+      file_cache: SafeFileCache::new_with_time_provider_and_crash_loop_bypass_timeout(
         "config",
         sdk_directory,
         time_provider.clone(),
+        crash_loop_bypass_timeout,
       ),
       configuration_version_id: Mutex::default(),
       apply_config,

--- a/bd-logger/src/client_config_test.rs
+++ b/bd-logger/src/client_config_test.rs
@@ -162,6 +162,10 @@ async fn load_persisted_config_does_not_record_config_delivery() {
     },
     std::sync::Arc::new(bd_time::SystemTimeProvider),
     tracker.clone(),
+    tokio::sync::watch::channel(time::Duration::seconds(
+      bd_client_common::safe_file_cache::DEFAULT_CRASH_LOOP_BYPASS_TIMEOUT_SECONDS,
+    ))
+    .1,
   );
 
   assert!(tracker.get().last_config_delivery_time.is_none());

--- a/bd-runtime/src/runtime.rs
+++ b/bd-runtime/src/runtime.rs
@@ -782,6 +782,17 @@ pub mod client_kill {
   );
 }
 
+pub mod safe_file_cache {
+  use bd_client_common::safe_file_cache::DEFAULT_CRASH_LOOP_BYPASS_TIMEOUT_SECONDS;
+  use time::ext::NumericalDuration as _;
+
+  duration_feature_flag!(
+    CrashLoopBypassTimeout,
+    "safe_file_cache.crash_loop_bypass_timeout_ms",
+    DEFAULT_CRASH_LOOP_BYPASS_TIMEOUT_SECONDS.seconds()
+  );
+}
+
 pub mod resource_utilization {
   use time::ext::NumericalDuration as _;
 


### PR DESCRIPTION
Resolves BIT-8645

Allowing to configured CRASH_LOOP_BYPASS_TIMEOUT_SECONDS via shard config flag `safe_file_cache.crash_loop_bypass_timeout_ms`

Verified with `gradle-test-app`. See session [here](https://timeline.bitdrift.dev/session/ab56709c-ad0b-4d63-9872-8e3d5a6f44ea?utm_source=sdk)