### PR TITLE
session strategy: handle switching from fixed -> activity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,6 +3193,7 @@ dependencies = [
  "bd-session",
  "bd-shutdown",
  "bd-test-helpers",
+ "bd-time",
  "bd-workspace-hack",
  "clap",
  "flatbuffers",

--- a/bd-session/src/activity_based.rs
+++ b/bd-session/src/activity_based.rs
@@ -40,6 +40,12 @@ impl Strategy {
     callbacks: Arc<dyn Callbacks>,
     time_provider: Arc<dyn bd_time::TimeProvider>,
   ) -> Self {
+    log::debug!(
+      "configured activity-based session strategy: inactivity_threshold={inactivity_threshold:?}, \
+       max_write_interval={:?}",
+      Duration::seconds(15)
+    );
+
     Self {
       callbacks,
       inactivity_threshold,
@@ -59,6 +65,14 @@ impl Strategy {
   ) -> Initialization {
     let now = self.time_provider.now();
     if let Some(persisted) = persisted {
+      log::debug!(
+        "initializing activity-based session from persisted state: current_session_id={}, \
+         pending_started_sessions={}, current_session_start={:?}",
+        persisted.current_session_id,
+        pending_started_sessions.len(),
+        OffsetDateTime::from(persisted.current_session_start)
+      );
+
       // Reuse the persisted session as input to the normal activity transition logic so restart
       // behavior matches a normal foreground access.
       let previous_process_session_id = Some(persisted.current_session_id.clone());
@@ -78,6 +92,11 @@ impl Strategy {
         .iter()
         .any(|started| started.session_id == state.persisted.current_session_id)
       {
+        log::debug!(
+          "re-queueing current activity session for handshake upload after restart: session_id={}",
+          state.persisted.current_session_id
+        );
+
         state
           .pending_started_sessions
           .push(StartedSessionRecord::new(
@@ -86,11 +105,29 @@ impl Strategy {
           ));
         mutation.persist_pending = true;
       }
+
+      log::debug!(
+        "initialized activity-based session from persisted state: current_session_id={}, \
+         previous_process_session_id={:?}, persist_state={}, persist_pending={}, \
+         pending_started_sessions={}",
+        state.persisted.current_session_id,
+        state.persisted.previous_process_session_id,
+        mutation.persist_state,
+        mutation.persist_pending,
+        state.pending_started_sessions.len()
+      );
+
       Initialization { state, mutation }
     } else {
       let session_id = Self::generate_session_id();
       let session_start = now;
       pending_started_sessions.push(StartedSessionRecord::new(session_id.clone(), session_start));
+
+      log::debug!(
+        "initializing new activity-based session: session_id={session_id}, \
+         session_start={session_start:?}, pending_started_sessions={}",
+        pending_started_sessions.len()
+      );
 
       Initialization {
         state: LoadedState {
@@ -117,16 +154,39 @@ impl Strategy {
   pub(crate) fn on_session_id(&self, state: &mut LoadedState) -> Mutation {
     let now = self.time_provider.now();
     let BackendState::ActivityBased { last_activity } = &mut state.persisted.backend else {
+      // `initialize_state()` should already resync any persisted backend mismatch before an
+      // activity-based strategy reaches its steady-state access path. Keep the branch as a
+      // defensive fallback so debug builds catch any future invariant drift immediately.
+      debug_assert!(
+        false,
+        "activity-based session observed incompatible backend state after initialization"
+      );
+      log::debug!(
+        "activity-based session observed incompatible backend state after initialization; leaving \
+         state unchanged"
+      );
       return Mutation::default();
     };
 
+    let previous_session_id = state.persisted.current_session_id.clone();
     let previous_last_activity = OffsetDateTime::from(*last_activity);
+    let inactivity_elapsed = now - previous_last_activity;
     let is_now_before_last_activity = now < previous_last_activity;
-    let is_inactivity_threshold_exceeded =
-      (now - previous_last_activity) > self.inactivity_threshold;
+    let is_inactivity_threshold_exceeded = inactivity_elapsed > self.inactivity_threshold;
     let last_activity_storage_needs_write = state
       .last_activity_write
       .is_none_or(|last_activity_write| now - last_activity_write > self.max_write_interval);
+
+    log::debug!(
+      "evaluating activity-based session access: current_session_id={}, now={now:?}, \
+       previous_last_activity={previous_last_activity:?}, \
+       inactivity_elapsed={inactivity_elapsed:?}, threshold={:?}, clock_moved_backwards={}, \
+       persist_last_activity={}",
+      previous_session_id,
+      self.inactivity_threshold,
+      is_now_before_last_activity,
+      last_activity_storage_needs_write
+    );
 
     *last_activity = now.into();
 
@@ -141,6 +201,19 @@ impl Strategy {
         .push(StartedSessionRecord::new(session_id.clone(), now));
       state.last_activity_write = Some(now);
 
+      log::debug!(
+        "rotating activity-based session: previous_session_id={}, new_session_id={}, reason={}, \
+         pending_started_sessions={}",
+        previous_session_id,
+        session_id,
+        if is_now_before_last_activity {
+          "clock_moved_backwards"
+        } else {
+          "inactivity_threshold_exceeded"
+        },
+        state.pending_started_sessions.len()
+      );
+
       Mutation {
         persist_state: true,
         persist_pending: true,
@@ -150,11 +223,22 @@ impl Strategy {
       // The session itself is unchanged, but we periodically persist the last-activity timestamp so
       // a restart can continue the inactivity window from roughly the right point in time.
       state.last_activity_write = Some(now);
+
+      log::debug!(
+        "persisting activity-based last-activity without session rotation: \
+         current_session_id={previous_session_id}, last_activity={now:?}"
+      );
+
       Mutation {
         persist_state: true,
         ..Default::default()
       }
     } else {
+      log::debug!(
+        "leaving activity-based session unchanged: current_session_id={previous_session_id}, no \
+         durable write required"
+      );
+
       Mutation::default()
     }
   }
@@ -175,6 +259,13 @@ impl Strategy {
     );
 
     pending_started_sessions.push(StartedSessionRecord::new(session_id.clone(), now));
+
+    log::debug!(
+      "starting explicit new activity-based session: new_session_id={}, \
+       previous_process_session_id={previous_process_session_id:?}, pending_started_sessions={}",
+      session_id,
+      pending_started_sessions.len()
+    );
 
     Initialization {
       state: LoadedState {
@@ -198,6 +289,7 @@ impl Strategy {
   }
 
   pub(crate) fn run_callback(&self, session_id: &str) {
+    log::debug!("dispatching activity-based session callback: session_id={session_id}");
     self.callbacks.session_id_changed(session_id);
   }
 }

--- a/bd-session/src/fixed.rs
+++ b/bd-session/src/fixed.rs
@@ -60,6 +60,14 @@ impl Strategy {
 
     pending_started_sessions.push(StartedSessionRecord::new(session_id.clone(), session_start));
 
+    log::debug!(
+      "initializing fixed session: new_session_id={}, previous_process_session_id={:?}, \
+       pending_started_sessions={}",
+      session_id,
+      previous_process_session_id,
+      pending_started_sessions.len()
+    );
+
     Initialization {
       state: LoadedState {
         persisted: PersistedSessionState {
@@ -99,6 +107,13 @@ impl Strategy {
     );
 
     pending_started_sessions.push(StartedSessionRecord::new(session_id.clone(), session_start));
+
+    log::debug!(
+      "starting explicit new fixed session: new_session_id={}, \
+       previous_process_session_id={previous_process_session_id:?}, pending_started_sessions={}",
+      session_id,
+      pending_started_sessions.len()
+    );
 
     Initialization {
       state: LoadedState {

--- a/bd-session/src/lib.rs
+++ b/bd-session/src/lib.rs
@@ -43,7 +43,7 @@ fn test_global_init() {
 use bd_proto::protos::client::api::StateUpdateRequest;
 use bd_proto::protos::client::api::state_update_request::StartedSession;
 use bd_time::{OffsetDateTimeExt as _, TimeProvider};
-use persistence::{PersistedSessionState, StartedSessionRecord, Store};
+use persistence::{BackendState, PersistedSessionState, StartedSessionRecord, Store};
 use std::cell::Cell;
 use std::path::Path;
 use std::sync::Arc;
@@ -214,9 +214,46 @@ impl PendingStateUpdate {
 // Backend
 //
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BackendKind {
+  Fixed,
+  ActivityBased,
+}
+
+impl BackendKind {
+  const fn type_name(self) -> &'static str {
+    match self {
+      Self::Fixed => "fixed",
+      Self::ActivityBased => "activity_based",
+    }
+  }
+}
+
 enum Backend {
   Fixed(fixed::Strategy),
   ActivityBased(activity_based::Strategy),
+}
+
+impl Backend {
+  const fn kind(&self) -> BackendKind {
+    match self {
+      Self::Fixed(_) => BackendKind::Fixed,
+      Self::ActivityBased(_) => BackendKind::ActivityBased,
+    }
+  }
+
+  fn matches_persisted_backend(&self, persisted_backend: &BackendState) -> bool {
+    self.kind() == persisted_backend.kind()
+  }
+}
+
+impl BackendState {
+  const fn kind(&self) -> BackendKind {
+    match self {
+      Self::Fixed => BackendKind::Fixed,
+      Self::ActivityBased { .. } => BackendKind::ActivityBased,
+    }
+  }
 }
 
 //
@@ -296,6 +333,16 @@ impl Strategy {
 
         let current_session_id = Self::loaded_session_id(state)?;
         if mutation.has_follow_up_work() {
+          log::debug!(
+            "session read requires follow-up work: backend={}, current_session_id={}, \
+             persist_state={}, persist_pending={}, callback={}",
+            self.type_name(),
+            current_session_id,
+            mutation.persist_state,
+            mutation.persist_pending,
+            mutation.callback.is_some()
+          );
+
           Ok(PreparedSessionOperation::follow_up(state.clone(), mutation))
         } else {
           Ok(PreparedSessionOperation::noop(current_session_id))
@@ -307,6 +354,17 @@ impl Strategy {
         *guard = Some(initialization.state.clone());
 
         let current_session_id = Self::loaded_session_id(&initialization.state)?;
+        log::debug!(
+          "initialized session state on first read: backend={}, current_session_id={}, \
+           persist_state={}, persist_pending={}, callback={}, pending_started_sessions={}",
+          self.type_name(),
+          current_session_id,
+          initialization.mutation.persist_state,
+          initialization.mutation.persist_pending,
+          initialization.mutation.callback.is_some(),
+          initialization.state.pending_started_sessions.len()
+        );
+
         if initialization.mutation.has_follow_up_work() {
           Ok(PreparedSessionOperation::follow_up(
             initialization.state,
@@ -401,6 +459,14 @@ impl Strategy {
       .iter()
       .any(|started| started.session_id == state.persisted.current_session_id)
     {
+      log::debug!(
+        "synthesizing current session into handshake: backend={}, current_session_id={}, \
+         pending_started_sessions={}",
+        self.type_name(),
+        state.persisted.current_session_id,
+        state.pending_started_sessions.len()
+      );
+
       request_started_sessions.push(StartedSessionRecord {
         session_id: state.persisted.current_session_id.clone(),
         start_time: state.persisted.current_session_start,
@@ -425,10 +491,23 @@ impl Strategy {
     let state = self.load_state_for_update().await;
 
     if state.pending_started_sessions.is_empty() {
+      log::debug!(
+        "no pending state update to emit: backend={}, current_session_id={}",
+        self.type_name(),
+        state.persisted.current_session_id
+      );
       return None;
     }
 
     let started_sessions = state.pending_started_sessions;
+    log::debug!(
+      "emitting pending state update: backend={}, current_session_id={}, \
+       pending_started_sessions={}",
+      self.type_name(),
+      state.persisted.current_session_id,
+      started_sessions.len()
+    );
+
     Some(PendingStateUpdate {
       request: StateUpdateRequest {
         started_sessions: started_sessions
@@ -463,6 +542,13 @@ impl Strategy {
       // Responses are not correlated, so we only advance the durable queue when the acknowledged
       // set matches the prefix we most recently sent.
       if !starts_with_sessions(&state.pending_started_sessions, &update.started_sessions) {
+        log::debug!(
+          "ignoring non-prefix state update acknowledgement: backend={}, current_pending={}, \
+           acknowledged={}",
+          self.type_name(),
+          state.pending_started_sessions.len(),
+          update.started_sessions.len()
+        );
         return;
       }
 
@@ -479,16 +565,18 @@ impl Strategy {
     {
       log::warn!("failed to persist acknowledged started sessions: {e}");
     } else {
+      log::debug!(
+        "acknowledged pending started sessions: backend={}, remaining_pending={}",
+        self.type_name(),
+        pending_started_sessions.len()
+      );
       self.notify_update();
     }
   }
 
   /// Pretty name of the strategy.
   pub const fn type_name(&self) -> &'static str {
-    match self.backend {
-      Backend::Fixed(_) => "fixed",
-      Backend::ActivityBased(_) => "activity_based",
-    }
+    self.backend.kind().type_name()
   }
 
   fn initialize_state(&self) -> Initialization {
@@ -496,6 +584,29 @@ impl Strategy {
     // backend makes decisions from a consistent snapshot of durable state.
     let persisted = self.store.load_state();
     let pending_started_sessions = self.store.load_pending_started_sessions();
+
+    log::debug!(
+      "loading session state snapshot: active_backend={}, has_persisted_state={}, \
+       pending_started_sessions={}",
+      self.type_name(),
+      persisted.is_some(),
+      pending_started_sessions.len()
+    );
+
+    if let Some(persisted) = persisted.as_ref()
+      && !self.backend.matches_persisted_backend(&persisted.backend)
+    {
+      log::debug!(
+        "resyncing session state after backend switch: persisted_backend={}, active_backend={}, \
+         previous_current_session_id={}, pending_started_sessions={}",
+        persisted.backend.kind().type_name(),
+        self.type_name(),
+        persisted.current_session_id,
+        pending_started_sessions.len()
+      );
+
+      return self.initialize_after_backend_switch(persisted.clone(), pending_started_sessions);
+    }
 
     match &self.backend {
       Backend::Fixed(strategy) => {
@@ -505,10 +616,35 @@ impl Strategy {
     }
   }
 
+  fn initialize_after_backend_switch(
+    &self,
+    persisted: PersistedSessionState,
+    pending_started_sessions: Vec<StartedSessionRecord>,
+  ) -> Initialization {
+    // Backend-specific durable fields are not portable, so a strategy switch is treated as a
+    // fresh session boundary. We still preserve the old current session as previous-process state
+    // by routing through the existing explicit-rotation path.
+    match &self.backend {
+      Backend::Fixed(strategy) => self.with_callback_guard(|| {
+        strategy.start_new_session(None, Some(persisted), pending_started_sessions)
+      }),
+      Backend::ActivityBased(strategy) => {
+        strategy.start_new_session(None, Some(persisted), pending_started_sessions)
+      },
+    }
+  }
+
   async fn load_state_for_update(&self) -> LoadedState {
     let (state, mutation) = {
       let mut guard = self.state.lock();
       if let Some(state) = guard.clone() {
+        log::debug!(
+          "serving state update from cached session state: backend={}, current_session_id={}, \
+           pending_started_sessions={}",
+          self.type_name(),
+          state.persisted.current_session_id,
+          state.pending_started_sessions.len()
+        );
         return state;
       }
 
@@ -516,6 +652,16 @@ impl Strategy {
       // then drop the lock before invoking any deferred callback.
       let initialization = self.initialize_state();
       *guard = Some(initialization.state.clone());
+      log::debug!(
+        "initialized session state for update flow: backend={}, current_session_id={}, \
+         persist_state={}, persist_pending={}, callback={}, pending_started_sessions={}",
+        self.type_name(),
+        initialization.state.persisted.current_session_id,
+        initialization.mutation.persist_state,
+        initialization.mutation.persist_pending,
+        initialization.mutation.callback.is_some(),
+        initialization.state.pending_started_sessions.len()
+      );
       (initialization.state, initialization.mutation)
     };
 
@@ -530,20 +676,36 @@ impl Strategy {
   ) -> (LoadedState, Mutation) {
     // Explicit session rotation re-reads persisted state so the durable queue remains the source
     // of truth even if this process has not initialized the in-memory cache yet.
+    let persisted = self.store.load_state();
+    let pending_started_sessions = self.store.load_pending_started_sessions();
+    log::debug!(
+      "starting explicit session rotation: backend={}, cached_state={}, has_persisted_state={}, \
+       pending_started_sessions={}",
+      self.type_name(),
+      guard.is_some(),
+      persisted.is_some(),
+      pending_started_sessions.len()
+    );
+
     let initialization = match &self.backend {
       Backend::Fixed(strategy) => self.with_callback_guard(|| {
-        strategy.start_new_session(
-          guard.as_ref(),
-          self.store.load_state(),
-          self.store.load_pending_started_sessions(),
-        )
+        strategy.start_new_session(guard.as_ref(), persisted, pending_started_sessions)
       }),
-      Backend::ActivityBased(strategy) => strategy.start_new_session(
-        guard.as_ref(),
-        self.store.load_state(),
-        self.store.load_pending_started_sessions(),
-      ),
+      Backend::ActivityBased(strategy) => {
+        strategy.start_new_session(guard.as_ref(), persisted, pending_started_sessions)
+      },
     };
+
+    log::debug!(
+      "computed explicit session rotation: backend={}, current_session_id={}, persist_state={}, \
+       persist_pending={}, callback={}, pending_started_sessions={}",
+      self.type_name(),
+      initialization.state.persisted.current_session_id,
+      initialization.mutation.persist_state,
+      initialization.mutation.persist_pending,
+      initialization.mutation.callback.is_some(),
+      initialization.state.pending_started_sessions.len()
+    );
 
     **guard = Some(initialization.state.clone());
     (initialization.state, initialization.mutation)
@@ -571,6 +733,17 @@ impl Strategy {
     state: LoadedState,
     mutation: Mutation,
   ) -> Option<DeferredCallback> {
+    log::debug!(
+      "finishing session mutation: backend={}, current_session_id={}, persist_state={}, \
+       persist_pending={}, callback={}, pending_started_sessions={}",
+      self.type_name(),
+      state.persisted.current_session_id,
+      mutation.persist_state,
+      mutation.persist_pending,
+      mutation.callback.is_some(),
+      state.pending_started_sessions.len()
+    );
+
     let pending_changed = mutation.persist_pending;
     let callback = mutation.callback.clone();
     self.persist_loaded_state(&state, &mutation).await;
@@ -583,6 +756,18 @@ impl Strategy {
   async fn persist_loaded_state(&self, state: &LoadedState, mutation: &Mutation) {
     // The strategy returns a mutation describing which durable pieces changed. Persist only those
     // pieces so reads can stay cheap while the on-disk view remains crash-safe.
+    if mutation.persist_state || mutation.persist_pending {
+      log::debug!(
+        "persisting durable session state: backend={}, current_session_id={}, persist_state={}, \
+         persist_pending={}, pending_started_sessions={}",
+        self.type_name(),
+        state.persisted.current_session_id,
+        mutation.persist_state,
+        mutation.persist_pending,
+        state.pending_started_sessions.len()
+      );
+    }
+
     if mutation.persist_state
       && let Err(e) = self.store.persist_state(&state.persisted).await
     {
@@ -604,6 +789,9 @@ impl Strategy {
     // observe half-applied transitions or deadlock against session APIs.
     match callback {
       Some(DeferredCallback::ActivitySessionChanged(session_id)) => {
+        log::debug!(
+          "dispatching deferred activity session callback: current_session_id={session_id}"
+        );
         if let Backend::ActivityBased(strategy) = &self.backend {
           self.with_callback_guard(|| strategy.run_callback(&session_id));
         }
@@ -613,9 +801,19 @@ impl Strategy {
   }
 
   fn notify_update(&self) {
-    self
-      .update_tx
-      .send_modify(|version| *version = version.wrapping_add(1));
+    let mut old_version = 0;
+    let mut new_version = 0;
+    self.update_tx.send_modify(|version| {
+      old_version = *version;
+      *version = version.wrapping_add(1);
+      new_version = *version;
+    });
+    log::debug!(
+      "advanced session update version: backend={}, old_version={}, new_version={}",
+      self.type_name(),
+      old_version,
+      new_version
+    );
   }
 }
 

--- a/bd-session/src/lib_test.rs
+++ b/bd-session/src/lib_test.rs
@@ -7,12 +7,15 @@
 
 use super::test::start_new_session;
 use super::{PendingStateUpdate, Strategy};
-use crate::fixed;
+use crate::persistence::{BackendState, PersistedSessionState, Store};
+use crate::{activity_based, fixed};
 use bd_proto::protos::client::api::StateUpdateRequest;
+use bd_time::TestTimeProvider;
 use pretty_assertions::assert_eq;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use tempfile::TempDir;
+use time::{Duration, OffsetDateTime};
 
 //
 // FixedCallbacks
@@ -45,11 +48,30 @@ impl fixed::Callbacks for FixedCallbacks {
   }
 }
 
+struct ActivityCallbacks;
+
+impl activity_based::Callbacks for ActivityCallbacks {
+  fn session_id_changed(&self, _session_id: &str) {}
+}
+
 fn fixed_strategy(sdk_directory: &TempDir, session_ids: &[&str]) -> Strategy {
   Strategy::fixed(
     sdk_directory.path(),
     Arc::new(FixedCallbacks::new(session_ids)),
   )
+}
+
+fn activity_strategy(sdk_directory: &TempDir, now: OffsetDateTime) -> Strategy {
+  Strategy::activity_based(
+    sdk_directory.path(),
+    Duration::minutes(30),
+    Arc::new(ActivityCallbacks),
+    Arc::new(TestTimeProvider::new(now)),
+  )
+}
+
+fn persisted_state(sdk_directory: &TempDir) -> PersistedSessionState {
+  Store::new(sdk_directory.path()).load_state().unwrap()
 }
 
 fn started_session_ids(request: &StateUpdateRequest) -> Vec<String> {
@@ -159,4 +181,58 @@ async fn handshake_does_not_duplicate_current_session_when_queue_already_contain
     started_session_ids(handshake.request())
   );
   assert_eq!(1, handshake.started_sessions.len());
+}
+
+#[tokio::test]
+async fn switching_from_fixed_to_activity_resyncs_persisted_backend() {
+  let sdk_directory = TempDir::new().unwrap();
+
+  let first_strategy = fixed_strategy(&sdk_directory, &["fixed-session"]);
+  let first_session_id = first_strategy.session_id().await.unwrap();
+  drop(first_strategy);
+
+  let restarted_strategy = activity_strategy(&sdk_directory, OffsetDateTime::now_utc());
+  let pending = restarted_strategy.pending_state_update().await.unwrap();
+  let restarted_session_id = restarted_strategy.try_current_session_id().unwrap();
+
+  assert_ne!(first_session_id, restarted_session_id);
+  assert_eq!(
+    Some(first_session_id.clone()),
+    restarted_strategy.previous_process_session_id()
+  );
+  assert_eq!(
+    vec![first_session_id.clone(), restarted_session_id],
+    started_session_ids(pending.request())
+  );
+  assert!(matches!(
+    persisted_state(&sdk_directory).backend,
+    BackendState::ActivityBased { .. }
+  ));
+}
+
+#[tokio::test]
+async fn switching_from_activity_to_fixed_resyncs_persisted_backend() {
+  let sdk_directory = TempDir::new().unwrap();
+
+  let first_strategy = activity_strategy(&sdk_directory, OffsetDateTime::now_utc());
+  let first_session_id = first_strategy.session_id().await.unwrap();
+  drop(first_strategy);
+
+  let restarted_strategy = fixed_strategy(&sdk_directory, &["fixed-session"]);
+  let pending = restarted_strategy.pending_state_update().await.unwrap();
+  let restarted_session_id = restarted_strategy.try_current_session_id().unwrap();
+
+  assert_ne!(first_session_id, restarted_session_id);
+  assert_eq!(
+    Some(first_session_id.clone()),
+    restarted_strategy.previous_process_session_id()
+  );
+  assert_eq!(
+    vec![first_session_id.clone(), restarted_session_id],
+    started_session_ids(pending.request())
+  );
+  assert!(matches!(
+    persisted_state(&sdk_directory).backend,
+    BackendState::Fixed
+  ));
 }

--- a/logger-cli/Cargo.toml
+++ b/logger-cli/Cargo.toml
@@ -20,6 +20,7 @@ bd-proto.path                = "../bd-proto"
 bd-session.path              = "../bd-session"
 bd-shutdown.path             = "../bd-shutdown"
 bd-test-helpers.path         = "../bd-test-helpers"
+bd-time.path                 = "../bd-time"
 bd-workspace-hack.workspace  = true
 clap.workspace               = true
 flatbuffers.workspace        = true

--- a/logger-cli/src/cli.rs
+++ b/logger-cli/src/cli.rs
@@ -6,7 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use clap::{ArgAction, Args, Parser, Subcommand};
-use logger_cli::logger::LoggerArgs;
+use logger_cli::logger::{LoggerArgs, SessionStrategyConfig};
 use logger_cli::types::{LogLevel, LogType, Platform, RuntimeValueType};
 use std::collections::HashMap;
 use std::hash::BuildHasher;
@@ -67,6 +67,12 @@ pub struct Options {
   pub command: Command,
 }
 
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionStrategy {
+  Fixed,
+  ActivityBased,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum Command {
   /// Emit a log
@@ -123,6 +129,14 @@ pub struct StartCommand {
   #[clap(long)]
   pub clean_data_dir: bool,
 
+  /// Session strategy used for logger sessions
+  #[clap(long, required = false, value_enum, default_value = "fixed")]
+  pub session_strategy: SessionStrategy,
+
+  /// Minutes of inactivity before rotating an activity-based session
+  #[clap(long, required = false, default_value_t = 30)]
+  pub inactivity_threshold_mins: i64,
+
   /// Bitdrift URL to connect
   #[clap(env, long, required = false, default_value = "https://api.bitdrift.io")]
   pub api_url: String,
@@ -150,6 +164,13 @@ pub struct StartCommand {
 
 impl From<StartCommand> for LoggerArgs {
   fn from(cmd: StartCommand) -> Self {
+    let session_strategy = match cmd.session_strategy {
+      SessionStrategy::Fixed => SessionStrategyConfig::Fixed,
+      SessionStrategy::ActivityBased => SessionStrategyConfig::ActivityBased {
+        inactivity_threshold_mins: cmd.inactivity_threshold_mins,
+      },
+    };
+
     Self {
       api_url: if cmd.api_url.contains("://") {
         cmd.api_url
@@ -163,6 +184,7 @@ impl From<StartCommand> for LoggerArgs {
       app_version_code: cmd.app_version_code,
       model: cmd.model,
       entity_id: cmd.entity_id,
+      session_strategy,
     }
   }
 }

--- a/logger-cli/src/cli_test.rs
+++ b/logger-cli/src/cli_test.rs
@@ -5,9 +5,10 @@
 // LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use super::{Command, Options};
+use super::{Command, Options, SessionStrategy};
 use crate::cli::FakeFeatureFlag;
 use clap::Parser;
+use logger_cli::logger::SessionStrategyConfig;
 
 #[test]
 fn parses_set_entity_id_command() {
@@ -34,6 +35,44 @@ fn parses_start_entity_id_flag() {
     options.command,
     Command::Start(cmd) if cmd.entity_id.as_deref() == Some("entity-123")
   ));
+}
+
+#[test]
+fn start_uses_fixed_session_strategy_by_default() {
+  let options = Options::parse_from(["logger-cli", "start", "--api-key", "test-key"]);
+
+  assert!(matches!(
+    options.command,
+    Command::Start(cmd)
+      if cmd.session_strategy == SessionStrategy::Fixed && cmd.inactivity_threshold_mins == 30
+  ));
+}
+
+#[test]
+fn parses_activity_based_session_strategy() {
+  let options = Options::parse_from([
+    "logger-cli",
+    "start",
+    "--api-key",
+    "test-key",
+    "--session-strategy",
+    "activity-based",
+    "--inactivity-threshold-mins",
+    "45",
+  ]);
+
+  let Command::Start(cmd) = options.command else {
+    panic!("expected start command");
+  };
+
+  let logger_args: logger_cli::logger::LoggerArgs = cmd.into();
+
+  assert_eq!(
+    SessionStrategyConfig::ActivityBased {
+      inactivity_threshold_mins: 45,
+    },
+    logger_args.session_strategy
+  );
 }
 
 #[test]

--- a/logger-cli/src/logger.rs
+++ b/logger-cli/src/logger.rs
@@ -15,7 +15,8 @@ use crate::types::{Platform, RuntimeValueType};
 use bd_log_primitives::LogFields;
 use bd_logger::{Block, CaptureSession, InitParams, Logger, MetadataProvider};
 use bd_proto::protos::logging::payload::LogType as ProtoLogType;
-use bd_session::{Strategy, fixed};
+use bd_session::{Strategy, activity_based, fixed};
+use bd_time::TimeProvider;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::path::Path;
@@ -41,6 +42,29 @@ impl MetadataProvider for LiveTimestampMetadata {
   fn fields(&self) -> anyhow::Result<(LogFields, LogFields)> {
     Ok((LogFields::default(), self.ootb_fields.clone()))
   }
+}
+
+//
+// ActivitySessionCallbacks
+//
+
+#[derive(Default)]
+struct ActivitySessionCallbacks;
+
+impl activity_based::Callbacks for ActivitySessionCallbacks {
+  fn session_id_changed(&self, session_id: &str) {
+    log::info!("activity-based session rotated: {session_id}");
+  }
+}
+
+//
+// SessionStrategyConfig
+//
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionStrategyConfig {
+  Fixed,
+  ActivityBased { inactivity_threshold_mins: i64 },
 }
 
 pub struct LoggerHolder {
@@ -261,11 +285,30 @@ async fn fetch_device_code(args: &LoggerArgs, device_id: &str) -> anyhow::Result
   Ok(device_code_response.code)
 }
 
-fn make_session_strategy(sdk_directory: &Path) -> Arc<Strategy> {
-  Arc::new(Strategy::fixed(
+fn make_session_strategy(sdk_directory: &Path, config: &SessionStrategyConfig) -> Arc<Strategy> {
+  make_session_strategy_with_time_provider(
     sdk_directory,
-    Arc::new(fixed::UUIDCallbacks),
-  ))
+    config,
+    Arc::new(bd_time::SystemTimeProvider),
+  )
+}
+
+fn make_session_strategy_with_time_provider(
+  sdk_directory: &Path,
+  config: &SessionStrategyConfig,
+  time_provider: Arc<dyn TimeProvider>,
+) -> Arc<Strategy> {
+  Arc::new(match config {
+    SessionStrategyConfig::Fixed => Strategy::fixed(sdk_directory, Arc::new(fixed::UUIDCallbacks)),
+    SessionStrategyConfig::ActivityBased {
+      inactivity_threshold_mins,
+    } => Strategy::activity_based(
+      sdk_directory,
+      time::Duration::minutes(*inactivity_threshold_mins),
+      Arc::new(ActivitySessionCallbacks),
+      time_provider,
+    ),
+  })
 }
 
 pub struct LoggerArgs {
@@ -277,10 +320,11 @@ pub struct LoggerArgs {
   pub app_version_code: String,
   pub model: String,
   pub entity_id: Option<String>,
+  pub session_strategy: SessionStrategyConfig,
 }
 
 pub async fn make_logger(sdk_directory: &Path, args: &LoggerArgs) -> anyhow::Result<LoggerHolder> {
-  let session_strategy = make_session_strategy(sdk_directory);
+  let session_strategy = make_session_strategy(sdk_directory, &args.session_strategy);
   let storage_db = sdk_directory.join("defaults.db");
   let storage = SQLiteStorage::new(&storage_db);
   let store = Arc::new(bd_key_value::Store::new(Box::new(storage)));

--- a/logger-cli/src/logger_test.rs
+++ b/logger-cli/src/logger_test.rs
@@ -7,10 +7,16 @@
 
 #![allow(clippy::unwrap_used)]
 
-use super::make_session_strategy;
+use super::{
+  SessionStrategyConfig,
+  make_session_strategy,
+  make_session_strategy_with_time_provider,
+};
+use bd_time::TestTimeProvider;
 use std::fs;
 use std::path::{Path, PathBuf};
-use time::OffsetDateTime;
+use std::sync::Arc;
+use time::{Duration, OffsetDateTime};
 
 struct TestSdkDirectory {
   path: PathBuf,
@@ -40,16 +46,45 @@ impl Drop for TestSdkDirectory {
 #[tokio::test]
 async fn fixed_sessions_do_not_persist_across_restarts() {
   let sdk_directory = TestSdkDirectory::new();
+  let config = SessionStrategyConfig::Fixed;
 
-  let first_strategy = make_session_strategy(sdk_directory.path());
+  let first_strategy = make_session_strategy(sdk_directory.path(), &config);
   let first_session_id = first_strategy.session_id().await.unwrap();
   first_strategy.flush().await;
   drop(first_strategy);
 
-  let restarted_strategy = make_session_strategy(sdk_directory.path());
+  let restarted_strategy = make_session_strategy(sdk_directory.path(), &config);
   let restarted_session_id = restarted_strategy.session_id().await.unwrap();
 
   assert_ne!(first_session_id, restarted_session_id);
+  assert_eq!(
+    Some(first_session_id),
+    restarted_strategy.previous_process_session_id()
+  );
+}
+
+#[tokio::test]
+async fn activity_based_sessions_persist_across_restarts_within_threshold() {
+  let sdk_directory = TestSdkDirectory::new();
+  let now = OffsetDateTime::now_utc();
+  let time_provider = Arc::new(TestTimeProvider::new(now));
+  let config = SessionStrategyConfig::ActivityBased {
+    inactivity_threshold_mins: 30,
+  };
+
+  let first_strategy =
+    make_session_strategy_with_time_provider(sdk_directory.path(), &config, time_provider.clone());
+  let first_session_id = first_strategy.session_id().await.unwrap();
+  first_strategy.flush().await;
+  drop(first_strategy);
+
+  time_provider.advance(Duration::minutes(5));
+
+  let restarted_strategy =
+    make_session_strategy_with_time_provider(sdk_directory.path(), &config, time_provider);
+  let restarted_session_id = restarted_strategy.session_id().await.unwrap();
+
+  assert_eq!(first_session_id, restarted_session_id);
   assert_eq!(
     Some(first_session_id),
     restarted_strategy.previous_process_session_id()


### PR DESCRIPTION
Previously if the fixed strategy was persisted this did not work correctly. This is really only an issue during onboarding but still a problem.

Also add the ability to configure the activity strategy in logger-cli to aid in testing.