### PR TITLE
script engine cleanup

### DIFF
--- a/bd-script/src/report/functions/add_field.rs
+++ b/bd-script/src/report/functions/add_field.rs
@@ -42,6 +42,10 @@ impl Function for AddField {
     kind::NULL
   }
 
+  fn pure(&self) -> bool {
+    false
+  }
+
   fn parameters(&self) -> &'static [Parameter] {
     &[
       Parameter {

--- a/bd-script/src/report/functions/mod.rs
+++ b/bd-script/src/report/functions/mod.rs
@@ -10,12 +10,18 @@ mod set_grouping_key;
 mod set_significant_frame;
 
 use crate::report::functions::add_field::AddField;
-use crate::report::functions::set_grouping_key::SetGroupingKey;
-use crate::report::functions::set_significant_frame::SetSignificantFrame;
 use vrl::prelude::Function;
 
 #[must_use]
 pub fn all_functions() -> Vec<Box<dyn Function>> {
+  vec![Box::new(AddField)]
+}
+
+#[cfg(test)]
+#[must_use]
+pub fn all_functions_for_test() -> Vec<Box<dyn Function>> {
+  use crate::report::functions::set_grouping_key::SetGroupingKey;
+  use crate::report::functions::set_significant_frame::SetSignificantFrame;
   vec![
     Box::new(AddField),
     Box::new(SetGroupingKey),

--- a/bd-script/src/report/functions/set_grouping_key.rs
+++ b/bd-script/src/report/functions/set_grouping_key.rs
@@ -17,6 +17,7 @@ use vrl::prelude::{
   kind,
 };
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct SetGroupingKey;
 

--- a/bd-script/src/report/functions/set_grouping_key.rs
+++ b/bd-script/src/report/functions/set_grouping_key.rs
@@ -41,6 +41,10 @@ impl Function for SetGroupingKey {
     kind::NULL
   }
 
+  fn pure(&self) -> bool {
+    false
+  }
+
   fn parameters(&self) -> &'static [Parameter] {
     &[Parameter {
       keyword: "key",

--- a/bd-script/src/report/functions/set_significant_frame.rs
+++ b/bd-script/src/report/functions/set_significant_frame.rs
@@ -39,6 +39,10 @@ impl Function for SetSignificantFrame {
     ""
   }
 
+  fn pure(&self) -> bool {
+    false
+  }
+
   fn return_kind(&self) -> u16 {
     kind::NULL
   }

--- a/bd-script/src/report/functions/set_significant_frame.rs
+++ b/bd-script/src/report/functions/set_significant_frame.rs
@@ -19,6 +19,7 @@ use vrl::prelude::{
   kind,
 };
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct SetSignificantFrame;
 
@@ -99,6 +100,7 @@ impl Function for SetSignificantFrame {
   }
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug)]
 struct FrameData {
   error_index: Box<dyn Expression>,

--- a/bd-script/src/report/mod.rs
+++ b/bd-script/src/report/mod.rs
@@ -10,6 +10,8 @@ mod generated;
 
 use crate::ScriptOutput;
 pub use functions::all_functions as report_functions;
+#[cfg(test)]
+pub use functions::all_functions_for_test;
 use std::collections::BTreeMap;
 use std::ops::Add;
 

--- a/bd-script/src/script_test.rs
+++ b/bd-script/src/script_test.rs
@@ -7,7 +7,7 @@
 
 use crate::Script;
 use crate::feature_flag::{FeatureFlag, FeatureFlagWrapper};
-use crate::report::{ReportOutput, report_functions};
+use crate::report::{ReportOutput, all_functions_for_test as report_functions};
 use bd_proto::flatbuffers::report::bitdrift_public::fbs::issue_reporting::v_1::{
   AppMetricsT,
   ErrorT,


### PR DESCRIPTION
* mark functions as impure to indicate that no variable assignment is needed to use them
* hide grouping functions from the engine