### PR TITLE
Split gRPC server error metrics by status class

### DIFF
--- a/bd-grpc/src/error.rs
+++ b/bd-grpc/src/error.rs
@@ -39,6 +39,20 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl Error {
+  #[must_use]
+  pub fn grpc_code(&self) -> Code {
+    match self {
+      Self::Grpc(status) => status.code(),
+      Self::Codec(bd_grpc_codec::Error::MessageTooLarge { .. }) => Code::ResourceExhausted,
+      Self::Codec(_) | Self::ProtoValidation(_) | Self::Snap(_) => Code::InvalidArgument,
+      Self::ConnectionTimeout
+      | Self::RequestTimeout
+      | Self::BodyStream(_)
+      | Self::Closed
+      | Self::HyperClient(_) => Code::Internal,
+    }
+  }
+
   fn into_status(self) -> Status {
     match self {
       Self::Grpc(status) => status,

--- a/bd-grpc/src/grpc_test.rs
+++ b/bd-grpc/src/grpc_test.rs
@@ -710,7 +710,44 @@ async fn unary_error_handler() {
     &labels! {
       "service" => "test_Test",
       "endpoint" => "Echo",
-      "result" => "failure"
+      "result" => "server_error"
+    },
+  );
+}
+
+#[tokio::test]
+async fn unary_error_handler_classifies_client_errors() {
+  let stats = Helper::new();
+  let endpoints_stats = EndpointStats::new(stats.collector().scope("test"));
+  let local_address = make_unary_server(
+    Arc::new(EncodedErrorHandler {}),
+    |_| {},
+    Some(&endpoints_stats),
+  )
+  .await;
+  let client = Client::new_http(local_address.to_string().as_str(), 1.minutes(), 1024).unwrap();
+  assert_matches!(
+    client
+      .unary(
+        &service_method(),
+        None,
+        EchoRequest {
+          echo: "ok".to_string(),
+          ..Default::default()
+        },
+        1.seconds(),
+        Compression::None,
+      )
+      .await,
+    Err(Error::Grpc(_))
+  );
+  stats.assert_counter_eq(
+    1,
+    "test:rpc",
+    &labels! {
+      "service" => "test_Test",
+      "endpoint" => "Echo",
+      "result" => "client_error"
     },
   );
 }
@@ -1298,7 +1335,7 @@ async fn server_streaming_error_handler() {
     &labels! {
       "service" => "test_Test",
       "endpoint" => "Echo",
-      "result" => "failure"
+      "result" => "server_error"
     },
   );
   stats_helper.assert_counter_eq(
@@ -2028,7 +2065,7 @@ async fn connect_unary_error_stats() {
     &labels! {
       "service" => "test_Test",
       "endpoint" => "Echo",
-      "result" => "failure"
+      "result" => "server_error"
     },
   );
 }

--- a/bd-grpc/src/lib.rs
+++ b/bd-grpc/src/lib.rs
@@ -307,7 +307,7 @@ where
 
               error_handler(e);
               if let Some(resolved_stats) = &resolved_stats {
-                resolved_stats.failure.inc();
+                resolved_stats.inc_error(e.grpc_code());
               }
             } else if let Some(resolved_stats) = &resolved_stats {
               resolved_stats.success.inc();
@@ -1046,7 +1046,7 @@ async fn server_streaming_handler<ResponseType: MessageFull, RequestType: Messag
   .await
   .inspect_err(|_| {
     if let Some(stream_stats) = &stream_stats {
-      stream_stats.rpc.failure.inc();
+      stream_stats.rpc.inc_error(Code::InvalidArgument);
     }
   })?;
 
@@ -1084,7 +1084,7 @@ async fn server_streaming_handler<ResponseType: MessageFull, RequestType: Messag
         }
 
         if let Some(stream_stats) = &stream_stats {
-          stream_stats.rpc.failure.inc();
+          stream_stats.rpc.inc_error(e.grpc_code());
         }
         error_handler(&e);
 
@@ -1179,7 +1179,7 @@ fn bidi_streaming_handler<ResponseType: MessageFull, RequestType: MessageFull>(
         }
 
         if let Some(stream_stats) = &stream_stats {
-          stream_stats.rpc.failure.inc();
+          stream_stats.rpc.inc_error(e.grpc_code());
         }
         error_handler(&e);
 

--- a/bd-grpc/src/stats.rs
+++ b/bd-grpc/src/stats.rs
@@ -6,6 +6,8 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use crate::service::ServiceMethod;
+use crate::status::code_to_connect_http_status;
+use bd_grpc_codec::code::Code;
 use bd_server_stats::stats::{CounterWrapper, Scope};
 use bd_stats_common::DynCounter;
 use prometheus::{IntCounter, IntCounterVec};
@@ -23,7 +25,18 @@ pub struct EndpointStats {
 #[derive(Clone)]
 pub struct ResolvedEndpointStats {
   pub success: IntCounter,
-  pub failure: IntCounter,
+  pub client_error: IntCounter,
+  pub server_error: IntCounter,
+}
+
+impl ResolvedEndpointStats {
+  pub fn inc_error(&self, code: Code) {
+    if code_to_connect_http_status(code).is_client_error() {
+      self.client_error.inc();
+    } else {
+      self.server_error.inc();
+    }
+  }
 }
 
 impl EndpointStats {
@@ -45,10 +58,15 @@ impl EndpointStats {
         service.method_name(),
         "success",
       ]),
-      failure: self.rpc.with_label_values(&[
+      client_error: self.rpc.with_label_values(&[
         service.service_name().replace('.', "_").as_str(),
         service.method_name(),
-        "failure",
+        "client_error",
+      ]),
+      server_error: self.rpc.with_label_values(&[
+        service.service_name().replace('.', "_").as_str(),
+        service.method_name(),
+        "server_error",
       ]),
     }
   }


### PR DESCRIPTION
Split bd-grpc RPC metrics so non-Ok responses are classified as client_error or server_error instead of all incrementing result=failure.

This keeps success scoped to Code::Ok, reuses the existing gRPC-to-HTTP status mapping for classification, and updates the unary and streaming tests to cover both client and server error paths.