### PR TITLE
add manual serde bindings to report models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "protobuf 4.0.0-alpha.0",
  "protobuf-codegen",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/bd-proto/Cargo.toml
+++ b/bd-proto/Cargo.toml
@@ -17,7 +17,8 @@ protobuf.workspace          = true
 serde.workspace             = true
 
 [dev-dependencies]
-matches.workspace = true
+matches.workspace           = true
+serde_json.workspace        = true
 
 [build-dependencies]
 flatc-rust.workspace       = true

--- a/bd-proto/build.rs
+++ b/bd-proto/build.rs
@@ -115,7 +115,7 @@ fn main() {
     ],
     includes: &[Path::new("../api/src")],
     out_dir: Path::new("src/flatbuffers"),
-    extra: &["--gen-object-api", "--rust-serialize"],
+    extra: &["--gen-object-api"],
     ..flatc_rust::Args::default()
   })
   .unwrap();
@@ -126,7 +126,7 @@ fn main() {
     ],
     includes: &[Path::new("../api/src")],
     out_dir: Path::new("src/flatbuffers"),
-    extra: &["--gen-object-api", "--rust-serialize"],
+    extra: &["--gen-object-api"],
     ..flatc_rust::Args::default()
   })
   .unwrap();

--- a/bd-proto/src/flatbuffers/buffer_log_generated.rs
+++ b/bd-proto/src/flatbuffers/buffer_log_generated.rs
@@ -7,9 +7,6 @@ use crate::common_generated::*;
 use core::mem;
 use core::cmp::Ordering;
 
-extern crate serde;
-use self::serde::ser::{Serialize, Serializer, SerializeStruct};
-
 extern crate flatbuffers;
 use self::flatbuffers::{EndianScalar, Follow};
 
@@ -20,9 +17,6 @@ pub mod bitdrift_public {
   use core::mem;
   use core::cmp::Ordering;
 
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
-
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
 #[allow(unused_imports, dead_code)]
@@ -31,9 +25,6 @@ pub mod fbs {
   use crate::common_generated::*;
   use core::mem;
   use core::cmp::Ordering;
-
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
 
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
@@ -44,9 +35,6 @@ pub mod logging {
   use core::mem;
   use core::cmp::Ordering;
 
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
-
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
 #[allow(unused_imports, dead_code)]
@@ -55,9 +43,6 @@ pub mod v_1 {
   use crate::common_generated::*;
   use core::mem;
   use core::cmp::Ordering;
-
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
 
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
@@ -133,15 +118,6 @@ impl core::fmt::Debug for LogType {
     }
   }
 }
-impl Serialize for LogType {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("LogType", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for LogType {
   type Inner = Self;
   #[inline]
@@ -419,58 +395,6 @@ impl<'a> Default for LogArgs<'a> {
       log_type: LogType::Normal,
       stream_ids: None,
     }
-  }
-}
-
-impl Serialize for Log<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("Log", 9)?;
-      s.serialize_field("log_level", &self.log_level())?;
-      s.serialize_field("message_type", &self.message_type())?;
-      match self.message_type() {
-        super::super::common::v_1::Data::NONE => (),
-          super::super::common::v_1::Data::string_data => {
-            let f = self.message_as_string_data()
-              .expect("Invalid union table, expected `super::super::common::v_1::Data::string_data`.");
-            s.serialize_field("message", &f)?;
-          }
-          super::super::common::v_1::Data::binary_data => {
-            let f = self.message_as_binary_data()
-              .expect("Invalid union table, expected `super::super::common::v_1::Data::binary_data`.");
-            s.serialize_field("message", &f)?;
-          }
-        _ => unimplemented!(),
-      }
-      if let Some(f) = self.fields() {
-        s.serialize_field("fields", &f)?;
-      } else {
-        s.skip_field("fields")?;
-      }
-      if let Some(f) = self.session_id() {
-        s.serialize_field("session_id", &f)?;
-      } else {
-        s.skip_field("session_id")?;
-      }
-      if let Some(f) = self.timestamp() {
-        s.serialize_field("timestamp", &f)?;
-      } else {
-        s.skip_field("timestamp")?;
-      }
-      if let Some(f) = self.workflow_action_ids() {
-        s.serialize_field("workflow_action_ids", &f)?;
-      } else {
-        s.skip_field("workflow_action_ids")?;
-      }
-      s.serialize_field("log_type", &self.log_type())?;
-      if let Some(f) = self.stream_ids() {
-        s.serialize_field("stream_ids", &f)?;
-      } else {
-        s.skip_field("stream_ids")?;
-      }
-    s.end()
   }
 }
 

--- a/bd-proto/src/flatbuffers/common_generated.rs
+++ b/bd-proto/src/flatbuffers/common_generated.rs
@@ -6,9 +6,6 @@
 use core::mem;
 use core::cmp::Ordering;
 
-extern crate serde;
-use self::serde::ser::{Serialize, Serializer, SerializeStruct};
-
 extern crate flatbuffers;
 use self::flatbuffers::{EndianScalar, Follow};
 
@@ -18,9 +15,6 @@ pub mod bitdrift_public {
   use core::mem;
   use core::cmp::Ordering;
 
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
-
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
 #[allow(unused_imports, dead_code)]
@@ -28,9 +22,6 @@ pub mod fbs {
 
   use core::mem;
   use core::cmp::Ordering;
-
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
 
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
@@ -40,9 +31,6 @@ pub mod common {
   use core::mem;
   use core::cmp::Ordering;
 
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
-
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
 #[allow(unused_imports, dead_code)]
@@ -50,9 +38,6 @@ pub mod v_1 {
 
   use core::mem;
   use core::cmp::Ordering;
-
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
 
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
@@ -104,15 +89,6 @@ impl core::fmt::Debug for Data {
     }
   }
 }
-impl Serialize for Data {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("Data", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for Data {
   type Inner = Self;
   #[inline]
@@ -303,17 +279,6 @@ impl<'a> Default for StringDataArgs<'a> {
   }
 }
 
-impl Serialize for StringData<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("StringData", 1)?;
-      s.serialize_field("data", &self.data())?;
-    s.end()
-  }
-}
-
 pub struct StringDataBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -460,22 +425,6 @@ impl<'a> Default for BinaryDataArgs<'a> {
       data_type: None,
       data: None, // required field
     }
-  }
-}
-
-impl Serialize for BinaryData<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("BinaryData", 2)?;
-      if let Some(f) = self.data_type() {
-        s.serialize_field("data_type", &f)?;
-      } else {
-        s.skip_field("data_type")?;
-      }
-      s.serialize_field("data", &self.data())?;
-    s.end()
   }
 }
 
@@ -695,32 +644,6 @@ impl<'a> Default for FieldArgs<'a> {
   }
 }
 
-impl Serialize for Field<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("Field", 3)?;
-      s.serialize_field("key", &self.key())?;
-      s.serialize_field("value_type", &self.value_type())?;
-      match self.value_type() {
-        Data::NONE => (),
-          Data::string_data => {
-            let f = self.value_as_string_data()
-              .expect("Invalid union table, expected `Data::string_data`.");
-            s.serialize_field("value", &f)?;
-          }
-          Data::binary_data => {
-            let f = self.value_as_binary_data()
-              .expect("Invalid union table, expected `Data::binary_data`.");
-            s.serialize_field("value", &f)?;
-          }
-        _ => unimplemented!(),
-      }
-    s.end()
-  }
-}
-
 pub struct FieldBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -898,18 +821,6 @@ impl<'a> Default for TimestampArgs {
       seconds: 0,
       nanos: 0,
     }
-  }
-}
-
-impl Serialize for Timestamp<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("Timestamp", 2)?;
-      s.serialize_field("seconds", &self.seconds())?;
-      s.serialize_field("nanos", &self.nanos())?;
-    s.end()
   }
 }
 

--- a/bd-proto/src/flatbuffers/common_serialize.rs
+++ b/bd-proto/src/flatbuffers/common_serialize.rs
@@ -1,0 +1,73 @@
+use crate::common_generated::common::v_1::{BinaryData, Data, Field, StringData, Timestamp};
+use crate::flatbuffers::serialize_enum;
+extern crate serde;
+use self::serde::ser::{Serialize, SerializeStruct, Serializer};
+
+serialize_enum!(Data);
+
+impl Serialize for StringData<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("StringData", 1)?;
+    s.serialize_field("data", &self.data())?;
+    s.end()
+  }
+}
+
+impl Serialize for BinaryData<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("BinaryData", 2)?;
+    if let Some(f) = self.data_type() {
+      s.serialize_field("data_type", &f)?;
+    } else {
+      s.skip_field("data_type")?;
+    }
+    s.serialize_field("data", &self.data())?;
+    s.end()
+  }
+}
+
+impl Serialize for Field<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("Field", 3)?;
+    s.serialize_field("key", &self.key())?;
+    s.serialize_field("value_type", &self.value_type())?;
+    match self.value_type() {
+      Data::NONE => (),
+      Data::string_data => {
+        let f = self
+          .value_as_string_data()
+          .expect("Invalid union table, expected `Data::string_data`.");
+        s.serialize_field("value", &f)?;
+      },
+      Data::binary_data => {
+        let f = self
+          .value_as_binary_data()
+          .expect("Invalid union table, expected `Data::binary_data`.");
+        s.serialize_field("value", &f)?;
+      },
+      _ => unimplemented!(),
+    }
+    s.end()
+  }
+}
+
+impl Serialize for Timestamp<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("Timestamp", 2)?;
+    s.serialize_field("seconds", &self.seconds())?;
+    s.serialize_field("nanos", &self.nanos())?;
+    s.end()
+  }
+}

--- a/bd-proto/src/flatbuffers/common_serialize.rs
+++ b/bd-proto/src/flatbuffers/common_serialize.rs
@@ -1,3 +1,10 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 use crate::common_generated::common::v_1::{BinaryData, Data, Field, StringData, Timestamp};
 use crate::flatbuffers::serialize_enum;
 extern crate serde;

--- a/bd-proto/src/flatbuffers/common_serialize.rs
+++ b/bd-proto/src/flatbuffers/common_serialize.rs
@@ -10,7 +10,7 @@ use crate::flatbuffers::serialize_enum;
 extern crate serde;
 use self::serde::ser::{Serialize, SerializeStruct, Serializer};
 
-serialize_enum!(Data);
+serialize_enum!(Data, serialize_u8);
 
 impl Serialize for StringData<'_> {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/bd-proto/src/flatbuffers/mod.rs
+++ b/bd-proto/src/flatbuffers/mod.rs
@@ -28,6 +28,7 @@ pub mod buffer_log;
   clippy::empty_line_after_outer_attr
 )]
 pub mod report;
+mod report_serialize;
 
 #[path = "common_generated.rs"]
 #[allow(clippy::all, clippy::use_self)]
@@ -40,3 +41,19 @@ pub mod report;
   clippy::empty_line_after_outer_attr
 )]
 pub mod common;
+mod common_serialize;
+
+macro_rules! serialize_enum {
+  ($name:ident) => {
+    impl Serialize for $name {
+      fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+      where
+        S: Serializer,
+      {
+        serializer.serialize_u32(self.0 as u32)
+      }
+    }
+  };
+}
+
+pub(crate) use serialize_enum;

--- a/bd-proto/src/flatbuffers/mod.rs
+++ b/bd-proto/src/flatbuffers/mod.rs
@@ -44,13 +44,13 @@ pub mod common;
 mod common_serialize;
 
 macro_rules! serialize_enum {
-  ($name:ident) => {
+  ($name:ident, $serializer:ident) => {
     impl Serialize for $name {
       fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
       where
         S: Serializer,
       {
-        serializer.serialize_u32(self.0 as u32)
+        serializer.$serializer(self.0)
       }
     }
   };

--- a/bd-proto/src/flatbuffers/report_generated.rs
+++ b/bd-proto/src/flatbuffers/report_generated.rs
@@ -7,9 +7,6 @@ use crate::common_generated::*;
 use core::mem;
 use core::cmp::Ordering;
 
-extern crate serde;
-use self::serde::ser::{Serialize, Serializer, SerializeStruct};
-
 extern crate flatbuffers;
 use self::flatbuffers::{EndianScalar, Follow};
 
@@ -20,9 +17,6 @@ pub mod bitdrift_public {
   use core::mem;
   use core::cmp::Ordering;
 
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
-
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
 #[allow(unused_imports, dead_code)]
@@ -31,9 +25,6 @@ pub mod fbs {
   use crate::common_generated::*;
   use core::mem;
   use core::cmp::Ordering;
-
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
 
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
@@ -44,9 +35,6 @@ pub mod issue_reporting {
   use core::mem;
   use core::cmp::Ordering;
 
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
-
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
 #[allow(unused_imports, dead_code)]
@@ -55,9 +43,6 @@ pub mod v_1 {
   use crate::common_generated::*;
   use core::mem;
   use core::cmp::Ordering;
-
-  extern crate serde;
-  use self::serde::ser::{Serialize, Serializer, SerializeStruct};
 
   extern crate flatbuffers;
   use self::flatbuffers::{EndianScalar, Follow};
@@ -133,15 +118,6 @@ impl core::fmt::Debug for ReportType {
     }
   }
 }
-impl Serialize for ReportType {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("ReportType", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for ReportType {
   type Inner = Self;
   #[inline]
@@ -235,15 +211,6 @@ impl core::fmt::Debug for Platform {
     }
   }
 }
-impl Serialize for Platform {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("Platform", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for Platform {
   type Inner = Self;
   #[inline]
@@ -341,15 +308,6 @@ impl core::fmt::Debug for Architecture {
     }
   }
 }
-impl Serialize for Architecture {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("Architecture", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for Architecture {
   type Inner = Self;
   #[inline]
@@ -447,15 +405,6 @@ impl core::fmt::Debug for FrameType {
     }
   }
 }
-impl Serialize for FrameType {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("FrameType", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for FrameType {
   type Inner = Self;
   #[inline]
@@ -537,15 +486,6 @@ impl core::fmt::Debug for ErrorRelation {
     }
   }
 }
-impl Serialize for ErrorRelation {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("ErrorRelation", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for ErrorRelation {
   type Inner = Self;
   #[inline]
@@ -643,15 +583,6 @@ impl core::fmt::Debug for PowerState {
     }
   }
 }
-impl Serialize for PowerState {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("PowerState", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for PowerState {
   type Inner = Self;
   #[inline]
@@ -745,15 +676,6 @@ impl core::fmt::Debug for NetworkState {
     }
   }
 }
-impl Serialize for NetworkState {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("NetworkState", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for NetworkState {
   type Inner = Self;
   #[inline]
@@ -843,15 +765,6 @@ impl core::fmt::Debug for JavaScriptEngine {
     }
   }
 }
-impl Serialize for JavaScriptEngine {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("JavaScriptEngine", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for JavaScriptEngine {
   type Inner = Self;
   #[inline]
@@ -945,15 +858,6 @@ impl core::fmt::Debug for MemoryPressureLevel {
     }
   }
 }
-impl Serialize for MemoryPressureLevel {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("MemoryPressureLevel", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for MemoryPressureLevel {
   type Inner = Self;
   #[inline]
@@ -1051,15 +955,6 @@ impl core::fmt::Debug for Rotation {
     }
   }
 }
-impl Serialize for Rotation {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("Rotation", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for Rotation {
   type Inner = Self;
   #[inline]
@@ -1157,15 +1052,6 @@ impl core::fmt::Debug for FrameStatus {
     }
   }
 }
-impl Serialize for FrameStatus {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    serializer.serialize_unit_variant("FrameStatus", self.0 as u32, self.variant_name().unwrap())
-  }
-}
-
 impl<'a> flatbuffers::Follow<'a> for FrameStatus {
   type Inner = Self;
   #[inline]
@@ -1261,18 +1147,6 @@ impl<'a> flatbuffers::Verifiable for Timestamp {
   ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
     use self::flatbuffers::Verifiable;
     v.in_buffer::<Self>(pos)
-  }
-}
-
-impl Serialize for Timestamp {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("Timestamp", 2)?;
-      s.serialize_field("seconds", &self.seconds())?;
-      s.serialize_field("nanos", &self.nanos())?;
-    s.end()
   }
 }
 
@@ -1422,19 +1296,6 @@ impl<'a> flatbuffers::Verifiable for Memory {
   ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
     use self::flatbuffers::Verifiable;
     v.in_buffer::<Self>(pos)
-  }
-}
-
-impl Serialize for Memory {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("Memory", 3)?;
-      s.serialize_field("total", &self.total())?;
-      s.serialize_field("free", &self.free())?;
-      s.serialize_field("used", &self.used())?;
-    s.end()
   }
 }
 
@@ -1652,22 +1513,6 @@ impl<'a> Default for AppBuildNumberArgs<'a> {
   }
 }
 
-impl Serialize for AppBuildNumber<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("AppBuildNumber", 2)?;
-      s.serialize_field("version_code", &self.version_code())?;
-      if let Some(f) = self.cf_bundle_version() {
-        s.serialize_field("cf_bundle_version", &f)?;
-      } else {
-        s.skip_field("cf_bundle_version")?;
-      }
-    s.end()
-  }
-}
-
 pub struct AppBuildNumberBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -1816,18 +1661,6 @@ impl<'a> Default for ProcessorUsageArgs {
       duration_seconds: 0,
       used_percent: 0,
     }
-  }
-}
-
-impl Serialize for ProcessorUsage<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("ProcessorUsage", 2)?;
-      s.serialize_field("duration_seconds", &self.duration_seconds())?;
-      s.serialize_field("used_percent", &self.used_percent())?;
-    s.end()
   }
 }
 
@@ -2122,59 +1955,6 @@ impl<'a> Default for AppMetricsArgs<'a> {
   }
 }
 
-impl Serialize for AppMetrics<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("AppMetrics", 11)?;
-      if let Some(f) = self.app_id() {
-        s.serialize_field("app_id", &f)?;
-      } else {
-        s.skip_field("app_id")?;
-      }
-      if let Some(f) = self.memory() {
-        s.serialize_field("memory", &f)?;
-      } else {
-        s.skip_field("memory")?;
-      }
-      if let Some(f) = self.version() {
-        s.serialize_field("version", &f)?;
-      } else {
-        s.skip_field("version")?;
-      }
-      if let Some(f) = self.build_number() {
-        s.serialize_field("build_number", &f)?;
-      } else {
-        s.skip_field("build_number")?;
-      }
-      if let Some(f) = self.running_state() {
-        s.serialize_field("running_state", &f)?;
-      } else {
-        s.skip_field("running_state")?;
-      }
-      s.serialize_field("process_id", &self.process_id())?;
-      if let Some(f) = self.region_format() {
-        s.serialize_field("region_format", &f)?;
-      } else {
-        s.skip_field("region_format")?;
-      }
-      if let Some(f) = self.cpu_usage() {
-        s.serialize_field("cpu_usage", &f)?;
-      } else {
-        s.skip_field("cpu_usage")?;
-      }
-      if let Some(f) = self.lifecycle_event() {
-        s.serialize_field("lifecycle_event", &f)?;
-      } else {
-        s.skip_field("lifecycle_event")?;
-      }
-      s.serialize_field("javascript_engine", &self.javascript_engine())?;
-      s.serialize_field("memory_pressure_level", &self.memory_pressure_level())?;
-    s.end()
-  }
-}
-
 pub struct AppMetricsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -2456,36 +2236,6 @@ impl<'a> Default for OSBuildArgs<'a> {
   }
 }
 
-impl Serialize for OSBuild<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("OSBuild", 4)?;
-      if let Some(f) = self.version() {
-        s.serialize_field("version", &f)?;
-      } else {
-        s.skip_field("version")?;
-      }
-      if let Some(f) = self.brand() {
-        s.serialize_field("brand", &f)?;
-      } else {
-        s.skip_field("brand")?;
-      }
-      if let Some(f) = self.fingerprint() {
-        s.serialize_field("fingerprint", &f)?;
-      } else {
-        s.skip_field("fingerprint")?;
-      }
-      if let Some(f) = self.kern_osversion() {
-        s.serialize_field("kern_osversion", &f)?;
-      } else {
-        s.skip_field("kern_osversion")?;
-      }
-    s.end()
-  }
-}
-
 pub struct OSBuildBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -2661,18 +2411,6 @@ impl<'a> Default for PowerMetricsArgs {
   }
 }
 
-impl Serialize for PowerMetrics<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("PowerMetrics", 2)?;
-      s.serialize_field("power_state", &self.power_state())?;
-      s.serialize_field("charge_percent", &self.charge_percent())?;
-    s.end()
-  }
-}
-
 pub struct PowerMetricsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -2833,19 +2571,6 @@ impl<'a> Default for DisplayArgs {
       width: 0,
       density_dpi: 0,
     }
-  }
-}
-
-impl Serialize for Display<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("Display", 3)?;
-      s.serialize_field("height", &self.height())?;
-      s.serialize_field("width", &self.width())?;
-      s.serialize_field("density_dpi", &self.density_dpi())?;
-    s.end()
   }
 }
 
@@ -3207,67 +2932,6 @@ impl<'a> Default for DeviceMetricsArgs<'a> {
   }
 }
 
-impl Serialize for DeviceMetrics<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("DeviceMetrics", 15)?;
-      if let Some(f) = self.time() {
-        s.serialize_field("time", &f)?;
-      } else {
-        s.skip_field("time")?;
-      }
-      if let Some(f) = self.timezone() {
-        s.serialize_field("timezone", &f)?;
-      } else {
-        s.skip_field("timezone")?;
-      }
-      if let Some(f) = self.power_metrics() {
-        s.serialize_field("power_metrics", &f)?;
-      } else {
-        s.skip_field("power_metrics")?;
-      }
-      s.serialize_field("network_state", &self.network_state())?;
-      s.serialize_field("rotation", &self.rotation())?;
-      s.serialize_field("arch", &self.arch())?;
-      if let Some(f) = self.display() {
-        s.serialize_field("display", &f)?;
-      } else {
-        s.skip_field("display")?;
-      }
-      if let Some(f) = self.manufacturer() {
-        s.serialize_field("manufacturer", &f)?;
-      } else {
-        s.skip_field("manufacturer")?;
-      }
-      if let Some(f) = self.model() {
-        s.serialize_field("model", &f)?;
-      } else {
-        s.skip_field("model")?;
-      }
-      if let Some(f) = self.os_build() {
-        s.serialize_field("os_build", &f)?;
-      } else {
-        s.skip_field("os_build")?;
-      }
-      s.serialize_field("platform", &self.platform())?;
-      if let Some(f) = self.cpu_abis() {
-        s.serialize_field("cpu_abis", &f)?;
-      } else {
-        s.skip_field("cpu_abis")?;
-      }
-      s.serialize_field("low_power_mode_enabled", &self.low_power_mode_enabled())?;
-      if let Some(f) = self.cpu_usage() {
-        s.serialize_field("cpu_usage", &f)?;
-      } else {
-        s.skip_field("cpu_usage")?;
-      }
-      s.serialize_field("thermal_state", &self.thermal_state())?;
-    s.end()
-  }
-}
-
 pub struct DeviceMetricsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -3567,23 +3231,6 @@ impl<'a> Default for SourceFileArgs<'a> {
   }
 }
 
-impl Serialize for SourceFile<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("SourceFile", 3)?;
-      if let Some(f) = self.path() {
-        s.serialize_field("path", &f)?;
-      } else {
-        s.skip_field("path")?;
-      }
-      s.serialize_field("line", &self.line())?;
-      s.serialize_field("column", &self.column())?;
-    s.end()
-  }
-}
-
 pub struct SourceFileBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -3743,22 +3390,6 @@ impl<'a> Default for CPURegisterArgs<'a> {
       name: None,
       value: 0,
     }
-  }
-}
-
-impl Serialize for CPURegister<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("CPURegister", 2)?;
-      if let Some(f) = self.name() {
-        s.serialize_field("name", &f)?;
-      } else {
-        s.skip_field("name")?;
-      }
-      s.serialize_field("value", &self.value())?;
-    s.end()
   }
 }
 
@@ -4094,62 +3725,6 @@ impl<'a> Default for FrameArgs<'a> {
       symbolicated_name: None,
       js_bundle_path: None,
     }
-  }
-}
-
-impl Serialize for Frame<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("Frame", 14)?;
-      s.serialize_field("type_", &self.type_())?;
-      if let Some(f) = self.class_name() {
-        s.serialize_field("class_name", &f)?;
-      } else {
-        s.skip_field("class_name")?;
-      }
-      if let Some(f) = self.symbol_name() {
-        s.serialize_field("symbol_name", &f)?;
-      } else {
-        s.skip_field("symbol_name")?;
-      }
-      if let Some(f) = self.source_file() {
-        s.serialize_field("source_file", &f)?;
-      } else {
-        s.skip_field("source_file")?;
-      }
-      if let Some(f) = self.image_id() {
-        s.serialize_field("image_id", &f)?;
-      } else {
-        s.skip_field("image_id")?;
-      }
-      s.serialize_field("frame_address", &self.frame_address())?;
-      s.serialize_field("symbol_address", &self.symbol_address())?;
-      if let Some(f) = self.registers() {
-        s.serialize_field("registers", &f)?;
-      } else {
-        s.skip_field("registers")?;
-      }
-      if let Some(f) = self.state() {
-        s.serialize_field("state", &f)?;
-      } else {
-        s.skip_field("state")?;
-      }
-      s.serialize_field("frame_status", &self.frame_status())?;
-      s.serialize_field("original_index", &self.original_index())?;
-      s.serialize_field("in_app", &self.in_app())?;
-      if let Some(f) = self.symbolicated_name() {
-        s.serialize_field("symbolicated_name", &f)?;
-      } else {
-        s.skip_field("symbolicated_name")?;
-      }
-      if let Some(f) = self.js_bundle_path() {
-        s.serialize_field("js_bundle_path", &f)?;
-      } else {
-        s.skip_field("js_bundle_path")?;
-      }
-    s.end()
   }
 }
 
@@ -4518,40 +4093,6 @@ impl<'a> Default for ThreadArgs<'a> {
   }
 }
 
-impl Serialize for Thread<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("Thread", 8)?;
-      if let Some(f) = self.name() {
-        s.serialize_field("name", &f)?;
-      } else {
-        s.skip_field("name")?;
-      }
-      s.serialize_field("active", &self.active())?;
-      s.serialize_field("index", &self.index())?;
-      if let Some(f) = self.state() {
-        s.serialize_field("state", &f)?;
-      } else {
-        s.skip_field("state")?;
-      }
-      s.serialize_field("priority", &self.priority())?;
-      s.serialize_field("quality_of_service", &self.quality_of_service())?;
-      if let Some(f) = self.stack_trace() {
-        s.serialize_field("stack_trace", &f)?;
-      } else {
-        s.skip_field("stack_trace")?;
-      }
-      if let Some(f) = self.summary() {
-        s.serialize_field("summary", &f)?;
-      } else {
-        s.skip_field("summary")?;
-      }
-    s.end()
-  }
-}
-
 pub struct ThreadBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -4765,22 +4306,6 @@ impl<'a> Default for ThreadDetailsArgs<'a> {
   }
 }
 
-impl Serialize for ThreadDetails<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("ThreadDetails", 2)?;
-      s.serialize_field("count", &self.count())?;
-      if let Some(f) = self.threads() {
-        s.serialize_field("threads", &f)?;
-      } else {
-        s.skip_field("threads")?;
-      }
-    s.end()
-  }
-}
-
 pub struct ThreadDetailsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -4963,32 +4488,6 @@ impl<'a> Default for ErrorArgs<'a> {
       stack_trace: None,
       relation_to_next: ErrorRelation::CausedBy,
     }
-  }
-}
-
-impl Serialize for Error<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("Error", 4)?;
-      if let Some(f) = self.name() {
-        s.serialize_field("name", &f)?;
-      } else {
-        s.skip_field("name")?;
-      }
-      if let Some(f) = self.reason() {
-        s.serialize_field("reason", &f)?;
-      } else {
-        s.skip_field("reason")?;
-      }
-      if let Some(f) = self.stack_trace() {
-        s.serialize_field("stack_trace", &f)?;
-      } else {
-        s.skip_field("stack_trace")?;
-      }
-      s.serialize_field("relation_to_next", &self.relation_to_next())?;
-    s.end()
   }
 }
 
@@ -5183,27 +4682,6 @@ impl<'a> Default for BinaryImageArgs<'a> {
   }
 }
 
-impl Serialize for BinaryImage<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("BinaryImage", 3)?;
-      if let Some(f) = self.id() {
-        s.serialize_field("id", &f)?;
-      } else {
-        s.skip_field("id")?;
-      }
-      if let Some(f) = self.path() {
-        s.serialize_field("path", &f)?;
-      } else {
-        s.skip_field("path")?;
-      }
-      s.serialize_field("load_address", &self.load_address())?;
-    s.end()
-  }
-}
-
 pub struct BinaryImageBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
@@ -5367,26 +4845,6 @@ impl<'a> Default for SDKInfoArgs<'a> {
       id: None,
       version: None,
     }
-  }
-}
-
-impl Serialize for SDKInfo<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("SDKInfo", 2)?;
-      if let Some(f) = self.id() {
-        s.serialize_field("id", &f)?;
-      } else {
-        s.skip_field("id")?;
-      }
-      if let Some(f) = self.version() {
-        s.serialize_field("version", &f)?;
-      } else {
-        s.skip_field("version")?;
-      }
-    s.end()
   }
 }
 
@@ -5560,31 +5018,6 @@ impl<'a> Default for FeatureFlagArgs<'a> {
       value: None,
       timestamp: None,
     }
-  }
-}
-
-impl Serialize for FeatureFlag<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("FeatureFlag", 3)?;
-      if let Some(f) = self.name() {
-        s.serialize_field("name", &f)?;
-      } else {
-        s.skip_field("name")?;
-      }
-      if let Some(f) = self.value() {
-        s.serialize_field("value", &f)?;
-      } else {
-        s.skip_field("value")?;
-      }
-      if let Some(f) = self.timestamp() {
-        s.serialize_field("timestamp", &f)?;
-      } else {
-        s.skip_field("timestamp")?;
-      }
-    s.end()
   }
 }
 
@@ -5863,57 +5296,6 @@ impl<'a> Default for ReportArgs<'a> {
       state: None,
       feature_flags: None,
     }
-  }
-}
-
-impl Serialize for Report<'_> {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: Serializer,
-  {
-    let mut s = serializer.serialize_struct("Report", 9)?;
-      if let Some(f) = self.sdk() {
-        s.serialize_field("sdk", &f)?;
-      } else {
-        s.skip_field("sdk")?;
-      }
-      s.serialize_field("type_", &self.type_())?;
-      if let Some(f) = self.app_metrics() {
-        s.serialize_field("app_metrics", &f)?;
-      } else {
-        s.skip_field("app_metrics")?;
-      }
-      if let Some(f) = self.device_metrics() {
-        s.serialize_field("device_metrics", &f)?;
-      } else {
-        s.skip_field("device_metrics")?;
-      }
-      if let Some(f) = self.errors() {
-        s.serialize_field("errors", &f)?;
-      } else {
-        s.skip_field("errors")?;
-      }
-      if let Some(f) = self.thread_details() {
-        s.serialize_field("thread_details", &f)?;
-      } else {
-        s.skip_field("thread_details")?;
-      }
-      if let Some(f) = self.binary_images() {
-        s.serialize_field("binary_images", &f)?;
-      } else {
-        s.skip_field("binary_images")?;
-      }
-      if let Some(f) = self.state() {
-        s.serialize_field("state", &f)?;
-      } else {
-        s.skip_field("state")?;
-      }
-      if let Some(f) = self.feature_flags() {
-        s.serialize_field("feature_flags", &f)?;
-      } else {
-        s.skip_field("feature_flags")?;
-      }
-    s.end()
   }
 }
 

--- a/bd-proto/src/flatbuffers/report_serialize.rs
+++ b/bd-proto/src/flatbuffers/report_serialize.rs
@@ -1,3 +1,10 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 #[cfg(test)]
 #[path = "./report_serialize_test.rs"]
 mod test;

--- a/bd-proto/src/flatbuffers/report_serialize.rs
+++ b/bd-proto/src/flatbuffers/report_serialize.rs
@@ -1,0 +1,524 @@
+#[cfg(test)]
+#[path = "./report_serialize_test.rs"]
+mod test;
+
+use crate::flatbuffers::report::bitdrift_public::fbs::issue_reporting::v_1::*;
+use crate::flatbuffers::serialize_enum;
+extern crate serde;
+use self::serde::ser::{Serialize, SerializeStruct, Serializer};
+
+serialize_enum!(ReportType);
+serialize_enum!(Platform);
+serialize_enum!(Architecture);
+serialize_enum!(FrameType);
+serialize_enum!(ErrorRelation);
+serialize_enum!(PowerState);
+serialize_enum!(NetworkState);
+serialize_enum!(JavaScriptEngine);
+serialize_enum!(MemoryPressureLevel);
+serialize_enum!(Rotation);
+serialize_enum!(FrameStatus);
+
+impl Serialize for Timestamp {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("Timestamp", 2)?;
+    s.serialize_field("seconds", &self.seconds())?;
+    s.serialize_field("nanos", &self.nanos())?;
+    s.end()
+  }
+}
+
+impl Serialize for Memory {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("Memory", 3)?;
+    s.serialize_field("total", &self.total())?;
+    s.serialize_field("free", &self.free())?;
+    s.serialize_field("used", &self.used())?;
+    s.end()
+  }
+}
+
+impl Serialize for AppBuildNumber<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("AppBuildNumber", 2)?;
+    if let Some(f) = self.cf_bundle_version() {
+      s.skip_field("version_code")?;
+      s.serialize_field("cf_bundle_version", &f)?;
+    } else {
+      s.serialize_field("version_code", &self.version_code())?;
+      s.skip_field("cf_bundle_version")?;
+    }
+    s.end()
+  }
+}
+
+impl Serialize for ProcessorUsage<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("ProcessorUsage", 2)?;
+    s.serialize_field("duration_seconds", &self.duration_seconds())?;
+    s.serialize_field("used_percent", &self.used_percent())?;
+    s.end()
+  }
+}
+impl Serialize for AppMetrics<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("AppMetrics", 11)?;
+    if let Some(f) = self.app_id() {
+      s.serialize_field("app_id", &f)?;
+    } else {
+      s.skip_field("app_id")?;
+    }
+    if let Some(f) = self.memory() {
+      s.serialize_field("memory", &f)?;
+    } else {
+      s.skip_field("memory")?;
+    }
+    if let Some(f) = self.version() {
+      s.serialize_field("version", &f)?;
+    } else {
+      s.skip_field("version")?;
+    }
+    if let Some(f) = self.build_number() {
+      s.serialize_field("build_number", &f)?;
+    } else {
+      s.skip_field("build_number")?;
+    }
+    if let Some(f) = self.running_state() {
+      s.serialize_field("running_state", &f)?;
+    } else {
+      s.skip_field("running_state")?;
+    }
+    s.serialize_field("process_id", &self.process_id())?;
+    if let Some(f) = self.region_format() {
+      s.serialize_field("region_format", &f)?;
+    } else {
+      s.skip_field("region_format")?;
+    }
+    if let Some(f) = self.cpu_usage() {
+      s.serialize_field("cpu_usage", &f)?;
+    } else {
+      s.skip_field("cpu_usage")?;
+    }
+    if let Some(f) = self.lifecycle_event() {
+      s.serialize_field("lifecycle_event", &f)?;
+    } else {
+      s.skip_field("lifecycle_event")?;
+    }
+    s.serialize_field("javascript_engine", &self.javascript_engine())?;
+    s.serialize_field("memory_pressure_level", &self.memory_pressure_level())?;
+    s.end()
+  }
+}
+
+impl Serialize for OSBuild<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("OSBuild", 4)?;
+    if let Some(f) = self.version() {
+      s.serialize_field("version", &f)?;
+    } else {
+      s.skip_field("version")?;
+    }
+    if let Some(f) = self.brand() {
+      s.serialize_field("brand", &f)?;
+    } else {
+      s.skip_field("brand")?;
+    }
+    if let Some(f) = self.fingerprint() {
+      s.serialize_field("fingerprint", &f)?;
+    } else {
+      s.skip_field("fingerprint")?;
+    }
+    if let Some(f) = self.kern_osversion() {
+      s.serialize_field("kern_osversion", &f)?;
+    } else {
+      s.skip_field("kern_osversion")?;
+    }
+    s.end()
+  }
+}
+
+impl Serialize for PowerMetrics<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("PowerMetrics", 2)?;
+    s.serialize_field("power_state", &self.power_state())?;
+    s.serialize_field("charge_percent", &self.charge_percent())?;
+    s.end()
+  }
+}
+
+impl Serialize for Display<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("Display", 3)?;
+    s.serialize_field("height", &self.height())?;
+    s.serialize_field("width", &self.width())?;
+    s.serialize_field("density_dpi", &self.density_dpi())?;
+    s.end()
+  }
+}
+
+impl Serialize for DeviceMetrics<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("DeviceMetrics", 15)?;
+    if let Some(f) = self.time() {
+      s.serialize_field("time", &f)?;
+    } else {
+      s.skip_field("time")?;
+    }
+    if let Some(f) = self.timezone() {
+      s.serialize_field("timezone", &f)?;
+    } else {
+      s.skip_field("timezone")?;
+    }
+    if let Some(f) = self.power_metrics() {
+      s.serialize_field("power_metrics", &f)?;
+    } else {
+      s.skip_field("power_metrics")?;
+    }
+    s.serialize_field("network_state", &self.network_state())?;
+    s.serialize_field("rotation", &self.rotation())?;
+    s.serialize_field("arch", &self.arch())?;
+    if let Some(f) = self.display() {
+      s.serialize_field("display", &f)?;
+    } else {
+      s.skip_field("display")?;
+    }
+    if let Some(f) = self.manufacturer() {
+      s.serialize_field("manufacturer", &f)?;
+    } else {
+      s.skip_field("manufacturer")?;
+    }
+    if let Some(f) = self.model() {
+      s.serialize_field("model", &f)?;
+    } else {
+      s.skip_field("model")?;
+    }
+    if let Some(f) = self.os_build() {
+      s.serialize_field("os_build", &f)?;
+    } else {
+      s.skip_field("os_build")?;
+    }
+    s.serialize_field("platform", &self.platform())?;
+    if let Some(f) = self.cpu_abis() {
+      s.serialize_field("cpu_abis", &f)?;
+    } else {
+      s.skip_field("cpu_abis")?;
+    }
+    s.serialize_field("low_power_mode_enabled", &self.low_power_mode_enabled())?;
+    if let Some(f) = self.cpu_usage() {
+      s.serialize_field("cpu_usage", &f)?;
+    } else {
+      s.skip_field("cpu_usage")?;
+    }
+    s.serialize_field("thermal_state", &self.thermal_state())?;
+    s.end()
+  }
+}
+
+impl Serialize for SourceFile<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("SourceFile", 3)?;
+    if let Some(f) = self.path() {
+      s.serialize_field("path", &f)?;
+    } else {
+      s.skip_field("path")?;
+    }
+    s.serialize_field("line", &self.line())?;
+    s.serialize_field("column", &self.column())?;
+    s.end()
+  }
+}
+
+impl Serialize for CPURegister<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("CPURegister", 2)?;
+    if let Some(f) = self.name() {
+      s.serialize_field("name", &f)?;
+    } else {
+      s.skip_field("name")?;
+    }
+    s.serialize_field("value", &self.value())?;
+    s.end()
+  }
+}
+
+impl Serialize for Frame<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("Frame", 14)?;
+    s.serialize_field("type", &self.type_())?;
+    if let Some(f) = self.class_name() {
+      s.serialize_field("class_name", &f)?;
+    } else {
+      s.skip_field("class_name")?;
+    }
+    if let Some(f) = self.symbol_name() {
+      s.serialize_field("symbol_name", &f)?;
+    } else {
+      s.skip_field("symbol_name")?;
+    }
+    if let Some(f) = self.source_file() {
+      s.serialize_field("source_file", &f)?;
+    } else {
+      s.skip_field("source_file")?;
+    }
+    if let Some(f) = self.image_id() {
+      s.serialize_field("image_id", &f)?;
+    } else {
+      s.skip_field("image_id")?;
+    }
+    s.serialize_field("frame_address", &self.frame_address())?;
+    s.serialize_field("symbol_address", &self.symbol_address())?;
+    if let Some(f) = self.registers() {
+      s.serialize_field("registers", &f)?;
+    } else {
+      s.skip_field("registers")?;
+    }
+    if let Some(f) = self.state() {
+      s.serialize_field("state", &f)?;
+    } else {
+      s.skip_field("state")?;
+    }
+    s.serialize_field("frame_status", &self.frame_status())?;
+    s.serialize_field("original_index", &self.original_index())?;
+    s.serialize_field("in_app", &self.in_app())?;
+    if let Some(f) = self.symbolicated_name() {
+      s.serialize_field("symbolicated_name", &f)?;
+    } else {
+      s.skip_field("symbolicated_name")?;
+    }
+    if let Some(f) = self.js_bundle_path() {
+      s.serialize_field("js_bundle_path", &f)?;
+    } else {
+      s.skip_field("js_bundle_path")?;
+    }
+    s.end()
+  }
+}
+
+impl Serialize for Thread<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("Thread", 8)?;
+    if let Some(f) = self.name() {
+      s.serialize_field("name", &f)?;
+    } else {
+      s.skip_field("name")?;
+    }
+    s.serialize_field("active", &self.active())?;
+    s.serialize_field("index", &self.index())?;
+    if let Some(f) = self.state() {
+      s.serialize_field("state", &f)?;
+    } else {
+      s.skip_field("state")?;
+    }
+    s.serialize_field("priority", &self.priority())?;
+    s.serialize_field("quality_of_service", &self.quality_of_service())?;
+    if let Some(f) = self.stack_trace() {
+      s.serialize_field("stack_trace", &f)?;
+    } else {
+      s.skip_field("stack_trace")?;
+    }
+    if let Some(f) = self.summary() {
+      s.serialize_field("summary", &f)?;
+    } else {
+      s.skip_field("summary")?;
+    }
+    s.end()
+  }
+}
+
+impl Serialize for ThreadDetails<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("ThreadDetails", 2)?;
+    s.serialize_field("count", &self.count())?;
+    if let Some(f) = self.threads() {
+      s.serialize_field("threads", &f)?;
+    } else {
+      s.skip_field("threads")?;
+    }
+    s.end()
+  }
+}
+
+impl Serialize for Error<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("Error", 4)?;
+    if let Some(f) = self.name() {
+      s.serialize_field("name", &f)?;
+    } else {
+      s.skip_field("name")?;
+    }
+    if let Some(f) = self.reason() {
+      s.serialize_field("reason", &f)?;
+    } else {
+      s.skip_field("reason")?;
+    }
+    if let Some(f) = self.stack_trace() {
+      s.serialize_field("stack_trace", &f)?;
+    } else {
+      s.skip_field("stack_trace")?;
+    }
+    s.serialize_field("relation_to_next", &self.relation_to_next())?;
+    s.end()
+  }
+}
+
+impl Serialize for BinaryImage<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("BinaryImage", 3)?;
+    if let Some(f) = self.id() {
+      s.serialize_field("id", &f)?;
+    } else {
+      s.skip_field("id")?;
+    }
+    if let Some(f) = self.path() {
+      s.serialize_field("path", &f)?;
+    } else {
+      s.skip_field("path")?;
+    }
+    s.serialize_field("load_address", &self.load_address())?;
+    s.end()
+  }
+}
+
+impl Serialize for SDKInfo<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("SDKInfo", 2)?;
+    if let Some(f) = self.id() {
+      s.serialize_field("id", &f)?;
+    } else {
+      s.skip_field("id")?;
+    }
+    if let Some(f) = self.version() {
+      s.serialize_field("version", &f)?;
+    } else {
+      s.skip_field("version")?;
+    }
+    s.end()
+  }
+}
+
+impl Serialize for FeatureFlag<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("FeatureFlag", 3)?;
+    if let Some(f) = self.name() {
+      s.serialize_field("name", &f)?;
+    } else {
+      s.skip_field("name")?;
+    }
+    if let Some(f) = self.value() {
+      s.serialize_field("value", &f)?;
+    } else {
+      s.skip_field("value")?;
+    }
+    if let Some(f) = self.timestamp() {
+      s.serialize_field("timestamp", &f)?;
+    } else {
+      s.skip_field("timestamp")?;
+    }
+    s.end()
+  }
+}
+
+impl Serialize for Report<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("Report", 9)?;
+    if let Some(f) = self.sdk() {
+      s.serialize_field("sdk", &f)?;
+    } else {
+      s.skip_field("sdk")?;
+    }
+    s.serialize_field("type", &self.type_())?;
+    if let Some(f) = self.app_metrics() {
+      s.serialize_field("app_metrics", &f)?;
+    } else {
+      s.skip_field("app_metrics")?;
+    }
+    if let Some(f) = self.device_metrics() {
+      s.serialize_field("device_metrics", &f)?;
+    } else {
+      s.skip_field("device_metrics")?;
+    }
+    if let Some(f) = self.errors() {
+      s.serialize_field("errors", &f)?;
+    } else {
+      s.skip_field("errors")?;
+    }
+    if let Some(f) = self.thread_details() {
+      s.serialize_field("thread_details", &f)?;
+    } else {
+      s.skip_field("thread_details")?;
+    }
+    if let Some(f) = self.binary_images() {
+      s.serialize_field("binary_images", &f)?;
+    } else {
+      s.skip_field("binary_images")?;
+    }
+    if let Some(f) = self.state() {
+      s.serialize_field("state", &f)?;
+    } else {
+      s.skip_field("state")?;
+    }
+    if let Some(f) = self.feature_flags() {
+      s.serialize_field("feature_flags", &f)?;
+    } else {
+      s.skip_field("feature_flags")?;
+    }
+    s.end()
+  }
+}

--- a/bd-proto/src/flatbuffers/report_serialize.rs
+++ b/bd-proto/src/flatbuffers/report_serialize.rs
@@ -14,17 +14,17 @@ use crate::flatbuffers::serialize_enum;
 extern crate serde;
 use self::serde::ser::{Serialize, SerializeStruct, Serializer};
 
-serialize_enum!(ReportType);
-serialize_enum!(Platform);
-serialize_enum!(Architecture);
-serialize_enum!(FrameType);
-serialize_enum!(ErrorRelation);
-serialize_enum!(PowerState);
-serialize_enum!(NetworkState);
-serialize_enum!(JavaScriptEngine);
-serialize_enum!(MemoryPressureLevel);
-serialize_enum!(Rotation);
-serialize_enum!(FrameStatus);
+serialize_enum!(ReportType, serialize_i8);
+serialize_enum!(Platform, serialize_i8);
+serialize_enum!(Architecture, serialize_i8);
+serialize_enum!(FrameType, serialize_i8);
+serialize_enum!(ErrorRelation, serialize_i8);
+serialize_enum!(PowerState, serialize_i8);
+serialize_enum!(NetworkState, serialize_i8);
+serialize_enum!(JavaScriptEngine, serialize_i8);
+serialize_enum!(MemoryPressureLevel, serialize_i8);
+serialize_enum!(Rotation, serialize_i8);
+serialize_enum!(FrameStatus, serialize_i8);
 
 impl Serialize for Timestamp {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/bd-proto/src/flatbuffers/report_serialize_test.rs
+++ b/bd-proto/src/flatbuffers/report_serialize_test.rs
@@ -1,3 +1,10 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
 use crate::flatbuffers::report::bitdrift_public::fbs::issue_reporting::v_1::*;
 use serde::Serialize;
 use serde_json::json;

--- a/bd-proto/src/flatbuffers/report_serialize_test.rs
+++ b/bd-proto/src/flatbuffers/report_serialize_test.rs
@@ -1,0 +1,461 @@
+use crate::flatbuffers::report::bitdrift_public::fbs::issue_reporting::v_1::*;
+use serde::Serialize;
+use serde_json::json;
+
+fn serialization_loop<T: Sized + Serialize>(object: &T) -> serde_json::Value {
+  let serialized = serde_json::to_string(&object).unwrap();
+  serde_json::from_str(&serialized).unwrap()
+}
+
+#[test]
+fn serialize_report_type() {
+  let object = serialization_loop(&ReportType::JVMCrash);
+  assert_eq!(json!(3), object);
+}
+
+#[test]
+fn serialize_platform() {
+  let object = serialization_loop(&Platform::Android);
+  assert_eq!(json!(1), object);
+}
+
+#[test]
+fn serialize_arch() {
+  let object = serialization_loop(&Architecture::arm64);
+  assert_eq!(json!(2), object);
+}
+
+#[test]
+fn serialize_frame_type() {
+  let object = serialization_loop(&FrameType::AndroidNative);
+  assert_eq!(json!(3), object);
+}
+
+#[test]
+fn serialize_error_relation() {
+  let object = serialization_loop(&ErrorRelation::CausedBy);
+  assert_eq!(json!(1), object);
+}
+
+#[test]
+fn serialize_power_state() {
+  let object = serialization_loop(&PowerState::PluggedInCharged);
+  assert_eq!(json!(4), object);
+}
+
+#[test]
+fn serialize_network_state() {
+  let object = serialization_loop(&NetworkState::Disconnected);
+  assert_eq!(json!(1), object);
+}
+
+#[test]
+fn serialize_js_engine() {
+  let object = serialization_loop(&JavaScriptEngine::Hermes);
+  assert_eq!(json!(2), object);
+}
+
+#[test]
+fn serialize_mem_pressure_level() {
+  let object = serialization_loop(&MemoryPressureLevel::Critical);
+  assert_eq!(json!(3), object);
+}
+
+#[test]
+fn serialize_rotation() {
+  let object = serialization_loop(&Rotation::LandscapeLeft);
+  assert_eq!(json!(3), object);
+}
+
+#[test]
+fn serialize_frame_status() {
+  let object = serialization_loop(&FrameStatus::Symbolicated);
+  assert_eq!(json!(1), object);
+}
+
+#[test]
+fn serialize_timestamp() {
+  let object = serialization_loop(&Timestamp::new(1830254100, 27186761));
+  assert_eq!(json!({"nanos": 27186761, "seconds": 1830254100}), object);
+}
+
+#[test]
+fn serialize_memory() {
+  let object = serialization_loop(&Memory::new(256, 19, 237));
+  assert_eq!(json!({"total": 256, "free": 19, "used": 237}), object);
+}
+
+macro_rules! build_table {
+  ($builder:ident, $typename:ident, $args:expr) => {{
+    let args = $args;
+    let input = $typename::create(&mut $builder, args);
+    $builder.finish(input, None);
+    flatbuffers::root::<$typename<'_>>($builder.finished_data()).unwrap()
+  }};
+}
+
+#[test]
+fn serialize_version_code() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let input = build_table!(
+    builder,
+    AppBuildNumber,
+    &AppBuildNumberArgs {
+      version_code: 56,
+      ..Default::default()
+    }
+  );
+  let object = serialization_loop(&input);
+  assert_eq!(json!({"version_code": 56}), object);
+}
+
+#[test]
+fn serialize_bundle_version() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let object = serialization_loop(&build_table!(
+    builder,
+    AppBuildNumber,
+    &AppBuildNumberArgs {
+      cf_bundle_version: Some(builder.create_string("4.5.22")),
+      ..Default::default()
+    }
+  ));
+  assert_eq!(json!({"cf_bundle_version": "4.5.22"}), object);
+}
+
+#[test]
+fn serialize_feature_flag() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let object = serialization_loop(&build_table!(
+    builder,
+    FeatureFlag,
+    &FeatureFlagArgs {
+      name: Some(builder.create_string("option_a")),
+      value: Some(builder.create_string("variant b")),
+      ..Default::default()
+    }
+  ));
+  assert_eq!(json!({"name": "option_a", "value": "variant b"}), object);
+}
+
+#[test]
+fn serialize_proc_usage() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let object = serialization_loop(&build_table!(
+    builder,
+    ProcessorUsage,
+    &ProcessorUsageArgs {
+      duration_seconds: 367,
+      used_percent: 81,
+    }
+  ));
+  assert_eq!(json!({"duration_seconds": 367, "used_percent": 81}), object);
+}
+
+#[test]
+fn serialize_app_metrics() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let object = serialization_loop(&build_table!(
+    builder,
+    AppMetrics,
+    &AppMetricsArgs {
+      app_id: Some(builder.create_string("co.example.someapp")),
+      memory: Some(&Memory::new(256, 19, 237)),
+      region_format: Some(builder.create_string("MQ")),
+      ..Default::default()
+    }
+  ));
+  assert_eq!(
+    json!({
+      "app_id":"co.example.someapp",
+      "region_format": "MQ",
+      "memory": {"total": 256, "free": 19, "used": 237},
+      "javascript_engine": 0,
+      "memory_pressure_level": 0,
+      "process_id": 0,
+    }),
+    object
+  );
+}
+
+#[test]
+fn serialize_error() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let args = &FrameArgs {
+    type_: FrameType::JVM,
+    symbol_name: Some(builder.create_string("Builder.make")),
+    in_app: true,
+    frame_address: 81716715,
+    symbol_address: 961261,
+    original_index: 1,
+    ..Default::default()
+  };
+  let frame = Frame::create(&mut builder, args);
+  let object = serialization_loop(&build_table!(
+    builder,
+    Error,
+    &ErrorArgs {
+      name: Some(builder.create_string("MissingArgumentError")),
+      reason: Some(builder.create_string("required argument 'x' was unset")),
+      stack_trace: Some(builder.create_vector(&[frame])),
+      relation_to_next: ErrorRelation::CausedBy,
+    }
+  ));
+  assert_eq!(
+    json!({
+      "name": "MissingArgumentError",
+      "reason": "required argument 'x' was unset",
+      "relation_to_next": 1,
+      "stack_trace": [{
+        "type": 1,
+        "symbol_name": "Builder.make",
+        "in_app": true,
+        "frame_address": 81716715,
+        "symbol_address": 961261,
+        "frame_status": 0,
+        "original_index": 1,
+      }],
+    }),
+    object
+  );
+}
+
+#[test]
+fn serialize_source_file() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let object = serialization_loop(&build_table!(
+    builder,
+    SourceFile,
+    &SourceFileArgs {
+      path: Some(builder.create_string("src/tmp.cpp")),
+      line: 189,
+      column: 13,
+    }
+  ));
+  assert_eq!(
+    json!({
+      "path": "src/tmp.cpp",
+      "line": 189,
+      "column": 13,
+    }),
+    object
+  );
+}
+
+#[test]
+fn serialize_frame() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let object = serialization_loop(&build_table!(
+    builder,
+    Frame,
+    &FrameArgs {
+      type_: FrameType::JVM,
+      symbol_name: Some(builder.create_string("Builder.make")),
+      in_app: true,
+      frame_address: 81716715,
+      symbol_address: 961261,
+      ..Default::default()
+    }
+  ));
+  assert_eq!(
+    json!({
+      "type": 1,
+      "symbol_name": "Builder.make",
+      "in_app": true,
+      "frame_address": 81716715,
+      "symbol_address": 961261,
+      "frame_status": 0,
+      "original_index": 0,
+    }),
+    object
+  );
+}
+
+#[test]
+fn serialize_report() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let app_id = Some(builder.create_string("co.example.someapp"));
+  let app_metrics = Some(AppMetrics::create(
+    &mut builder,
+    &AppMetricsArgs {
+      app_id,
+      ..Default::default()
+    },
+  ));
+  let device_metrics = Some(DeviceMetrics::create(
+    &mut builder,
+    &DeviceMetricsArgs {
+      network_state: NetworkState::Disconnected,
+      thermal_state: 5,
+      platform: Platform::macOS,
+      rotation: Rotation::LandscapeLeft,
+      ..Default::default()
+    },
+  ));
+  let frame = Frame::create(
+    &mut builder,
+    &FrameArgs {
+      type_: FrameType::JVM,
+      in_app: true,
+      frame_address: 81716715,
+      symbol_address: 961261,
+      original_index: 1,
+      ..Default::default()
+    },
+  );
+  let stack_trace = Some(builder.create_vector(&[frame]));
+  let error = Error::create(
+    &mut builder,
+    &ErrorArgs {
+      stack_trace,
+      relation_to_next: ErrorRelation::CausedBy,
+      ..Default::default()
+    },
+  );
+  let object = serialization_loop(&build_table!(
+    builder,
+    Report,
+    &ReportArgs {
+      type_: ReportType::AppNotResponding,
+      app_metrics,
+      device_metrics,
+      errors: Some(builder.create_vector(&[error])),
+      ..Default::default()
+    }
+  ));
+  assert_eq!(
+    json!({
+      "type": 1,
+      "app_metrics": {
+        "app_id": "co.example.someapp",
+        "javascript_engine": 0,
+        "memory_pressure_level": 0,
+        "process_id": 0,
+      },
+      "device_metrics": {
+        "thermal_state": 5,
+        "rotation": 3,
+        "network_state": 1,
+        "arch": 0,
+        "platform": 3,
+        "low_power_mode_enabled": false,
+      },
+      "errors": [{
+        "relation_to_next": 1,
+        "stack_trace": [{
+          "type": 1,
+          "in_app": true,
+          "frame_address": 81716715,
+          "symbol_address": 961261,
+          "frame_status": 0,
+          "original_index": 1,
+        }],
+      }],
+    }),
+    object
+  );
+}
+
+#[test]
+fn serialize_thread() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let object = serialization_loop(&build_table!(
+    builder,
+    Thread,
+    &ThreadArgs {
+      name: Some(builder.create_string("main")),
+      index: 12,
+      active: true,
+      priority: 3.0,
+      quality_of_service: 5,
+      summary: Some(builder.create_string("locked")),
+      ..Default::default()
+    }
+  ));
+  assert_eq!(
+    json!({
+      "name": "main",
+      "index": 12,
+      "active": true,
+      "priority": 3.0,
+      "quality_of_service": 5,
+      "summary": "locked",
+    }),
+    object
+  );
+}
+
+#[test]
+fn serialize_thread_details() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let args = &ThreadArgs {
+    name: Some(builder.create_string("main")),
+    index: 12,
+    active: true,
+    priority: 3.0,
+    quality_of_service: 5,
+    summary: Some(builder.create_string("locked")),
+    ..Default::default()
+  };
+  let thread = Thread::create(&mut builder, args);
+  let object = serialization_loop(&build_table!(
+    builder,
+    ThreadDetails,
+    &ThreadDetailsArgs {
+      count: 12,
+      threads: Some(builder.create_vector(&[thread]))
+    }
+  ));
+  assert_eq!(
+    json!({
+      "count": 12,
+        "threads": [{
+          "name": "main",
+          "index": 12,
+          "active": true,
+          "priority": 3.0,
+          "quality_of_service": 5,
+          "summary": "locked",
+        }],
+    }),
+    object
+  );
+}
+
+#[test]
+fn serialize_device_metrics() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let power_metrics = PowerMetrics::create(
+    &mut builder,
+    &PowerMetricsArgs {
+      power_state: PowerState::PluggedInCharging,
+      charge_percent: 15,
+    },
+  );
+  let object = serialization_loop(&build_table!(
+    builder,
+    DeviceMetrics,
+    &DeviceMetricsArgs {
+      timezone: Some(builder.create_string("AS")),
+      power_metrics: Some(power_metrics),
+      network_state: NetworkState::Disconnected,
+      thermal_state: 5,
+      platform: Platform::macOS,
+      rotation: Rotation::LandscapeLeft,
+      ..Default::default()
+    }
+  ));
+  assert_eq!(
+    json!({
+      "timezone":"AS",
+      "power_metrics": {"power_state": 3, "charge_percent": 15},
+      "thermal_state": 5,
+      "rotation": 3,
+      "network_state": 1,
+      "arch": 0,
+      "platform": 3,
+      "low_power_mode_enabled": false,
+    }),
+    object
+  );
+}

--- a/bd-proto/src/flatbuffers/report_serialize_test.rs
+++ b/bd-proto/src/flatbuffers/report_serialize_test.rs
@@ -2,6 +2,21 @@ use crate::flatbuffers::report::bitdrift_public::fbs::issue_reporting::v_1::*;
 use serde::Serialize;
 use serde_json::json;
 
+// Quick and dirty means to determining whether the structures have changed
+// since the last time the serialization logic was updated to avoid breakage
+macro_rules! assert_struct_size {
+  ($name:ident, $value:expr) => {
+    assert_eq!(
+      core::mem::size_of::<$name>(),
+      $value,
+      concat!(
+        "src/flatbuffers/report_serialize.rs needs to be updated for ",
+        stringify!($name),
+      )
+    )
+  };
+}
+
 fn serialization_loop<T: Sized + Serialize>(object: &T) -> serde_json::Value {
   let serialized = serde_json::to_string(&object).unwrap();
   serde_json::from_str(&serialized).unwrap()
@@ -83,6 +98,7 @@ fn serialize_timestamp() {
 fn serialize_memory() {
   let object = serialization_loop(&Memory::new(256, 19, 237));
   assert_eq!(json!({"total": 256, "free": 19, "used": 237}), object);
+  assert_struct_size!(Memory, 24);
 }
 
 macro_rules! build_table {
@@ -107,6 +123,7 @@ fn serialize_version_code() {
   );
   let object = serialization_loop(&input);
   assert_eq!(json!({"version_code": 56}), object);
+  assert_struct_size!(AppBuildNumberArgs, 16);
 }
 
 #[test]
@@ -136,6 +153,7 @@ fn serialize_feature_flag() {
     }
   ));
   assert_eq!(json!({"name": "option_a", "value": "variant b"}), object);
+  assert_struct_size!(FeatureFlagArgs, 24);
 }
 
 #[test]
@@ -150,6 +168,7 @@ fn serialize_proc_usage() {
     }
   ));
   assert_eq!(json!({"duration_seconds": 367, "used_percent": 81}), object);
+  assert_struct_size!(ProcessorUsageArgs, 16);
 }
 
 #[test]
@@ -176,6 +195,7 @@ fn serialize_app_metrics() {
     }),
     object
   );
+  assert_struct_size!(AppMetricsArgs, 72);
 }
 
 #[test]
@@ -218,6 +238,7 @@ fn serialize_error() {
     }),
     object
   );
+  assert_struct_size!(ErrorArgs, 28);
 }
 
 #[test]
@@ -240,6 +261,7 @@ fn serialize_source_file() {
     }),
     object
   );
+  assert_struct_size!(SourceFileArgs, 24);
 }
 
 #[test]
@@ -269,6 +291,7 @@ fn serialize_frame() {
     }),
     object
   );
+  assert_struct_size!(FrameArgs, 96);
 }
 
 #[test]
@@ -354,6 +377,7 @@ fn serialize_report() {
     }),
     object
   );
+  assert_struct_size!(ReportArgs, 68);
 }
 
 #[test]
@@ -383,6 +407,7 @@ fn serialize_thread() {
     }),
     object
   );
+  assert_struct_size!(ThreadArgs, 44);
 }
 
 #[test]
@@ -420,6 +445,7 @@ fn serialize_thread_details() {
     }),
     object
   );
+  assert_struct_size!(ThreadDetailsArgs, 12);
 }
 
 #[test]
@@ -458,4 +484,5 @@ fn serialize_device_metrics() {
     }),
     object
   );
+  assert_struct_size!(DeviceMetricsArgs, 80);
 }

--- a/ci/license_header.py
+++ b/ci/license_header.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 # Define the header you want to check for and insert
 rust_header = """
@@ -16,20 +17,25 @@ headers = {
 
 exclude_dirs = (
     './.git',
-    './bd-grpc/src/generated',
-    './bd-pgv/src/generated',
-    './bd-report-convert/src/generated',
-    './bd-proto/',
+    './bd-proto/src/protos/',
     './fuzz/corpus/',
     './proto/',
     './target/',
     './thirdparty/',
 )
 
+exclude_patterns = (
+    re.compile('generated'),
+)
+
 extensions_to_check = ('.rs', '.toml')
 
 
-def check_file(file_path):
+def check_file(file_path: str):
+    for pattern in exclude_patterns:
+        if pattern.findall(file_path):
+            return
+
     for dir in exclude_dirs:
         if file_path.startswith(dir):
             return


### PR DESCRIPTION
workaround for generated serde bindings being crash-prone for enum values.

* added a new implementation for enums
* fixed the field names for `type_` to be `type` since that's what in the spec
* avoided serializing unneeded union values, like `version_code` when `cf_bundle_version` is set
* added checks in the tests that if the `Args` or struct sizes change, that the serialization logic should be updated (not that it happens often)