### PR TITLE
[BIT-9017] Add Apple crash_info support to report serialization and writer

### DIFF
--- a/bd-proto/src/flatbuffers/report.schema.json
+++ b/bd-proto/src/flatbuffers/report.schema.json
@@ -25,6 +25,14 @@
       "type" : "string",
       "enum": ["CausedBy"]
     },
+    "bitdrift_public_fbs_issue_reporting_v1_CrashReporterScope" : {
+      "type" : "string",
+      "enum": ["Unknown", "InProcess", "OutOfProcess"]
+    },
+    "bitdrift_public_fbs_issue_reporting_v1_CrashReporter" : {
+      "type" : "string",
+      "enum": ["Unknown", "AppleMetricKit", "AppleKSCrash", "AppleBitdriftCrashReporter", "AndroidUncaughtExceptionHandler", "AndroidApplicationExitInfo"]
+    },
     "bitdrift_public_fbs_issue_reporting_v1_PowerState" : {
       "type" : "string",
       "enum": ["Unknown", "RunningOnBattery", "PluggedInNoBattery", "PluggedInCharging", "PluggedInCharged"]
@@ -48,6 +56,10 @@
     "bitdrift_public_fbs_issue_reporting_v1_FrameStatus" : {
       "type" : "string",
       "enum": ["Missing", "Symbolicated", "MissingSymbol", "UnknownImage", "Malformed"]
+    },
+    "bitdrift_public_fbs_issue_reporting_v1_CrashInfoDetails" : {
+      "type" : "string",
+      "enum": ["NONE", "AppleCrashDetails"]
     },
     "bitdrift_public_fbs_common_v1_StringData" : {
       "type" : "object",
@@ -421,6 +433,126 @@
       },
       "additionalProperties" : false
     },
+    "bitdrift_public_fbs_issue_reporting_v1_NSException" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+                "type" : "string"
+              },
+        "reason" : {
+                "type" : "string"
+              },
+        "user_info" : {
+                "type" : "array", "items" : {"$ref" : "#/definitions/bitdrift_public_fbs_common_v1_Field"}
+              }
+      },
+      "additionalProperties" : false
+    },
+    "bitdrift_public_fbs_issue_reporting_v1_MachException" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+                "type" : "integer", "minimum" : 0, "maximum" : 4294967295
+              },
+        "code" : {
+                "type" : "integer", "minimum" : 0, "maximum" : 18446744073709551615
+              },
+        "subcode" : {
+                "type" : "integer", "minimum" : 0, "maximum" : 18446744073709551615
+              }
+      },
+      "additionalProperties" : false
+    },
+    "bitdrift_public_fbs_issue_reporting_v1_PosixSignal" : {
+      "type" : "object",
+      "properties" : {
+        "number" : {
+                "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
+              },
+        "code" : {
+                "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
+              },
+        "errno" : {
+                "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
+              },
+        "has_fault_address" : {
+                "type" : "boolean"
+              },
+        "fault_address" : {
+                "type" : "integer", "minimum" : 0, "maximum" : 18446744073709551615
+              }
+      },
+      "additionalProperties" : false
+    },
+    "bitdrift_public_fbs_issue_reporting_v1_AppleTermination" : {
+      "type" : "object",
+      "properties" : {
+        "domain" : {
+                "type" : "string"
+              },
+        "code" : {
+                "type" : "string"
+              },
+        "explanation" : {
+                "type" : "string"
+              },
+        "process_visibility" : {
+                "type" : "string"
+              },
+        "process_state" : {
+                "type" : "string"
+              },
+        "watchdog_event" : {
+                "type" : "string"
+              },
+        "watchdog_visibility" : {
+                "type" : "string"
+              }
+      },
+      "additionalProperties" : false
+    },
+    "bitdrift_public_fbs_issue_reporting_v1_AppleCrashDetails" : {
+      "type" : "object",
+      "properties" : {
+        "nsexception" : {
+                "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_NSException"
+              },
+        "mach_exception" : {
+                "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_MachException"
+              },
+        "posix_signal" : {
+                "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_PosixSignal"
+              },
+        "termination" : {
+                "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_AppleTermination"
+              }
+      },
+      "additionalProperties" : false
+    },
+    "bitdrift_public_fbs_issue_reporting_v1_CrashInfo" : {
+      "type" : "object",
+      "properties" : {
+        "reporter_scope" : {
+                "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_CrashReporterScope"
+              },
+        "reporter" : {
+                "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_CrashReporter"
+              },
+        "occurred_at" : {
+                "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_Timestamp"
+              },
+        "details_type" : {
+                "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_CrashInfoDetails"
+              },
+        "details" : {
+                "anyOf": [{ "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_AppleCrashDetails" }]
+              },
+        "thread_details" : {
+                "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_ThreadDetails"
+              }
+      },
+      "additionalProperties" : false
+    },
     "bitdrift_public_fbs_issue_reporting_v1_BinaryImage" : {
       "type" : "object",
       "properties" : {
@@ -504,6 +636,9 @@
               },
         "processing_result" : {
                 "$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_ProcessingResult"
+              },
+        "crash_info" : {
+                "type" : "array", "items" : {"$ref" : "#/definitions/bitdrift_public_fbs_issue_reporting_v1_CrashInfo"}
               }
       },
       "additionalProperties" : false

--- a/bd-proto/src/flatbuffers/report.schema.json
+++ b/bd-proto/src/flatbuffers/report.schema.json
@@ -472,7 +472,7 @@
         "code" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
-        "errno" : {
+        "errno_value" : {
                 "type" : "integer", "minimum" : -2147483648, "maximum" : 2147483647
               },
         "has_fault_address" : {

--- a/bd-proto/src/flatbuffers/report_generated.rs
+++ b/bd-proto/src/flatbuffers/report_generated.rs
@@ -529,6 +529,196 @@ impl<'a> flatbuffers::Verifiable for ErrorRelation {
 
 impl flatbuffers::SimpleToVerifyInSlice for ErrorRelation {}
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MIN_CRASH_REPORTER_SCOPE: i8 = 0;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MAX_CRASH_REPORTER_SCOPE: i8 = 2;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_CRASH_REPORTER_SCOPE: [CrashReporterScope; 3] = [
+  CrashReporterScope::Unknown,
+  CrashReporterScope::InProcess,
+  CrashReporterScope::OutOfProcess,
+];
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct CrashReporterScope(pub i8);
+#[allow(non_upper_case_globals)]
+impl CrashReporterScope {
+  pub const Unknown: Self = Self(0);
+  pub const InProcess: Self = Self(1);
+  pub const OutOfProcess: Self = Self(2);
+
+  pub const ENUM_MIN: i8 = 0;
+  pub const ENUM_MAX: i8 = 2;
+  pub const ENUM_VALUES: &'static [Self] = &[
+    Self::Unknown,
+    Self::InProcess,
+    Self::OutOfProcess,
+  ];
+  /// Returns the variant's name or "" if unknown.
+  pub fn variant_name(self) -> Option<&'static str> {
+    match self {
+      Self::Unknown => Some("Unknown"),
+      Self::InProcess => Some("InProcess"),
+      Self::OutOfProcess => Some("OutOfProcess"),
+      _ => None,
+    }
+  }
+}
+impl core::fmt::Debug for CrashReporterScope {
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    if let Some(name) = self.variant_name() {
+      f.write_str(name)
+    } else {
+      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+    }
+  }
+}
+impl<'a> flatbuffers::Follow<'a> for CrashReporterScope {
+  type Inner = Self;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    let b = unsafe { flatbuffers::read_scalar_at::<i8>(buf, loc) };
+    Self(b)
+  }
+}
+
+impl flatbuffers::Push for CrashReporterScope {
+    type Output = CrashReporterScope;
+    #[inline]
+    unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
+        unsafe { flatbuffers::emplace_scalar::<i8>(dst, self.0); }
+    }
+}
+
+impl flatbuffers::EndianScalar for CrashReporterScope {
+  type Scalar = i8;
+  #[inline]
+  fn to_little_endian(self) -> i8 {
+    self.0.to_le()
+  }
+  #[inline]
+  #[allow(clippy::wrong_self_convention)]
+  fn from_little_endian(v: i8) -> Self {
+    let b = i8::from_le(v);
+    Self(b)
+  }
+}
+
+impl<'a> flatbuffers::Verifiable for CrashReporterScope {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    i8::run_verifier(v, pos)
+  }
+}
+
+impl flatbuffers::SimpleToVerifyInSlice for CrashReporterScope {}
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MIN_CRASH_REPORTER: i8 = 0;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MAX_CRASH_REPORTER: i8 = 5;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_CRASH_REPORTER: [CrashReporter; 6] = [
+  CrashReporter::Unknown,
+  CrashReporter::AppleMetricKit,
+  CrashReporter::AppleKSCrash,
+  CrashReporter::AppleBitdriftCrashReporter,
+  CrashReporter::AndroidUncaughtExceptionHandler,
+  CrashReporter::AndroidApplicationExitInfo,
+];
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct CrashReporter(pub i8);
+#[allow(non_upper_case_globals)]
+impl CrashReporter {
+  pub const Unknown: Self = Self(0);
+  pub const AppleMetricKit: Self = Self(1);
+  pub const AppleKSCrash: Self = Self(2);
+  pub const AppleBitdriftCrashReporter: Self = Self(3);
+  pub const AndroidUncaughtExceptionHandler: Self = Self(4);
+  pub const AndroidApplicationExitInfo: Self = Self(5);
+
+  pub const ENUM_MIN: i8 = 0;
+  pub const ENUM_MAX: i8 = 5;
+  pub const ENUM_VALUES: &'static [Self] = &[
+    Self::Unknown,
+    Self::AppleMetricKit,
+    Self::AppleKSCrash,
+    Self::AppleBitdriftCrashReporter,
+    Self::AndroidUncaughtExceptionHandler,
+    Self::AndroidApplicationExitInfo,
+  ];
+  /// Returns the variant's name or "" if unknown.
+  pub fn variant_name(self) -> Option<&'static str> {
+    match self {
+      Self::Unknown => Some("Unknown"),
+      Self::AppleMetricKit => Some("AppleMetricKit"),
+      Self::AppleKSCrash => Some("AppleKSCrash"),
+      Self::AppleBitdriftCrashReporter => Some("AppleBitdriftCrashReporter"),
+      Self::AndroidUncaughtExceptionHandler => Some("AndroidUncaughtExceptionHandler"),
+      Self::AndroidApplicationExitInfo => Some("AndroidApplicationExitInfo"),
+      _ => None,
+    }
+  }
+}
+impl core::fmt::Debug for CrashReporter {
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    if let Some(name) = self.variant_name() {
+      f.write_str(name)
+    } else {
+      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+    }
+  }
+}
+impl<'a> flatbuffers::Follow<'a> for CrashReporter {
+  type Inner = Self;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    let b = unsafe { flatbuffers::read_scalar_at::<i8>(buf, loc) };
+    Self(b)
+  }
+}
+
+impl flatbuffers::Push for CrashReporter {
+    type Output = CrashReporter;
+    #[inline]
+    unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
+        unsafe { flatbuffers::emplace_scalar::<i8>(dst, self.0); }
+    }
+}
+
+impl flatbuffers::EndianScalar for CrashReporter {
+  type Scalar = i8;
+  #[inline]
+  fn to_little_endian(self) -> i8 {
+    self.0.to_le()
+  }
+  #[inline]
+  #[allow(clippy::wrong_self_convention)]
+  fn from_little_endian(v: i8) -> Self {
+    let b = i8::from_le(v);
+    Self(b)
+  }
+}
+
+impl<'a> flatbuffers::Verifiable for CrashReporter {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    i8::run_verifier(v, pos)
+  }
+}
+
+impl flatbuffers::SimpleToVerifyInSlice for CrashReporter {}
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_POWER_STATE: i8 = 0;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MAX_POWER_STATE: i8 = 4;
@@ -1094,6 +1284,140 @@ impl<'a> flatbuffers::Verifiable for FrameStatus {
 }
 
 impl flatbuffers::SimpleToVerifyInSlice for FrameStatus {}
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MIN_CRASH_INFO_DETAILS: u8 = 0;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MAX_CRASH_INFO_DETAILS: u8 = 1;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_CRASH_INFO_DETAILS: [CrashInfoDetails; 2] = [
+  CrashInfoDetails::NONE,
+  CrashInfoDetails::AppleCrashDetails,
+];
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct CrashInfoDetails(pub u8);
+#[allow(non_upper_case_globals)]
+impl CrashInfoDetails {
+  pub const NONE: Self = Self(0);
+  pub const AppleCrashDetails: Self = Self(1);
+
+  pub const ENUM_MIN: u8 = 0;
+  pub const ENUM_MAX: u8 = 1;
+  pub const ENUM_VALUES: &'static [Self] = &[
+    Self::NONE,
+    Self::AppleCrashDetails,
+  ];
+  /// Returns the variant's name or "" if unknown.
+  pub fn variant_name(self) -> Option<&'static str> {
+    match self {
+      Self::NONE => Some("NONE"),
+      Self::AppleCrashDetails => Some("AppleCrashDetails"),
+      _ => None,
+    }
+  }
+}
+impl core::fmt::Debug for CrashInfoDetails {
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    if let Some(name) = self.variant_name() {
+      f.write_str(name)
+    } else {
+      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+    }
+  }
+}
+impl<'a> flatbuffers::Follow<'a> for CrashInfoDetails {
+  type Inner = Self;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
+    Self(b)
+  }
+}
+
+impl flatbuffers::Push for CrashInfoDetails {
+    type Output = CrashInfoDetails;
+    #[inline]
+    unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
+        unsafe { flatbuffers::emplace_scalar::<u8>(dst, self.0); }
+    }
+}
+
+impl flatbuffers::EndianScalar for CrashInfoDetails {
+  type Scalar = u8;
+  #[inline]
+  fn to_little_endian(self) -> u8 {
+    self.0.to_le()
+  }
+  #[inline]
+  #[allow(clippy::wrong_self_convention)]
+  fn from_little_endian(v: u8) -> Self {
+    let b = u8::from_le(v);
+    Self(b)
+  }
+}
+
+impl<'a> flatbuffers::Verifiable for CrashInfoDetails {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    u8::run_verifier(v, pos)
+  }
+}
+
+impl flatbuffers::SimpleToVerifyInSlice for CrashInfoDetails {}
+pub struct CrashInfoDetailsUnionTableOffset {}
+
+#[allow(clippy::upper_case_acronyms)]
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub enum CrashInfoDetailsT {
+  NONE,
+  AppleCrashDetails(Box<AppleCrashDetailsT>),
+}
+impl Default for CrashInfoDetailsT {
+  fn default() -> Self {
+    Self::NONE
+  }
+}
+impl CrashInfoDetailsT {
+  pub fn crash_info_details_type(&self) -> CrashInfoDetails {
+    match self {
+      Self::NONE => CrashInfoDetails::NONE,
+      Self::AppleCrashDetails(_) => CrashInfoDetails::AppleCrashDetails,
+    }
+  }
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(&self, fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>) -> Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>> {
+    match self {
+      Self::NONE => None,
+      Self::AppleCrashDetails(v) => Some(v.pack(fbb).as_union_value()),
+    }
+  }
+  /// If the union variant matches, return the owned AppleCrashDetailsT, setting the union to NONE.
+  pub fn take_apple_crash_details(&mut self) -> Option<Box<AppleCrashDetailsT>> {
+    if let Self::AppleCrashDetails(_) = self {
+      let v = core::mem::replace(self, Self::NONE);
+      if let Self::AppleCrashDetails(w) = v {
+        Some(w)
+      } else {
+        unreachable!()
+      }
+    } else {
+      None
+    }
+  }
+  /// If the union variant matches, return a reference to the AppleCrashDetailsT.
+  pub fn as_apple_crash_details(&self) -> Option<&AppleCrashDetailsT> {
+    if let Self::AppleCrashDetails(v) = self { Some(v.as_ref()) } else { None }
+  }
+  /// If the union variant matches, return a mutable reference to the AppleCrashDetailsT.
+  pub fn as_apple_crash_details_mut(&mut self) -> Option<&mut AppleCrashDetailsT> {
+    if let Self::AppleCrashDetails(v) = self { Some(v.as_mut()) } else { None }
+  }
+}
 // struct Timestamp, aligned to 8
 #[repr(transparent)]
 #[derive(Clone, Copy, PartialEq)]
@@ -4578,6 +4902,1366 @@ impl ErrorT {
     })
   }
 }
+pub enum NSExceptionOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct NSException<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for NSException<'a> {
+  type Inner = NSException<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
+  }
+}
+
+impl<'a> NSException<'a> {
+  pub const VT_NAME: flatbuffers::VOffsetT = 4;
+  pub const VT_REASON: flatbuffers::VOffsetT = 6;
+  pub const VT_USER_INFO: flatbuffers::VOffsetT = 8;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    NSException { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args NSExceptionArgs<'args>
+  ) -> flatbuffers::WIPOffset<NSException<'bldr>> {
+    let mut builder = NSExceptionBuilder::new(_fbb);
+    if let Some(x) = args.user_info { builder.add_user_info(x); }
+    if let Some(x) = args.reason { builder.add_reason(x); }
+    if let Some(x) = args.name { builder.add_name(x); }
+    builder.finish()
+  }
+
+  pub fn unpack(&self) -> NSExceptionT {
+    let name = self.name().map(|x| {
+      x.to_string()
+    });
+    let reason = self.reason().map(|x| {
+      x.to_string()
+    });
+    let user_info = self.user_info().map(|x| {
+      x.iter().map(|t| t.unpack()).collect()
+    });
+    NSExceptionT {
+      name,
+      reason,
+      user_info,
+    }
+  }
+
+  #[inline]
+  pub fn name(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(NSException::VT_NAME, None)}
+  }
+  #[inline]
+  pub fn reason(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(NSException::VT_REASON, None)}
+  }
+  #[inline]
+  pub fn user_info(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<super::super::common::v_1::Field<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<super::super::common::v_1::Field>>>>(NSException::VT_USER_INFO, None)}
+  }
+}
+
+impl flatbuffers::Verifiable for NSException<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("name", Self::VT_NAME, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("reason", Self::VT_REASON, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<super::super::common::v_1::Field>>>>("user_info", Self::VT_USER_INFO, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct NSExceptionArgs<'a> {
+    pub name: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub reason: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub user_info: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<super::super::common::v_1::Field<'a>>>>>,
+}
+impl<'a> Default for NSExceptionArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    NSExceptionArgs {
+      name: None,
+      reason: None,
+      user_info: None,
+    }
+  }
+}
+
+pub struct NSExceptionBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> NSExceptionBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_name(&mut self, name: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(NSException::VT_NAME, name);
+  }
+  #[inline]
+  pub fn add_reason(&mut self, reason: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(NSException::VT_REASON, reason);
+  }
+  #[inline]
+  pub fn add_user_info(&mut self, user_info: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<super::super::common::v_1::Field<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(NSException::VT_USER_INFO, user_info);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> NSExceptionBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    NSExceptionBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<NSException<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for NSException<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("NSException");
+      ds.field("name", &self.name());
+      ds.field("reason", &self.reason());
+      ds.field("user_info", &self.user_info());
+      ds.finish()
+  }
+}
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct NSExceptionT {
+  pub name: Option<String>,
+  pub reason: Option<String>,
+  pub user_info: Option<Vec<super::super::common::v_1::FieldT>>,
+}
+impl Default for NSExceptionT {
+  fn default() -> Self {
+    Self {
+      name: None,
+      reason: None,
+      user_info: None,
+    }
+  }
+}
+impl NSExceptionT {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
+    &self,
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
+  ) -> flatbuffers::WIPOffset<NSException<'b>> {
+    let name = self.name.as_ref().map(|x|{
+      _fbb.create_string(x)
+    });
+    let reason = self.reason.as_ref().map(|x|{
+      _fbb.create_string(x)
+    });
+    let user_info = self.user_info.as_ref().map(|x|{
+      let w: Vec<_> = x.iter().map(|t| t.pack(_fbb)).collect();_fbb.create_vector(&w)
+    });
+    NSException::create(_fbb, &NSExceptionArgs{
+      name,
+      reason,
+      user_info,
+    })
+  }
+}
+pub enum MachExceptionOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct MachException<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for MachException<'a> {
+  type Inner = MachException<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
+  }
+}
+
+impl<'a> MachException<'a> {
+  pub const VT_TYPE_: flatbuffers::VOffsetT = 4;
+  pub const VT_CODE: flatbuffers::VOffsetT = 6;
+  pub const VT_SUBCODE: flatbuffers::VOffsetT = 8;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    MachException { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args MachExceptionArgs
+  ) -> flatbuffers::WIPOffset<MachException<'bldr>> {
+    let mut builder = MachExceptionBuilder::new(_fbb);
+    builder.add_subcode(args.subcode);
+    builder.add_code(args.code);
+    builder.add_type_(args.type_);
+    builder.finish()
+  }
+
+  pub fn unpack(&self) -> MachExceptionT {
+    let type_ = self.type_();
+    let code = self.code();
+    let subcode = self.subcode();
+    MachExceptionT {
+      type_,
+      code,
+      subcode,
+    }
+  }
+
+  #[inline]
+  pub fn type_(&self) -> u32 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u32>(MachException::VT_TYPE_, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn code(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(MachException::VT_CODE, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn subcode(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(MachException::VT_SUBCODE, Some(0)).unwrap()}
+  }
+}
+
+impl flatbuffers::Verifiable for MachException<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<u32>("type_", Self::VT_TYPE_, false)?
+     .visit_field::<u64>("code", Self::VT_CODE, false)?
+     .visit_field::<u64>("subcode", Self::VT_SUBCODE, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct MachExceptionArgs {
+    pub type_: u32,
+    pub code: u64,
+    pub subcode: u64,
+}
+impl<'a> Default for MachExceptionArgs {
+  #[inline]
+  fn default() -> Self {
+    MachExceptionArgs {
+      type_: 0,
+      code: 0,
+      subcode: 0,
+    }
+  }
+}
+
+pub struct MachExceptionBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> MachExceptionBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_type_(&mut self, type_: u32) {
+    self.fbb_.push_slot::<u32>(MachException::VT_TYPE_, type_, 0);
+  }
+  #[inline]
+  pub fn add_code(&mut self, code: u64) {
+    self.fbb_.push_slot::<u64>(MachException::VT_CODE, code, 0);
+  }
+  #[inline]
+  pub fn add_subcode(&mut self, subcode: u64) {
+    self.fbb_.push_slot::<u64>(MachException::VT_SUBCODE, subcode, 0);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> MachExceptionBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    MachExceptionBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<MachException<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for MachException<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("MachException");
+      ds.field("type_", &self.type_());
+      ds.field("code", &self.code());
+      ds.field("subcode", &self.subcode());
+      ds.finish()
+  }
+}
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct MachExceptionT {
+  pub type_: u32,
+  pub code: u64,
+  pub subcode: u64,
+}
+impl Default for MachExceptionT {
+  fn default() -> Self {
+    Self {
+      type_: 0,
+      code: 0,
+      subcode: 0,
+    }
+  }
+}
+impl MachExceptionT {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
+    &self,
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
+  ) -> flatbuffers::WIPOffset<MachException<'b>> {
+    let type_ = self.type_;
+    let code = self.code;
+    let subcode = self.subcode;
+    MachException::create(_fbb, &MachExceptionArgs{
+      type_,
+      code,
+      subcode,
+    })
+  }
+}
+pub enum PosixSignalOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct PosixSignal<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for PosixSignal<'a> {
+  type Inner = PosixSignal<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
+  }
+}
+
+impl<'a> PosixSignal<'a> {
+  pub const VT_NUMBER: flatbuffers::VOffsetT = 4;
+  pub const VT_CODE: flatbuffers::VOffsetT = 6;
+  pub const VT_ERRNO: flatbuffers::VOffsetT = 8;
+  pub const VT_HAS_FAULT_ADDRESS: flatbuffers::VOffsetT = 10;
+  pub const VT_FAULT_ADDRESS: flatbuffers::VOffsetT = 12;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    PosixSignal { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args PosixSignalArgs
+  ) -> flatbuffers::WIPOffset<PosixSignal<'bldr>> {
+    let mut builder = PosixSignalBuilder::new(_fbb);
+    builder.add_fault_address(args.fault_address);
+    builder.add_errno(args.errno);
+    builder.add_code(args.code);
+    builder.add_number(args.number);
+    builder.add_has_fault_address(args.has_fault_address);
+    builder.finish()
+  }
+
+  pub fn unpack(&self) -> PosixSignalT {
+    let number = self.number();
+    let code = self.code();
+    let errno = self.errno();
+    let has_fault_address = self.has_fault_address();
+    let fault_address = self.fault_address();
+    PosixSignalT {
+      number,
+      code,
+      errno,
+      has_fault_address,
+      fault_address,
+    }
+  }
+
+  #[inline]
+  pub fn number(&self) -> i32 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<i32>(PosixSignal::VT_NUMBER, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn code(&self) -> i32 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<i32>(PosixSignal::VT_CODE, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn errno(&self) -> i32 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<i32>(PosixSignal::VT_ERRNO, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn has_fault_address(&self) -> bool {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<bool>(PosixSignal::VT_HAS_FAULT_ADDRESS, Some(false)).unwrap()}
+  }
+  #[inline]
+  pub fn fault_address(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(PosixSignal::VT_FAULT_ADDRESS, Some(0)).unwrap()}
+  }
+}
+
+impl flatbuffers::Verifiable for PosixSignal<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<i32>("number", Self::VT_NUMBER, false)?
+     .visit_field::<i32>("code", Self::VT_CODE, false)?
+     .visit_field::<i32>("errno", Self::VT_ERRNO, false)?
+     .visit_field::<bool>("has_fault_address", Self::VT_HAS_FAULT_ADDRESS, false)?
+     .visit_field::<u64>("fault_address", Self::VT_FAULT_ADDRESS, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct PosixSignalArgs {
+    pub number: i32,
+    pub code: i32,
+    pub errno: i32,
+    pub has_fault_address: bool,
+    pub fault_address: u64,
+}
+impl<'a> Default for PosixSignalArgs {
+  #[inline]
+  fn default() -> Self {
+    PosixSignalArgs {
+      number: 0,
+      code: 0,
+      errno: 0,
+      has_fault_address: false,
+      fault_address: 0,
+    }
+  }
+}
+
+pub struct PosixSignalBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> PosixSignalBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_number(&mut self, number: i32) {
+    self.fbb_.push_slot::<i32>(PosixSignal::VT_NUMBER, number, 0);
+  }
+  #[inline]
+  pub fn add_code(&mut self, code: i32) {
+    self.fbb_.push_slot::<i32>(PosixSignal::VT_CODE, code, 0);
+  }
+  #[inline]
+  pub fn add_errno(&mut self, errno: i32) {
+    self.fbb_.push_slot::<i32>(PosixSignal::VT_ERRNO, errno, 0);
+  }
+  #[inline]
+  pub fn add_has_fault_address(&mut self, has_fault_address: bool) {
+    self.fbb_.push_slot::<bool>(PosixSignal::VT_HAS_FAULT_ADDRESS, has_fault_address, false);
+  }
+  #[inline]
+  pub fn add_fault_address(&mut self, fault_address: u64) {
+    self.fbb_.push_slot::<u64>(PosixSignal::VT_FAULT_ADDRESS, fault_address, 0);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> PosixSignalBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    PosixSignalBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<PosixSignal<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for PosixSignal<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("PosixSignal");
+      ds.field("number", &self.number());
+      ds.field("code", &self.code());
+      ds.field("errno", &self.errno());
+      ds.field("has_fault_address", &self.has_fault_address());
+      ds.field("fault_address", &self.fault_address());
+      ds.finish()
+  }
+}
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct PosixSignalT {
+  pub number: i32,
+  pub code: i32,
+  pub errno: i32,
+  pub has_fault_address: bool,
+  pub fault_address: u64,
+}
+impl Default for PosixSignalT {
+  fn default() -> Self {
+    Self {
+      number: 0,
+      code: 0,
+      errno: 0,
+      has_fault_address: false,
+      fault_address: 0,
+    }
+  }
+}
+impl PosixSignalT {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
+    &self,
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
+  ) -> flatbuffers::WIPOffset<PosixSignal<'b>> {
+    let number = self.number;
+    let code = self.code;
+    let errno = self.errno;
+    let has_fault_address = self.has_fault_address;
+    let fault_address = self.fault_address;
+    PosixSignal::create(_fbb, &PosixSignalArgs{
+      number,
+      code,
+      errno,
+      has_fault_address,
+      fault_address,
+    })
+  }
+}
+pub enum AppleTerminationOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct AppleTermination<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for AppleTermination<'a> {
+  type Inner = AppleTermination<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
+  }
+}
+
+impl<'a> AppleTermination<'a> {
+  pub const VT_DOMAIN: flatbuffers::VOffsetT = 4;
+  pub const VT_CODE: flatbuffers::VOffsetT = 6;
+  pub const VT_EXPLANATION: flatbuffers::VOffsetT = 8;
+  pub const VT_PROCESS_VISIBILITY: flatbuffers::VOffsetT = 10;
+  pub const VT_PROCESS_STATE: flatbuffers::VOffsetT = 12;
+  pub const VT_WATCHDOG_EVENT: flatbuffers::VOffsetT = 14;
+  pub const VT_WATCHDOG_VISIBILITY: flatbuffers::VOffsetT = 16;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    AppleTermination { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args AppleTerminationArgs<'args>
+  ) -> flatbuffers::WIPOffset<AppleTermination<'bldr>> {
+    let mut builder = AppleTerminationBuilder::new(_fbb);
+    if let Some(x) = args.watchdog_visibility { builder.add_watchdog_visibility(x); }
+    if let Some(x) = args.watchdog_event { builder.add_watchdog_event(x); }
+    if let Some(x) = args.process_state { builder.add_process_state(x); }
+    if let Some(x) = args.process_visibility { builder.add_process_visibility(x); }
+    if let Some(x) = args.explanation { builder.add_explanation(x); }
+    if let Some(x) = args.code { builder.add_code(x); }
+    if let Some(x) = args.domain { builder.add_domain(x); }
+    builder.finish()
+  }
+
+  pub fn unpack(&self) -> AppleTerminationT {
+    let domain = self.domain().map(|x| {
+      x.to_string()
+    });
+    let code = self.code().map(|x| {
+      x.to_string()
+    });
+    let explanation = self.explanation().map(|x| {
+      x.to_string()
+    });
+    let process_visibility = self.process_visibility().map(|x| {
+      x.to_string()
+    });
+    let process_state = self.process_state().map(|x| {
+      x.to_string()
+    });
+    let watchdog_event = self.watchdog_event().map(|x| {
+      x.to_string()
+    });
+    let watchdog_visibility = self.watchdog_visibility().map(|x| {
+      x.to_string()
+    });
+    AppleTerminationT {
+      domain,
+      code,
+      explanation,
+      process_visibility,
+      process_state,
+      watchdog_event,
+      watchdog_visibility,
+    }
+  }
+
+  #[inline]
+  pub fn domain(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(AppleTermination::VT_DOMAIN, None)}
+  }
+  #[inline]
+  pub fn code(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(AppleTermination::VT_CODE, None)}
+  }
+  #[inline]
+  pub fn explanation(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(AppleTermination::VT_EXPLANATION, None)}
+  }
+  #[inline]
+  pub fn process_visibility(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(AppleTermination::VT_PROCESS_VISIBILITY, None)}
+  }
+  #[inline]
+  pub fn process_state(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(AppleTermination::VT_PROCESS_STATE, None)}
+  }
+  #[inline]
+  pub fn watchdog_event(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(AppleTermination::VT_WATCHDOG_EVENT, None)}
+  }
+  #[inline]
+  pub fn watchdog_visibility(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(AppleTermination::VT_WATCHDOG_VISIBILITY, None)}
+  }
+}
+
+impl flatbuffers::Verifiable for AppleTermination<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("domain", Self::VT_DOMAIN, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("code", Self::VT_CODE, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("explanation", Self::VT_EXPLANATION, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("process_visibility", Self::VT_PROCESS_VISIBILITY, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("process_state", Self::VT_PROCESS_STATE, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("watchdog_event", Self::VT_WATCHDOG_EVENT, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("watchdog_visibility", Self::VT_WATCHDOG_VISIBILITY, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct AppleTerminationArgs<'a> {
+    pub domain: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub code: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub explanation: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub process_visibility: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub process_state: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub watchdog_event: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub watchdog_visibility: Option<flatbuffers::WIPOffset<&'a str>>,
+}
+impl<'a> Default for AppleTerminationArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    AppleTerminationArgs {
+      domain: None,
+      code: None,
+      explanation: None,
+      process_visibility: None,
+      process_state: None,
+      watchdog_event: None,
+      watchdog_visibility: None,
+    }
+  }
+}
+
+pub struct AppleTerminationBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> AppleTerminationBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_domain(&mut self, domain: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(AppleTermination::VT_DOMAIN, domain);
+  }
+  #[inline]
+  pub fn add_code(&mut self, code: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(AppleTermination::VT_CODE, code);
+  }
+  #[inline]
+  pub fn add_explanation(&mut self, explanation: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(AppleTermination::VT_EXPLANATION, explanation);
+  }
+  #[inline]
+  pub fn add_process_visibility(&mut self, process_visibility: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(AppleTermination::VT_PROCESS_VISIBILITY, process_visibility);
+  }
+  #[inline]
+  pub fn add_process_state(&mut self, process_state: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(AppleTermination::VT_PROCESS_STATE, process_state);
+  }
+  #[inline]
+  pub fn add_watchdog_event(&mut self, watchdog_event: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(AppleTermination::VT_WATCHDOG_EVENT, watchdog_event);
+  }
+  #[inline]
+  pub fn add_watchdog_visibility(&mut self, watchdog_visibility: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(AppleTermination::VT_WATCHDOG_VISIBILITY, watchdog_visibility);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> AppleTerminationBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    AppleTerminationBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<AppleTermination<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for AppleTermination<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("AppleTermination");
+      ds.field("domain", &self.domain());
+      ds.field("code", &self.code());
+      ds.field("explanation", &self.explanation());
+      ds.field("process_visibility", &self.process_visibility());
+      ds.field("process_state", &self.process_state());
+      ds.field("watchdog_event", &self.watchdog_event());
+      ds.field("watchdog_visibility", &self.watchdog_visibility());
+      ds.finish()
+  }
+}
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct AppleTerminationT {
+  pub domain: Option<String>,
+  pub code: Option<String>,
+  pub explanation: Option<String>,
+  pub process_visibility: Option<String>,
+  pub process_state: Option<String>,
+  pub watchdog_event: Option<String>,
+  pub watchdog_visibility: Option<String>,
+}
+impl Default for AppleTerminationT {
+  fn default() -> Self {
+    Self {
+      domain: None,
+      code: None,
+      explanation: None,
+      process_visibility: None,
+      process_state: None,
+      watchdog_event: None,
+      watchdog_visibility: None,
+    }
+  }
+}
+impl AppleTerminationT {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
+    &self,
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
+  ) -> flatbuffers::WIPOffset<AppleTermination<'b>> {
+    let domain = self.domain.as_ref().map(|x|{
+      _fbb.create_string(x)
+    });
+    let code = self.code.as_ref().map(|x|{
+      _fbb.create_string(x)
+    });
+    let explanation = self.explanation.as_ref().map(|x|{
+      _fbb.create_string(x)
+    });
+    let process_visibility = self.process_visibility.as_ref().map(|x|{
+      _fbb.create_string(x)
+    });
+    let process_state = self.process_state.as_ref().map(|x|{
+      _fbb.create_string(x)
+    });
+    let watchdog_event = self.watchdog_event.as_ref().map(|x|{
+      _fbb.create_string(x)
+    });
+    let watchdog_visibility = self.watchdog_visibility.as_ref().map(|x|{
+      _fbb.create_string(x)
+    });
+    AppleTermination::create(_fbb, &AppleTerminationArgs{
+      domain,
+      code,
+      explanation,
+      process_visibility,
+      process_state,
+      watchdog_event,
+      watchdog_visibility,
+    })
+  }
+}
+pub enum AppleCrashDetailsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct AppleCrashDetails<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for AppleCrashDetails<'a> {
+  type Inner = AppleCrashDetails<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
+  }
+}
+
+impl<'a> AppleCrashDetails<'a> {
+  pub const VT_NSEXCEPTION: flatbuffers::VOffsetT = 4;
+  pub const VT_MACH_EXCEPTION: flatbuffers::VOffsetT = 6;
+  pub const VT_POSIX_SIGNAL: flatbuffers::VOffsetT = 8;
+  pub const VT_TERMINATION: flatbuffers::VOffsetT = 10;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    AppleCrashDetails { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args AppleCrashDetailsArgs<'args>
+  ) -> flatbuffers::WIPOffset<AppleCrashDetails<'bldr>> {
+    let mut builder = AppleCrashDetailsBuilder::new(_fbb);
+    if let Some(x) = args.termination { builder.add_termination(x); }
+    if let Some(x) = args.posix_signal { builder.add_posix_signal(x); }
+    if let Some(x) = args.mach_exception { builder.add_mach_exception(x); }
+    if let Some(x) = args.nsexception { builder.add_nsexception(x); }
+    builder.finish()
+  }
+
+  pub fn unpack(&self) -> AppleCrashDetailsT {
+    let nsexception = self.nsexception().map(|x| {
+      Box::new(x.unpack())
+    });
+    let mach_exception = self.mach_exception().map(|x| {
+      Box::new(x.unpack())
+    });
+    let posix_signal = self.posix_signal().map(|x| {
+      Box::new(x.unpack())
+    });
+    let termination = self.termination().map(|x| {
+      Box::new(x.unpack())
+    });
+    AppleCrashDetailsT {
+      nsexception,
+      mach_exception,
+      posix_signal,
+      termination,
+    }
+  }
+
+  #[inline]
+  pub fn nsexception(&self) -> Option<NSException<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<NSException>>(AppleCrashDetails::VT_NSEXCEPTION, None)}
+  }
+  #[inline]
+  pub fn mach_exception(&self) -> Option<MachException<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<MachException>>(AppleCrashDetails::VT_MACH_EXCEPTION, None)}
+  }
+  #[inline]
+  pub fn posix_signal(&self) -> Option<PosixSignal<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<PosixSignal>>(AppleCrashDetails::VT_POSIX_SIGNAL, None)}
+  }
+  #[inline]
+  pub fn termination(&self) -> Option<AppleTermination<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<AppleTermination>>(AppleCrashDetails::VT_TERMINATION, None)}
+  }
+}
+
+impl flatbuffers::Verifiable for AppleCrashDetails<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<NSException>>("nsexception", Self::VT_NSEXCEPTION, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<MachException>>("mach_exception", Self::VT_MACH_EXCEPTION, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<PosixSignal>>("posix_signal", Self::VT_POSIX_SIGNAL, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<AppleTermination>>("termination", Self::VT_TERMINATION, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct AppleCrashDetailsArgs<'a> {
+    pub nsexception: Option<flatbuffers::WIPOffset<NSException<'a>>>,
+    pub mach_exception: Option<flatbuffers::WIPOffset<MachException<'a>>>,
+    pub posix_signal: Option<flatbuffers::WIPOffset<PosixSignal<'a>>>,
+    pub termination: Option<flatbuffers::WIPOffset<AppleTermination<'a>>>,
+}
+impl<'a> Default for AppleCrashDetailsArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    AppleCrashDetailsArgs {
+      nsexception: None,
+      mach_exception: None,
+      posix_signal: None,
+      termination: None,
+    }
+  }
+}
+
+pub struct AppleCrashDetailsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> AppleCrashDetailsBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_nsexception(&mut self, nsexception: flatbuffers::WIPOffset<NSException<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<NSException>>(AppleCrashDetails::VT_NSEXCEPTION, nsexception);
+  }
+  #[inline]
+  pub fn add_mach_exception(&mut self, mach_exception: flatbuffers::WIPOffset<MachException<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<MachException>>(AppleCrashDetails::VT_MACH_EXCEPTION, mach_exception);
+  }
+  #[inline]
+  pub fn add_posix_signal(&mut self, posix_signal: flatbuffers::WIPOffset<PosixSignal<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<PosixSignal>>(AppleCrashDetails::VT_POSIX_SIGNAL, posix_signal);
+  }
+  #[inline]
+  pub fn add_termination(&mut self, termination: flatbuffers::WIPOffset<AppleTermination<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<AppleTermination>>(AppleCrashDetails::VT_TERMINATION, termination);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> AppleCrashDetailsBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    AppleCrashDetailsBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<AppleCrashDetails<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for AppleCrashDetails<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("AppleCrashDetails");
+      ds.field("nsexception", &self.nsexception());
+      ds.field("mach_exception", &self.mach_exception());
+      ds.field("posix_signal", &self.posix_signal());
+      ds.field("termination", &self.termination());
+      ds.finish()
+  }
+}
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct AppleCrashDetailsT {
+  pub nsexception: Option<Box<NSExceptionT>>,
+  pub mach_exception: Option<Box<MachExceptionT>>,
+  pub posix_signal: Option<Box<PosixSignalT>>,
+  pub termination: Option<Box<AppleTerminationT>>,
+}
+impl Default for AppleCrashDetailsT {
+  fn default() -> Self {
+    Self {
+      nsexception: None,
+      mach_exception: None,
+      posix_signal: None,
+      termination: None,
+    }
+  }
+}
+impl AppleCrashDetailsT {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
+    &self,
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
+  ) -> flatbuffers::WIPOffset<AppleCrashDetails<'b>> {
+    let nsexception = self.nsexception.as_ref().map(|x|{
+      x.pack(_fbb)
+    });
+    let mach_exception = self.mach_exception.as_ref().map(|x|{
+      x.pack(_fbb)
+    });
+    let posix_signal = self.posix_signal.as_ref().map(|x|{
+      x.pack(_fbb)
+    });
+    let termination = self.termination.as_ref().map(|x|{
+      x.pack(_fbb)
+    });
+    AppleCrashDetails::create(_fbb, &AppleCrashDetailsArgs{
+      nsexception,
+      mach_exception,
+      posix_signal,
+      termination,
+    })
+  }
+}
+pub enum CrashInfoOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct CrashInfo<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for CrashInfo<'a> {
+  type Inner = CrashInfo<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: unsafe { flatbuffers::Table::new(buf, loc) } }
+  }
+}
+
+impl<'a> CrashInfo<'a> {
+  pub const VT_REPORTER_SCOPE: flatbuffers::VOffsetT = 4;
+  pub const VT_REPORTER: flatbuffers::VOffsetT = 6;
+  pub const VT_OCCURRED_AT: flatbuffers::VOffsetT = 8;
+  pub const VT_DETAILS_TYPE: flatbuffers::VOffsetT = 10;
+  pub const VT_DETAILS: flatbuffers::VOffsetT = 12;
+  pub const VT_THREAD_DETAILS: flatbuffers::VOffsetT = 14;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    CrashInfo { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args CrashInfoArgs<'args>
+  ) -> flatbuffers::WIPOffset<CrashInfo<'bldr>> {
+    let mut builder = CrashInfoBuilder::new(_fbb);
+    if let Some(x) = args.thread_details { builder.add_thread_details(x); }
+    if let Some(x) = args.details { builder.add_details(x); }
+    if let Some(x) = args.occurred_at { builder.add_occurred_at(x); }
+    builder.add_details_type(args.details_type);
+    builder.add_reporter(args.reporter);
+    builder.add_reporter_scope(args.reporter_scope);
+    builder.finish()
+  }
+
+  pub fn unpack(&self) -> CrashInfoT {
+    let reporter_scope = self.reporter_scope();
+    let reporter = self.reporter();
+    let occurred_at = self.occurred_at().map(|x| {
+      x.unpack()
+    });
+    let details = match self.details_type() {
+      CrashInfoDetails::NONE => CrashInfoDetailsT::NONE,
+      CrashInfoDetails::AppleCrashDetails => CrashInfoDetailsT::AppleCrashDetails(Box::new(
+        self.details_as_apple_crash_details()
+            .expect("Invalid union table, expected `CrashInfoDetails::AppleCrashDetails`.")
+            .unpack()
+      )),
+      _ => CrashInfoDetailsT::NONE,
+    };
+    let thread_details = self.thread_details().map(|x| {
+      Box::new(x.unpack())
+    });
+    CrashInfoT {
+      reporter_scope,
+      reporter,
+      occurred_at,
+      details,
+      thread_details,
+    }
+  }
+
+  #[inline]
+  pub fn reporter_scope(&self) -> CrashReporterScope {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<CrashReporterScope>(CrashInfo::VT_REPORTER_SCOPE, Some(CrashReporterScope::Unknown)).unwrap()}
+  }
+  #[inline]
+  pub fn reporter(&self) -> CrashReporter {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<CrashReporter>(CrashInfo::VT_REPORTER, Some(CrashReporter::Unknown)).unwrap()}
+  }
+  #[inline]
+  pub fn occurred_at(&self) -> Option<&'a Timestamp> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<Timestamp>(CrashInfo::VT_OCCURRED_AT, None)}
+  }
+  #[inline]
+  pub fn details_type(&self) -> CrashInfoDetails {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<CrashInfoDetails>(CrashInfo::VT_DETAILS_TYPE, Some(CrashInfoDetails::NONE)).unwrap()}
+  }
+  #[inline]
+  pub fn details(&self) -> Option<flatbuffers::Table<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>(CrashInfo::VT_DETAILS, None)}
+  }
+  #[inline]
+  pub fn thread_details(&self) -> Option<ThreadDetails<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<ThreadDetails>>(CrashInfo::VT_THREAD_DETAILS, None)}
+  }
+  #[inline]
+  #[allow(non_snake_case)]
+  pub fn details_as_apple_crash_details(&self) -> Option<AppleCrashDetails<'a>> {
+    if self.details_type() == CrashInfoDetails::AppleCrashDetails {
+      self.details().map(|t| {
+       // Safety:
+       // Created from a valid Table for this object
+       // Which contains a valid union in this slot
+       unsafe { AppleCrashDetails::init_from_table(t) }
+     })
+    } else {
+      None
+    }
+  }
+
+}
+
+impl flatbuffers::Verifiable for CrashInfo<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<CrashReporterScope>("reporter_scope", Self::VT_REPORTER_SCOPE, false)?
+     .visit_field::<CrashReporter>("reporter", Self::VT_REPORTER, false)?
+     .visit_field::<Timestamp>("occurred_at", Self::VT_OCCURRED_AT, false)?
+     .visit_union::<CrashInfoDetails, _>("details_type", Self::VT_DETAILS_TYPE, "details", Self::VT_DETAILS, false, |key, v, pos| {
+        match key {
+          CrashInfoDetails::AppleCrashDetails => v.verify_union_variant::<flatbuffers::ForwardsUOffset<AppleCrashDetails>>("CrashInfoDetails::AppleCrashDetails", pos),
+          _ => Ok(()),
+        }
+     })?
+     .visit_field::<flatbuffers::ForwardsUOffset<ThreadDetails>>("thread_details", Self::VT_THREAD_DETAILS, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct CrashInfoArgs<'a> {
+    pub reporter_scope: CrashReporterScope,
+    pub reporter: CrashReporter,
+    pub occurred_at: Option<&'a Timestamp>,
+    pub details_type: CrashInfoDetails,
+    pub details: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
+    pub thread_details: Option<flatbuffers::WIPOffset<ThreadDetails<'a>>>,
+}
+impl<'a> Default for CrashInfoArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    CrashInfoArgs {
+      reporter_scope: CrashReporterScope::Unknown,
+      reporter: CrashReporter::Unknown,
+      occurred_at: None,
+      details_type: CrashInfoDetails::NONE,
+      details: None,
+      thread_details: None,
+    }
+  }
+}
+
+pub struct CrashInfoBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> CrashInfoBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_reporter_scope(&mut self, reporter_scope: CrashReporterScope) {
+    self.fbb_.push_slot::<CrashReporterScope>(CrashInfo::VT_REPORTER_SCOPE, reporter_scope, CrashReporterScope::Unknown);
+  }
+  #[inline]
+  pub fn add_reporter(&mut self, reporter: CrashReporter) {
+    self.fbb_.push_slot::<CrashReporter>(CrashInfo::VT_REPORTER, reporter, CrashReporter::Unknown);
+  }
+  #[inline]
+  pub fn add_occurred_at(&mut self, occurred_at: &Timestamp) {
+    self.fbb_.push_slot_always::<&Timestamp>(CrashInfo::VT_OCCURRED_AT, occurred_at);
+  }
+  #[inline]
+  pub fn add_details_type(&mut self, details_type: CrashInfoDetails) {
+    self.fbb_.push_slot::<CrashInfoDetails>(CrashInfo::VT_DETAILS_TYPE, details_type, CrashInfoDetails::NONE);
+  }
+  #[inline]
+  pub fn add_details(&mut self, details: flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(CrashInfo::VT_DETAILS, details);
+  }
+  #[inline]
+  pub fn add_thread_details(&mut self, thread_details: flatbuffers::WIPOffset<ThreadDetails<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<ThreadDetails>>(CrashInfo::VT_THREAD_DETAILS, thread_details);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> CrashInfoBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    CrashInfoBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<CrashInfo<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for CrashInfo<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("CrashInfo");
+      ds.field("reporter_scope", &self.reporter_scope());
+      ds.field("reporter", &self.reporter());
+      ds.field("occurred_at", &self.occurred_at());
+      ds.field("details_type", &self.details_type());
+      match self.details_type() {
+        CrashInfoDetails::AppleCrashDetails => {
+          if let Some(x) = self.details_as_apple_crash_details() {
+            ds.field("details", &x)
+          } else {
+            ds.field("details", &"InvalidFlatbuffer: Union discriminant does not match value.")
+          }
+        },
+        _ => {
+          let x: Option<()> = None;
+          ds.field("details", &x)
+        },
+      };
+      ds.field("thread_details", &self.thread_details());
+      ds.finish()
+  }
+}
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct CrashInfoT {
+  pub reporter_scope: CrashReporterScope,
+  pub reporter: CrashReporter,
+  pub occurred_at: Option<TimestampT>,
+  pub details: CrashInfoDetailsT,
+  pub thread_details: Option<Box<ThreadDetailsT>>,
+}
+impl Default for CrashInfoT {
+  fn default() -> Self {
+    Self {
+      reporter_scope: CrashReporterScope::Unknown,
+      reporter: CrashReporter::Unknown,
+      occurred_at: None,
+      details: CrashInfoDetailsT::NONE,
+      thread_details: None,
+    }
+  }
+}
+impl CrashInfoT {
+  pub fn pack<'b, A: flatbuffers::Allocator + 'b>(
+    &self,
+    _fbb: &mut flatbuffers::FlatBufferBuilder<'b, A>
+  ) -> flatbuffers::WIPOffset<CrashInfo<'b>> {
+    let reporter_scope = self.reporter_scope;
+    let reporter = self.reporter;
+    let occurred_at_tmp = self.occurred_at.as_ref().map(|x| x.pack());
+    let occurred_at = occurred_at_tmp.as_ref();
+    let details_type = self.details.crash_info_details_type();
+    let details = self.details.pack(_fbb);
+    let thread_details = self.thread_details.as_ref().map(|x|{
+      x.pack(_fbb)
+    });
+    CrashInfo::create(_fbb, &CrashInfoArgs{
+      reporter_scope,
+      reporter,
+      occurred_at,
+      details_type,
+      details,
+      thread_details,
+    })
+  }
+}
 pub enum BinaryImageOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -5251,6 +6935,7 @@ impl<'a> Report<'a> {
   pub const VT_FIELDS: flatbuffers::VOffsetT = 18;
   pub const VT_FEATURE_FLAGS: flatbuffers::VOffsetT = 20;
   pub const VT_PROCESSING_RESULT: flatbuffers::VOffsetT = 22;
+  pub const VT_CRASH_INFO: flatbuffers::VOffsetT = 24;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -5262,6 +6947,7 @@ impl<'a> Report<'a> {
     args: &'args ReportArgs<'args>
   ) -> flatbuffers::WIPOffset<Report<'bldr>> {
     let mut builder = ReportBuilder::new(_fbb);
+    if let Some(x) = args.crash_info { builder.add_crash_info(x); }
     if let Some(x) = args.processing_result { builder.add_processing_result(x); }
     if let Some(x) = args.feature_flags { builder.add_feature_flags(x); }
     if let Some(x) = args.fields { builder.add_fields(x); }
@@ -5304,6 +6990,9 @@ impl<'a> Report<'a> {
     let processing_result = self.processing_result().map(|x| {
       Box::new(x.unpack())
     });
+    let crash_info = self.crash_info().map(|x| {
+      x.iter().map(|t| t.unpack()).collect()
+    });
     ReportT {
       sdk,
       type_,
@@ -5315,6 +7004,7 @@ impl<'a> Report<'a> {
       fields,
       feature_flags,
       processing_result,
+      crash_info,
     }
   }
 
@@ -5388,6 +7078,13 @@ impl<'a> Report<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<ProcessingResult>>(Report::VT_PROCESSING_RESULT, None)}
   }
+  #[inline]
+  pub fn crash_info(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CrashInfo<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CrashInfo>>>>(Report::VT_CRASH_INFO, None)}
+  }
 }
 
 impl flatbuffers::Verifiable for Report<'_> {
@@ -5407,6 +7104,7 @@ impl flatbuffers::Verifiable for Report<'_> {
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<super::super::common::v_1::Field>>>>("fields", Self::VT_FIELDS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<FeatureFlag>>>>("feature_flags", Self::VT_FEATURE_FLAGS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<ProcessingResult>>("processing_result", Self::VT_PROCESSING_RESULT, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CrashInfo>>>>("crash_info", Self::VT_CRASH_INFO, false)?
      .finish();
     Ok(())
   }
@@ -5422,6 +7120,7 @@ pub struct ReportArgs<'a> {
     pub fields: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<super::super::common::v_1::Field<'a>>>>>,
     pub feature_flags: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<FeatureFlag<'a>>>>>,
     pub processing_result: Option<flatbuffers::WIPOffset<ProcessingResult<'a>>>,
+    pub crash_info: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CrashInfo<'a>>>>>,
 }
 impl<'a> Default for ReportArgs<'a> {
   #[inline]
@@ -5437,6 +7136,7 @@ impl<'a> Default for ReportArgs<'a> {
       fields: None,
       feature_flags: None,
       processing_result: None,
+      crash_info: None,
     }
   }
 }
@@ -5487,6 +7187,10 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ReportBuilder<'a, 'b, A> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<ProcessingResult>>(Report::VT_PROCESSING_RESULT, processing_result);
   }
   #[inline]
+  pub fn add_crash_info(&mut self, crash_info: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<CrashInfo<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Report::VT_CRASH_INFO, crash_info);
+  }
+  #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> ReportBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     ReportBuilder {
@@ -5514,6 +7218,7 @@ impl core::fmt::Debug for Report<'_> {
       ds.field("fields", &self.fields());
       ds.field("feature_flags", &self.feature_flags());
       ds.field("processing_result", &self.processing_result());
+      ds.field("crash_info", &self.crash_info());
       ds.finish()
   }
 }
@@ -5530,6 +7235,7 @@ pub struct ReportT {
   pub fields: Option<Vec<super::super::common::v_1::FieldT>>,
   pub feature_flags: Option<Vec<FeatureFlagT>>,
   pub processing_result: Option<Box<ProcessingResultT>>,
+  pub crash_info: Option<Vec<CrashInfoT>>,
 }
 impl Default for ReportT {
   fn default() -> Self {
@@ -5544,6 +7250,7 @@ impl Default for ReportT {
       fields: None,
       feature_flags: None,
       processing_result: None,
+      crash_info: None,
     }
   }
 }
@@ -5580,6 +7287,9 @@ impl ReportT {
     let processing_result = self.processing_result.as_ref().map(|x|{
       x.pack(_fbb)
     });
+    let crash_info = self.crash_info.as_ref().map(|x|{
+      let w: Vec<_> = x.iter().map(|t| t.pack(_fbb)).collect();_fbb.create_vector(&w)
+    });
     Report::create(_fbb, &ReportArgs{
       sdk,
       type_,
@@ -5591,6 +7301,7 @@ impl ReportT {
       fields,
       feature_flags,
       processing_result,
+      crash_info,
     })
   }
 }

--- a/bd-proto/src/flatbuffers/report_generated.rs
+++ b/bd-proto/src/flatbuffers/report_generated.rs
@@ -5276,7 +5276,7 @@ impl<'a> flatbuffers::Follow<'a> for PosixSignal<'a> {
 impl<'a> PosixSignal<'a> {
   pub const VT_NUMBER: flatbuffers::VOffsetT = 4;
   pub const VT_CODE: flatbuffers::VOffsetT = 6;
-  pub const VT_ERRNO: flatbuffers::VOffsetT = 8;
+  pub const VT_ERRNO_VALUE: flatbuffers::VOffsetT = 8;
   pub const VT_HAS_FAULT_ADDRESS: flatbuffers::VOffsetT = 10;
   pub const VT_FAULT_ADDRESS: flatbuffers::VOffsetT = 12;
 
@@ -5291,7 +5291,7 @@ impl<'a> PosixSignal<'a> {
   ) -> flatbuffers::WIPOffset<PosixSignal<'bldr>> {
     let mut builder = PosixSignalBuilder::new(_fbb);
     builder.add_fault_address(args.fault_address);
-    builder.add_errno(args.errno);
+    builder.add_errno_value(args.errno_value);
     builder.add_code(args.code);
     builder.add_number(args.number);
     builder.add_has_fault_address(args.has_fault_address);
@@ -5301,13 +5301,13 @@ impl<'a> PosixSignal<'a> {
   pub fn unpack(&self) -> PosixSignalT {
     let number = self.number();
     let code = self.code();
-    let errno = self.errno();
+    let errno_value = self.errno_value();
     let has_fault_address = self.has_fault_address();
     let fault_address = self.fault_address();
     PosixSignalT {
       number,
       code,
-      errno,
+      errno_value,
       has_fault_address,
       fault_address,
     }
@@ -5328,11 +5328,11 @@ impl<'a> PosixSignal<'a> {
     unsafe { self._tab.get::<i32>(PosixSignal::VT_CODE, Some(0)).unwrap()}
   }
   #[inline]
-  pub fn errno(&self) -> i32 {
+  pub fn errno_value(&self) -> i32 {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<i32>(PosixSignal::VT_ERRNO, Some(0)).unwrap()}
+    unsafe { self._tab.get::<i32>(PosixSignal::VT_ERRNO_VALUE, Some(0)).unwrap()}
   }
   #[inline]
   pub fn has_fault_address(&self) -> bool {
@@ -5359,7 +5359,7 @@ impl flatbuffers::Verifiable for PosixSignal<'_> {
     v.visit_table(pos)?
      .visit_field::<i32>("number", Self::VT_NUMBER, false)?
      .visit_field::<i32>("code", Self::VT_CODE, false)?
-     .visit_field::<i32>("errno", Self::VT_ERRNO, false)?
+     .visit_field::<i32>("errno_value", Self::VT_ERRNO_VALUE, false)?
      .visit_field::<bool>("has_fault_address", Self::VT_HAS_FAULT_ADDRESS, false)?
      .visit_field::<u64>("fault_address", Self::VT_FAULT_ADDRESS, false)?
      .finish();
@@ -5369,7 +5369,7 @@ impl flatbuffers::Verifiable for PosixSignal<'_> {
 pub struct PosixSignalArgs {
     pub number: i32,
     pub code: i32,
-    pub errno: i32,
+    pub errno_value: i32,
     pub has_fault_address: bool,
     pub fault_address: u64,
 }
@@ -5379,7 +5379,7 @@ impl<'a> Default for PosixSignalArgs {
     PosixSignalArgs {
       number: 0,
       code: 0,
-      errno: 0,
+      errno_value: 0,
       has_fault_address: false,
       fault_address: 0,
     }
@@ -5400,8 +5400,8 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> PosixSignalBuilder<'a, 'b, A> {
     self.fbb_.push_slot::<i32>(PosixSignal::VT_CODE, code, 0);
   }
   #[inline]
-  pub fn add_errno(&mut self, errno: i32) {
-    self.fbb_.push_slot::<i32>(PosixSignal::VT_ERRNO, errno, 0);
+  pub fn add_errno_value(&mut self, errno_value: i32) {
+    self.fbb_.push_slot::<i32>(PosixSignal::VT_ERRNO_VALUE, errno_value, 0);
   }
   #[inline]
   pub fn add_has_fault_address(&mut self, has_fault_address: bool) {
@@ -5431,7 +5431,7 @@ impl core::fmt::Debug for PosixSignal<'_> {
     let mut ds = f.debug_struct("PosixSignal");
       ds.field("number", &self.number());
       ds.field("code", &self.code());
-      ds.field("errno", &self.errno());
+      ds.field("errno_value", &self.errno_value());
       ds.field("has_fault_address", &self.has_fault_address());
       ds.field("fault_address", &self.fault_address());
       ds.finish()
@@ -5442,7 +5442,7 @@ impl core::fmt::Debug for PosixSignal<'_> {
 pub struct PosixSignalT {
   pub number: i32,
   pub code: i32,
-  pub errno: i32,
+  pub errno_value: i32,
   pub has_fault_address: bool,
   pub fault_address: u64,
 }
@@ -5451,7 +5451,7 @@ impl Default for PosixSignalT {
     Self {
       number: 0,
       code: 0,
-      errno: 0,
+      errno_value: 0,
       has_fault_address: false,
       fault_address: 0,
     }
@@ -5464,13 +5464,13 @@ impl PosixSignalT {
   ) -> flatbuffers::WIPOffset<PosixSignal<'b>> {
     let number = self.number;
     let code = self.code;
-    let errno = self.errno;
+    let errno_value = self.errno_value;
     let has_fault_address = self.has_fault_address;
     let fault_address = self.fault_address;
     PosixSignal::create(_fbb, &PosixSignalArgs{
       number,
       code,
-      errno,
+      errno_value,
       has_fault_address,
       fault_address,
     })

--- a/bd-proto/src/flatbuffers/report_serialize.rs
+++ b/bd-proto/src/flatbuffers/report_serialize.rs
@@ -19,12 +19,15 @@ serialize_enum!(Platform);
 serialize_enum!(Architecture);
 serialize_enum!(FrameType);
 serialize_enum!(ErrorRelation);
+serialize_enum!(CrashReporterScope);
+serialize_enum!(CrashReporter);
 serialize_enum!(PowerState);
 serialize_enum!(NetworkState);
 serialize_enum!(JavaScriptEngine);
 serialize_enum!(MemoryPressureLevel);
 serialize_enum!(Rotation);
 serialize_enum!(FrameStatus);
+serialize_enum!(CrashInfoDetails);
 
 impl Serialize for Timestamp {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -413,6 +416,167 @@ impl Serialize for Error<'_> {
   }
 }
 
+impl Serialize for NSException<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("NSException", 3)?;
+    if let Some(f) = self.name() {
+      s.serialize_field("name", &f)?;
+    } else {
+      s.skip_field("name")?;
+    }
+    if let Some(f) = self.reason() {
+      s.serialize_field("reason", &f)?;
+    } else {
+      s.skip_field("reason")?;
+    }
+    if let Some(f) = self.user_info() {
+      s.serialize_field("user_info", &f)?;
+    } else {
+      s.skip_field("user_info")?;
+    }
+    s.end()
+  }
+}
+
+impl Serialize for MachException<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("MachException", 3)?;
+    s.serialize_field("type", &self.type_())?;
+    s.serialize_field("code", &self.code())?;
+    s.serialize_field("subcode", &self.subcode())?;
+    s.end()
+  }
+}
+
+impl Serialize for PosixSignal<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("PosixSignal", 5)?;
+    s.serialize_field("number", &self.number())?;
+    s.serialize_field("code", &self.code())?;
+    s.serialize_field("errno", &self.errno())?;
+    s.serialize_field("has_fault_address", &self.has_fault_address())?;
+    s.serialize_field("fault_address", &self.fault_address())?;
+    s.end()
+  }
+}
+
+impl Serialize for AppleTermination<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("AppleTermination", 7)?;
+    if let Some(f) = self.domain() {
+      s.serialize_field("domain", &f)?;
+    } else {
+      s.skip_field("domain")?;
+    }
+    if let Some(f) = self.code() {
+      s.serialize_field("code", &f)?;
+    } else {
+      s.skip_field("code")?;
+    }
+    if let Some(f) = self.explanation() {
+      s.serialize_field("explanation", &f)?;
+    } else {
+      s.skip_field("explanation")?;
+    }
+    if let Some(f) = self.process_visibility() {
+      s.serialize_field("process_visibility", &f)?;
+    } else {
+      s.skip_field("process_visibility")?;
+    }
+    if let Some(f) = self.process_state() {
+      s.serialize_field("process_state", &f)?;
+    } else {
+      s.skip_field("process_state")?;
+    }
+    if let Some(f) = self.watchdog_event() {
+      s.serialize_field("watchdog_event", &f)?;
+    } else {
+      s.skip_field("watchdog_event")?;
+    }
+    if let Some(f) = self.watchdog_visibility() {
+      s.serialize_field("watchdog_visibility", &f)?;
+    } else {
+      s.skip_field("watchdog_visibility")?;
+    }
+    s.end()
+  }
+}
+
+impl Serialize for AppleCrashDetails<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("AppleCrashDetails", 4)?;
+    if let Some(f) = self.nsexception() {
+      s.serialize_field("nsexception", &f)?;
+    } else {
+      s.skip_field("nsexception")?;
+    }
+    if let Some(f) = self.mach_exception() {
+      s.serialize_field("mach_exception", &f)?;
+    } else {
+      s.skip_field("mach_exception")?;
+    }
+    if let Some(f) = self.posix_signal() {
+      s.serialize_field("posix_signal", &f)?;
+    } else {
+      s.skip_field("posix_signal")?;
+    }
+    if let Some(f) = self.termination() {
+      s.serialize_field("termination", &f)?;
+    } else {
+      s.skip_field("termination")?;
+    }
+    s.end()
+  }
+}
+
+impl Serialize for CrashInfo<'_> {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    let mut s = serializer.serialize_struct("CrashInfo", 5)?;
+    s.serialize_field("reporter_scope", &self.reporter_scope())?;
+    s.serialize_field("reporter", &self.reporter())?;
+    if let Some(f) = self.occurred_at() {
+      s.serialize_field("occurred_at", &f)?;
+    } else {
+      s.skip_field("occurred_at")?;
+    }
+    s.serialize_field("details_type", &self.details_type())?;
+    match self.details_type() {
+      CrashInfoDetails::AppleCrashDetails => {
+        if let Some(f) = self.details_as_apple_crash_details() {
+          s.serialize_field("details", &f)?;
+        } else {
+          s.skip_field("details")?;
+        }
+      },
+      _ => s.skip_field("details")?,
+    }
+    if let Some(f) = self.thread_details() {
+      s.serialize_field("thread_details", &f)?;
+    } else {
+      s.skip_field("thread_details")?;
+    }
+    s.end()
+  }
+}
+
 impl Serialize for BinaryImage<'_> {
   fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
   where
@@ -495,7 +659,7 @@ impl Serialize for Report<'_> {
   where
     S: Serializer,
   {
-    let mut s = serializer.serialize_struct("Report", 10)?;
+    let mut s = serializer.serialize_struct("Report", 11)?;
     if let Some(f) = self.sdk() {
       s.serialize_field("sdk", &f)?;
     } else {
@@ -541,6 +705,11 @@ impl Serialize for Report<'_> {
       s.serialize_field("processing_result", &f)?;
     } else {
       s.skip_field("processing_result")?;
+    }
+    if let Some(f) = self.crash_info() {
+      s.serialize_field("crash_info", &f)?;
+    } else {
+      s.skip_field("crash_info")?;
     }
     s.end()
   }

--- a/bd-proto/src/flatbuffers/report_serialize.rs
+++ b/bd-proto/src/flatbuffers/report_serialize.rs
@@ -549,7 +549,7 @@ impl Serialize for CrashInfo<'_> {
   where
     S: Serializer,
   {
-    let mut s = serializer.serialize_struct("CrashInfo", 5)?;
+    let mut s = serializer.serialize_struct("CrashInfo", 6)?;
     s.serialize_field("reporter_scope", &self.reporter_scope())?;
     s.serialize_field("reporter", &self.reporter())?;
     if let Some(f) = self.occurred_at() {

--- a/bd-proto/src/flatbuffers/report_serialize.rs
+++ b/bd-proto/src/flatbuffers/report_serialize.rs
@@ -462,7 +462,7 @@ impl Serialize for PosixSignal<'_> {
     let mut s = serializer.serialize_struct("PosixSignal", 5)?;
     s.serialize_field("number", &self.number())?;
     s.serialize_field("code", &self.code())?;
-    s.serialize_field("errno", &self.errno())?;
+    s.serialize_field("errno_value", &self.errno_value())?;
     s.serialize_field("has_fault_address", &self.has_fault_address())?;
     s.serialize_field("fault_address", &self.fault_address())?;
     s.end()

--- a/bd-proto/src/flatbuffers/report_serialize_test.rs
+++ b/bd-proto/src/flatbuffers/report_serialize_test.rs
@@ -440,15 +440,14 @@ fn serialize_crash_info() {
     &PosixSignalArgs {
       number: 11,
       code: 3,
-      errno: 4,
+      errno_value: 4,
       has_fault_address: true,
       fault_address: 0x1234,
     },
   );
   let termination_domain = builder.create_string("10");
   let termination_code = builder.create_string("0x8BADF00D");
-  let termination_explanation =
-    builder.create_string("Failed to terminate gracefully after 5.0s");
+  let termination_explanation = builder.create_string("Failed to terminate gracefully after 5.0s");
   let termination_process_visibility = builder.create_string("Unknown");
   let termination_process_state = builder.create_string("Running");
   let termination_watchdog_event = builder.create_string("process-exit");
@@ -526,7 +525,7 @@ fn serialize_crash_info() {
         "posix_signal": {
           "number": 11,
           "code": 3,
-          "errno": 4,
+          "errno_value": 4,
           "has_fault_address": true,
           "fault_address": 4660,
         },

--- a/bd-proto/src/flatbuffers/report_serialize_test.rs
+++ b/bd-proto/src/flatbuffers/report_serialize_test.rs
@@ -415,6 +415,209 @@ fn serialize_report() {
 }
 
 #[test]
+fn serialize_crash_info() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let nsexception_name = builder.create_string("NSRangeException");
+  let nsexception_reason = builder.create_string("index 9 beyond bounds 8");
+  let nsexception = NSException::create(
+    &mut builder,
+    &NSExceptionArgs {
+      name: Some(nsexception_name),
+      reason: Some(nsexception_reason),
+      ..Default::default()
+    },
+  );
+  let mach_exception = MachException::create(
+    &mut builder,
+    &MachExceptionArgs {
+      type_: 10,
+      code: 1,
+      subcode: 2,
+    },
+  );
+  let posix_signal = PosixSignal::create(
+    &mut builder,
+    &PosixSignalArgs {
+      number: 11,
+      code: 3,
+      errno: 4,
+      has_fault_address: true,
+      fault_address: 0x1234,
+    },
+  );
+  let termination_domain = builder.create_string("10");
+  let termination_code = builder.create_string("0x8BADF00D");
+  let termination_explanation =
+    builder.create_string("Failed to terminate gracefully after 5.0s");
+  let termination_process_visibility = builder.create_string("Unknown");
+  let termination_process_state = builder.create_string("Running");
+  let termination_watchdog_event = builder.create_string("process-exit");
+  let termination_watchdog_visibility = builder.create_string("Foreground");
+  let termination = AppleTermination::create(
+    &mut builder,
+    &AppleTerminationArgs {
+      domain: Some(termination_domain),
+      code: Some(termination_code),
+      explanation: Some(termination_explanation),
+      process_visibility: Some(termination_process_visibility),
+      process_state: Some(termination_process_state),
+      watchdog_event: Some(termination_watchdog_event),
+      watchdog_visibility: Some(termination_watchdog_visibility),
+    },
+  );
+  let details = AppleCrashDetails::create(
+    &mut builder,
+    &AppleCrashDetailsArgs {
+      nsexception: Some(nsexception),
+      mach_exception: Some(mach_exception),
+      posix_signal: Some(posix_signal),
+      termination: Some(termination),
+    },
+  );
+  let thread_name = builder.create_string("main");
+  let thread = Thread::create(
+    &mut builder,
+    &ThreadArgs {
+      name: Some(thread_name),
+      index: 12,
+      active: true,
+      ..Default::default()
+    },
+  );
+  let threads = builder.create_vector(&[thread]);
+  let thread_details = ThreadDetails::create(
+    &mut builder,
+    &ThreadDetailsArgs {
+      count: 1,
+      threads: Some(threads),
+    },
+  );
+  let object = serialization_loop(&build_table!(
+    builder,
+    CrashInfo,
+    &CrashInfoArgs {
+      reporter_scope: CrashReporterScope::OutOfProcess,
+      reporter: CrashReporter::AppleMetricKit,
+      occurred_at: Some(&Timestamp::new(1_700_000_000, 55)),
+      details_type: CrashInfoDetails::AppleCrashDetails,
+      details: Some(details.as_union_value()),
+      thread_details: Some(thread_details),
+    }
+  ));
+  assert_eq!(
+    json!({
+      "reporter_scope": "OutOfProcess",
+      "reporter": "AppleMetricKit",
+      "occurred_at": {
+        "seconds": 1700000000,
+        "nanos": 55,
+      },
+      "details_type": "AppleCrashDetails",
+      "details": {
+        "nsexception": {
+          "name": "NSRangeException",
+          "reason": "index 9 beyond bounds 8",
+        },
+        "mach_exception": {
+          "type": 10,
+          "code": 1,
+          "subcode": 2,
+        },
+        "posix_signal": {
+          "number": 11,
+          "code": 3,
+          "errno": 4,
+          "has_fault_address": true,
+          "fault_address": 4660,
+        },
+        "termination": {
+          "domain": "10",
+          "code": "0x8BADF00D",
+          "explanation": "Failed to terminate gracefully after 5.0s",
+          "process_visibility": "Unknown",
+          "process_state": "Running",
+          "watchdog_event": "process-exit",
+          "watchdog_visibility": "Foreground",
+        },
+      },
+      "thread_details": {
+        "count": 1,
+        "threads": [{
+          "name": "main",
+          "index": 12,
+          "active": true,
+          "priority": 0.0,
+          "quality_of_service": -1,
+        }],
+      },
+    }),
+    object
+  );
+  assert_struct_size!(CrashInfoArgs, 32);
+}
+
+#[test]
+fn serialize_report_with_crash_info() {
+  let mut builder = flatbuffers::FlatBufferBuilder::new();
+  let nsexception_name = builder.create_string("NSInvalidArgumentException");
+  let nsexception_reason = builder.create_string("bad argument");
+  let nsexception = NSException::create(
+    &mut builder,
+    &NSExceptionArgs {
+      name: Some(nsexception_name),
+      reason: Some(nsexception_reason),
+      ..Default::default()
+    },
+  );
+  let details = AppleCrashDetails::create(
+    &mut builder,
+    &AppleCrashDetailsArgs {
+      nsexception: Some(nsexception),
+      ..Default::default()
+    },
+  );
+  let crash_info = CrashInfo::create(
+    &mut builder,
+    &CrashInfoArgs {
+      reporter_scope: CrashReporterScope::InProcess,
+      reporter: CrashReporter::AppleBitdriftCrashReporter,
+      occurred_at: Some(&Timestamp::new(1_700_000_001, 77)),
+      details_type: CrashInfoDetails::AppleCrashDetails,
+      details: Some(details.as_union_value()),
+      ..Default::default()
+    },
+  );
+  let crash_info_vector = builder.create_vector(&[crash_info]);
+  let object = serialization_loop(&build_table!(
+    builder,
+    Report,
+    &ReportArgs {
+      type_: ReportType::NativeCrash,
+      crash_info: Some(crash_info_vector),
+      ..Default::default()
+    }
+  ));
+  assert_eq!(
+    json!([{
+      "reporter_scope": "InProcess",
+      "reporter": "AppleBitdriftCrashReporter",
+      "occurred_at": {
+        "seconds": 1700000001,
+        "nanos": 77,
+      },
+      "details_type": "AppleCrashDetails",
+      "details": {
+        "nsexception": {
+          "name": "NSInvalidArgumentException",
+          "reason": "bad argument",
+        },
+      },
+    }]),
+    object["crash_info"]
+  );
+}
+
+#[test]
 fn serialize_thread() {
   let mut builder = flatbuffers::FlatBufferBuilder::new();
   let object = serialization_loop(&build_table!(

--- a/bd-proto/src/flatbuffers/report_serialize_test.rs
+++ b/bd-proto/src/flatbuffers/report_serialize_test.rs
@@ -411,7 +411,7 @@ fn serialize_report() {
     }),
     object
   );
-  assert_struct_size!(ReportArgs, 76);
+  assert_struct_size!(ReportArgs, 84);
 }
 
 #[test]

--- a/bd-report-convert/src/flatbuffers/report_generated.h
+++ b/bd-report-convert/src/flatbuffers/report_generated.h
@@ -2323,7 +2323,7 @@ struct PosixSignal FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NUMBER = 4,
     VT_CODE = 6,
-    VT_ERRNO = 8,
+    VT_ERRNO_VALUE = 8,
     VT_HAS_FAULT_ADDRESS = 10,
     VT_FAULT_ADDRESS = 12
   };
@@ -2333,8 +2333,8 @@ struct PosixSignal FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int32_t code() const {
     return GetField<int32_t>(VT_CODE, 0);
   }
-  int32_t errno() const {
-    return GetField<int32_t>(VT_ERRNO, 0);
+  int32_t errno_value() const {
+    return GetField<int32_t>(VT_ERRNO_VALUE, 0);
   }
   bool has_fault_address() const {
     return GetField<uint8_t>(VT_HAS_FAULT_ADDRESS, 0) != 0;
@@ -2346,7 +2346,7 @@ struct PosixSignal FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return VerifyTableStart(verifier) &&
            VerifyField<int32_t>(verifier, VT_NUMBER, 4) &&
            VerifyField<int32_t>(verifier, VT_CODE, 4) &&
-           VerifyField<int32_t>(verifier, VT_ERRNO, 4) &&
+           VerifyField<int32_t>(verifier, VT_ERRNO_VALUE, 4) &&
            VerifyField<uint8_t>(verifier, VT_HAS_FAULT_ADDRESS, 1) &&
            VerifyField<uint64_t>(verifier, VT_FAULT_ADDRESS, 8) &&
            verifier.EndTable();
@@ -2363,8 +2363,8 @@ struct PosixSignalBuilder {
   void add_code(int32_t code) {
     fbb_.AddElement<int32_t>(PosixSignal::VT_CODE, code, 0);
   }
-  void add_errno(int32_t errno) {
-    fbb_.AddElement<int32_t>(PosixSignal::VT_ERRNO, errno, 0);
+  void add_errno_value(int32_t errno_value) {
+    fbb_.AddElement<int32_t>(PosixSignal::VT_ERRNO_VALUE, errno_value, 0);
   }
   void add_has_fault_address(bool has_fault_address) {
     fbb_.AddElement<uint8_t>(PosixSignal::VT_HAS_FAULT_ADDRESS, static_cast<uint8_t>(has_fault_address), 0);
@@ -2387,12 +2387,12 @@ inline ::flatbuffers::Offset<PosixSignal> CreatePosixSignal(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     int32_t number = 0,
     int32_t code = 0,
-    int32_t errno = 0,
+    int32_t errno_value = 0,
     bool has_fault_address = false,
     uint64_t fault_address = 0) {
   PosixSignalBuilder builder_(_fbb);
   builder_.add_fault_address(fault_address);
-  builder_.add_errno(errno);
+  builder_.add_errno_value(errno_value);
   builder_.add_code(code);
   builder_.add_number(number);
   builder_.add_has_fault_address(has_fault_address);
@@ -3934,7 +3934,7 @@ inline const ::flatbuffers::TypeTable *PosixSignalTypeTable() {
   static const char * const names[] = {
     "number",
     "code",
-    "errno",
+    "errno_value",
     "has_fault_address",
     "fault_address"
   };

--- a/bd-report-convert/src/flatbuffers/report_generated.h
+++ b/bd-report-convert/src/flatbuffers/report_generated.h
@@ -63,6 +63,24 @@ struct ThreadDetailsBuilder;
 struct Error;
 struct ErrorBuilder;
 
+struct NSException;
+struct NSExceptionBuilder;
+
+struct MachException;
+struct MachExceptionBuilder;
+
+struct PosixSignal;
+struct PosixSignalBuilder;
+
+struct AppleTermination;
+struct AppleTerminationBuilder;
+
+struct AppleCrashDetails;
+struct AppleCrashDetailsBuilder;
+
+struct CrashInfo;
+struct CrashInfoBuilder;
+
 struct BinaryImage;
 struct BinaryImageBuilder;
 
@@ -107,6 +125,18 @@ inline const ::flatbuffers::TypeTable *ThreadTypeTable();
 inline const ::flatbuffers::TypeTable *ThreadDetailsTypeTable();
 
 inline const ::flatbuffers::TypeTable *ErrorTypeTable();
+
+inline const ::flatbuffers::TypeTable *NSExceptionTypeTable();
+
+inline const ::flatbuffers::TypeTable *MachExceptionTypeTable();
+
+inline const ::flatbuffers::TypeTable *PosixSignalTypeTable();
+
+inline const ::flatbuffers::TypeTable *AppleTerminationTypeTable();
+
+inline const ::flatbuffers::TypeTable *AppleCrashDetailsTypeTable();
+
+inline const ::flatbuffers::TypeTable *CrashInfoTypeTable();
 
 inline const ::flatbuffers::TypeTable *BinaryImageTypeTable();
 
@@ -308,6 +338,81 @@ inline const char *EnumNameErrorRelation(ErrorRelation e) {
   if (::flatbuffers::IsOutRange(e, ErrorRelation_CausedBy, ErrorRelation_CausedBy)) return "";
   const size_t index = static_cast<size_t>(e) - static_cast<size_t>(ErrorRelation_CausedBy);
   return EnumNamesErrorRelation()[index];
+}
+
+enum CrashReporterScope : int8_t {
+  CrashReporterScope_Unknown = 0,
+  CrashReporterScope_InProcess = 1,
+  CrashReporterScope_OutOfProcess = 2,
+  CrashReporterScope_MIN = CrashReporterScope_Unknown,
+  CrashReporterScope_MAX = CrashReporterScope_OutOfProcess
+};
+
+inline const CrashReporterScope (&EnumValuesCrashReporterScope())[3] {
+  static const CrashReporterScope values[] = {
+    CrashReporterScope_Unknown,
+    CrashReporterScope_InProcess,
+    CrashReporterScope_OutOfProcess
+  };
+  return values;
+}
+
+inline const char * const *EnumNamesCrashReporterScope() {
+  static const char * const names[4] = {
+    "Unknown",
+    "InProcess",
+    "OutOfProcess",
+    nullptr
+  };
+  return names;
+}
+
+inline const char *EnumNameCrashReporterScope(CrashReporterScope e) {
+  if (::flatbuffers::IsOutRange(e, CrashReporterScope_Unknown, CrashReporterScope_OutOfProcess)) return "";
+  const size_t index = static_cast<size_t>(e);
+  return EnumNamesCrashReporterScope()[index];
+}
+
+enum CrashReporter : int8_t {
+  CrashReporter_Unknown = 0,
+  CrashReporter_AppleMetricKit = 1,
+  CrashReporter_AppleKSCrash = 2,
+  CrashReporter_AppleBitdriftCrashReporter = 3,
+  CrashReporter_AndroidUncaughtExceptionHandler = 4,
+  CrashReporter_AndroidApplicationExitInfo = 5,
+  CrashReporter_MIN = CrashReporter_Unknown,
+  CrashReporter_MAX = CrashReporter_AndroidApplicationExitInfo
+};
+
+inline const CrashReporter (&EnumValuesCrashReporter())[6] {
+  static const CrashReporter values[] = {
+    CrashReporter_Unknown,
+    CrashReporter_AppleMetricKit,
+    CrashReporter_AppleKSCrash,
+    CrashReporter_AppleBitdriftCrashReporter,
+    CrashReporter_AndroidUncaughtExceptionHandler,
+    CrashReporter_AndroidApplicationExitInfo
+  };
+  return values;
+}
+
+inline const char * const *EnumNamesCrashReporter() {
+  static const char * const names[7] = {
+    "Unknown",
+    "AppleMetricKit",
+    "AppleKSCrash",
+    "AppleBitdriftCrashReporter",
+    "AndroidUncaughtExceptionHandler",
+    "AndroidApplicationExitInfo",
+    nullptr
+  };
+  return names;
+}
+
+inline const char *EnumNameCrashReporter(CrashReporter e) {
+  if (::flatbuffers::IsOutRange(e, CrashReporter_Unknown, CrashReporter_AndroidApplicationExitInfo)) return "";
+  const size_t index = static_cast<size_t>(e);
+  return EnumNamesCrashReporter()[index];
 }
 
 enum PowerState : int8_t {
@@ -531,6 +636,47 @@ inline const char *EnumNameFrameStatus(FrameStatus e) {
   const size_t index = static_cast<size_t>(e);
   return EnumNamesFrameStatus()[index];
 }
+
+enum CrashInfoDetails : uint8_t {
+  CrashInfoDetails_NONE = 0,
+  CrashInfoDetails_AppleCrashDetails = 1,
+  CrashInfoDetails_MIN = CrashInfoDetails_NONE,
+  CrashInfoDetails_MAX = CrashInfoDetails_AppleCrashDetails
+};
+
+inline const CrashInfoDetails (&EnumValuesCrashInfoDetails())[2] {
+  static const CrashInfoDetails values[] = {
+    CrashInfoDetails_NONE,
+    CrashInfoDetails_AppleCrashDetails
+  };
+  return values;
+}
+
+inline const char * const *EnumNamesCrashInfoDetails() {
+  static const char * const names[3] = {
+    "NONE",
+    "AppleCrashDetails",
+    nullptr
+  };
+  return names;
+}
+
+inline const char *EnumNameCrashInfoDetails(CrashInfoDetails e) {
+  if (::flatbuffers::IsOutRange(e, CrashInfoDetails_NONE, CrashInfoDetails_AppleCrashDetails)) return "";
+  const size_t index = static_cast<size_t>(e);
+  return EnumNamesCrashInfoDetails()[index];
+}
+
+template<typename T> struct CrashInfoDetailsTraits {
+  static const CrashInfoDetails enum_value = CrashInfoDetails_NONE;
+};
+
+template<> struct CrashInfoDetailsTraits<bitdrift_public::fbs::issue_reporting::v1::AppleCrashDetails> {
+  static const CrashInfoDetails enum_value = CrashInfoDetails_AppleCrashDetails;
+};
+
+bool VerifyCrashInfoDetails(::flatbuffers::Verifier &verifier, const void *obj, CrashInfoDetails type);
+bool VerifyCrashInfoDetailsVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types);
 
 FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Timestamp FLATBUFFERS_FINAL_CLASS {
  private:
@@ -2022,6 +2168,557 @@ inline ::flatbuffers::Offset<Error> CreateErrorDirect(
       relation_to_next);
 }
 
+struct NSException FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
+  typedef NSExceptionBuilder Builder;
+  static const ::flatbuffers::TypeTable *MiniReflectTypeTable() {
+    return NSExceptionTypeTable();
+  }
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_NAME = 4,
+    VT_REASON = 6,
+    VT_USER_INFO = 8
+  };
+  const ::flatbuffers::String *name() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_NAME);
+  }
+  const ::flatbuffers::String *reason() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_REASON);
+  }
+  const ::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::common::v1::Field>> *user_info() const {
+    return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::common::v1::Field>> *>(VT_USER_INFO);
+  }
+  bool Verify(::flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyOffset(verifier, VT_NAME) &&
+           verifier.VerifyString(name()) &&
+           VerifyOffset(verifier, VT_REASON) &&
+           verifier.VerifyString(reason()) &&
+           VerifyOffset(verifier, VT_USER_INFO) &&
+           verifier.VerifyVector(user_info()) &&
+           verifier.VerifyVectorOfTables(user_info()) &&
+           verifier.EndTable();
+  }
+};
+
+struct NSExceptionBuilder {
+  typedef NSException Table;
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_name(::flatbuffers::Offset<::flatbuffers::String> name) {
+    fbb_.AddOffset(NSException::VT_NAME, name);
+  }
+  void add_reason(::flatbuffers::Offset<::flatbuffers::String> reason) {
+    fbb_.AddOffset(NSException::VT_REASON, reason);
+  }
+  void add_user_info(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::common::v1::Field>>> user_info) {
+    fbb_.AddOffset(NSException::VT_USER_INFO, user_info);
+  }
+  explicit NSExceptionBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  ::flatbuffers::Offset<NSException> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = ::flatbuffers::Offset<NSException>(end);
+    return o;
+  }
+};
+
+inline ::flatbuffers::Offset<NSException> CreateNSException(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    ::flatbuffers::Offset<::flatbuffers::String> name = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> reason = 0,
+    ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::common::v1::Field>>> user_info = 0) {
+  NSExceptionBuilder builder_(_fbb);
+  builder_.add_user_info(user_info);
+  builder_.add_reason(reason);
+  builder_.add_name(name);
+  return builder_.Finish();
+}
+
+inline ::flatbuffers::Offset<NSException> CreateNSExceptionDirect(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    const char *name = nullptr,
+    const char *reason = nullptr,
+    const std::vector<::flatbuffers::Offset<bitdrift_public::fbs::common::v1::Field>> *user_info = nullptr) {
+  auto name__ = name ? _fbb.CreateString(name) : 0;
+  auto reason__ = reason ? _fbb.CreateString(reason) : 0;
+  auto user_info__ = user_info ? _fbb.CreateVector<::flatbuffers::Offset<bitdrift_public::fbs::common::v1::Field>>(*user_info) : 0;
+  return bitdrift_public::fbs::issue_reporting::v1::CreateNSException(
+      _fbb,
+      name__,
+      reason__,
+      user_info__);
+}
+
+struct MachException FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
+  typedef MachExceptionBuilder Builder;
+  static const ::flatbuffers::TypeTable *MiniReflectTypeTable() {
+    return MachExceptionTypeTable();
+  }
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_TYPE = 4,
+    VT_CODE = 6,
+    VT_SUBCODE = 8
+  };
+  uint32_t type() const {
+    return GetField<uint32_t>(VT_TYPE, 0);
+  }
+  uint64_t code() const {
+    return GetField<uint64_t>(VT_CODE, 0);
+  }
+  uint64_t subcode() const {
+    return GetField<uint64_t>(VT_SUBCODE, 0);
+  }
+  bool Verify(::flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<uint32_t>(verifier, VT_TYPE, 4) &&
+           VerifyField<uint64_t>(verifier, VT_CODE, 8) &&
+           VerifyField<uint64_t>(verifier, VT_SUBCODE, 8) &&
+           verifier.EndTable();
+  }
+};
+
+struct MachExceptionBuilder {
+  typedef MachException Table;
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_type(uint32_t type) {
+    fbb_.AddElement<uint32_t>(MachException::VT_TYPE, type, 0);
+  }
+  void add_code(uint64_t code) {
+    fbb_.AddElement<uint64_t>(MachException::VT_CODE, code, 0);
+  }
+  void add_subcode(uint64_t subcode) {
+    fbb_.AddElement<uint64_t>(MachException::VT_SUBCODE, subcode, 0);
+  }
+  explicit MachExceptionBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  ::flatbuffers::Offset<MachException> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = ::flatbuffers::Offset<MachException>(end);
+    return o;
+  }
+};
+
+inline ::flatbuffers::Offset<MachException> CreateMachException(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    uint32_t type = 0,
+    uint64_t code = 0,
+    uint64_t subcode = 0) {
+  MachExceptionBuilder builder_(_fbb);
+  builder_.add_subcode(subcode);
+  builder_.add_code(code);
+  builder_.add_type(type);
+  return builder_.Finish();
+}
+
+struct PosixSignal FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
+  typedef PosixSignalBuilder Builder;
+  static const ::flatbuffers::TypeTable *MiniReflectTypeTable() {
+    return PosixSignalTypeTable();
+  }
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_NUMBER = 4,
+    VT_CODE = 6,
+    VT_ERRNO = 8,
+    VT_HAS_FAULT_ADDRESS = 10,
+    VT_FAULT_ADDRESS = 12
+  };
+  int32_t number() const {
+    return GetField<int32_t>(VT_NUMBER, 0);
+  }
+  int32_t code() const {
+    return GetField<int32_t>(VT_CODE, 0);
+  }
+  int32_t errno() const {
+    return GetField<int32_t>(VT_ERRNO, 0);
+  }
+  bool has_fault_address() const {
+    return GetField<uint8_t>(VT_HAS_FAULT_ADDRESS, 0) != 0;
+  }
+  uint64_t fault_address() const {
+    return GetField<uint64_t>(VT_FAULT_ADDRESS, 0);
+  }
+  bool Verify(::flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<int32_t>(verifier, VT_NUMBER, 4) &&
+           VerifyField<int32_t>(verifier, VT_CODE, 4) &&
+           VerifyField<int32_t>(verifier, VT_ERRNO, 4) &&
+           VerifyField<uint8_t>(verifier, VT_HAS_FAULT_ADDRESS, 1) &&
+           VerifyField<uint64_t>(verifier, VT_FAULT_ADDRESS, 8) &&
+           verifier.EndTable();
+  }
+};
+
+struct PosixSignalBuilder {
+  typedef PosixSignal Table;
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_number(int32_t number) {
+    fbb_.AddElement<int32_t>(PosixSignal::VT_NUMBER, number, 0);
+  }
+  void add_code(int32_t code) {
+    fbb_.AddElement<int32_t>(PosixSignal::VT_CODE, code, 0);
+  }
+  void add_errno(int32_t errno) {
+    fbb_.AddElement<int32_t>(PosixSignal::VT_ERRNO, errno, 0);
+  }
+  void add_has_fault_address(bool has_fault_address) {
+    fbb_.AddElement<uint8_t>(PosixSignal::VT_HAS_FAULT_ADDRESS, static_cast<uint8_t>(has_fault_address), 0);
+  }
+  void add_fault_address(uint64_t fault_address) {
+    fbb_.AddElement<uint64_t>(PosixSignal::VT_FAULT_ADDRESS, fault_address, 0);
+  }
+  explicit PosixSignalBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  ::flatbuffers::Offset<PosixSignal> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = ::flatbuffers::Offset<PosixSignal>(end);
+    return o;
+  }
+};
+
+inline ::flatbuffers::Offset<PosixSignal> CreatePosixSignal(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    int32_t number = 0,
+    int32_t code = 0,
+    int32_t errno = 0,
+    bool has_fault_address = false,
+    uint64_t fault_address = 0) {
+  PosixSignalBuilder builder_(_fbb);
+  builder_.add_fault_address(fault_address);
+  builder_.add_errno(errno);
+  builder_.add_code(code);
+  builder_.add_number(number);
+  builder_.add_has_fault_address(has_fault_address);
+  return builder_.Finish();
+}
+
+struct AppleTermination FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
+  typedef AppleTerminationBuilder Builder;
+  static const ::flatbuffers::TypeTable *MiniReflectTypeTable() {
+    return AppleTerminationTypeTable();
+  }
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_DOMAIN = 4,
+    VT_CODE = 6,
+    VT_EXPLANATION = 8,
+    VT_PROCESS_VISIBILITY = 10,
+    VT_PROCESS_STATE = 12,
+    VT_WATCHDOG_EVENT = 14,
+    VT_WATCHDOG_VISIBILITY = 16
+  };
+  const ::flatbuffers::String *domain() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_DOMAIN);
+  }
+  const ::flatbuffers::String *code() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_CODE);
+  }
+  const ::flatbuffers::String *explanation() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_EXPLANATION);
+  }
+  const ::flatbuffers::String *process_visibility() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_PROCESS_VISIBILITY);
+  }
+  const ::flatbuffers::String *process_state() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_PROCESS_STATE);
+  }
+  const ::flatbuffers::String *watchdog_event() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_WATCHDOG_EVENT);
+  }
+  const ::flatbuffers::String *watchdog_visibility() const {
+    return GetPointer<const ::flatbuffers::String *>(VT_WATCHDOG_VISIBILITY);
+  }
+  bool Verify(::flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyOffset(verifier, VT_DOMAIN) &&
+           verifier.VerifyString(domain()) &&
+           VerifyOffset(verifier, VT_CODE) &&
+           verifier.VerifyString(code()) &&
+           VerifyOffset(verifier, VT_EXPLANATION) &&
+           verifier.VerifyString(explanation()) &&
+           VerifyOffset(verifier, VT_PROCESS_VISIBILITY) &&
+           verifier.VerifyString(process_visibility()) &&
+           VerifyOffset(verifier, VT_PROCESS_STATE) &&
+           verifier.VerifyString(process_state()) &&
+           VerifyOffset(verifier, VT_WATCHDOG_EVENT) &&
+           verifier.VerifyString(watchdog_event()) &&
+           VerifyOffset(verifier, VT_WATCHDOG_VISIBILITY) &&
+           verifier.VerifyString(watchdog_visibility()) &&
+           verifier.EndTable();
+  }
+};
+
+struct AppleTerminationBuilder {
+  typedef AppleTermination Table;
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_domain(::flatbuffers::Offset<::flatbuffers::String> domain) {
+    fbb_.AddOffset(AppleTermination::VT_DOMAIN, domain);
+  }
+  void add_code(::flatbuffers::Offset<::flatbuffers::String> code) {
+    fbb_.AddOffset(AppleTermination::VT_CODE, code);
+  }
+  void add_explanation(::flatbuffers::Offset<::flatbuffers::String> explanation) {
+    fbb_.AddOffset(AppleTermination::VT_EXPLANATION, explanation);
+  }
+  void add_process_visibility(::flatbuffers::Offset<::flatbuffers::String> process_visibility) {
+    fbb_.AddOffset(AppleTermination::VT_PROCESS_VISIBILITY, process_visibility);
+  }
+  void add_process_state(::flatbuffers::Offset<::flatbuffers::String> process_state) {
+    fbb_.AddOffset(AppleTermination::VT_PROCESS_STATE, process_state);
+  }
+  void add_watchdog_event(::flatbuffers::Offset<::flatbuffers::String> watchdog_event) {
+    fbb_.AddOffset(AppleTermination::VT_WATCHDOG_EVENT, watchdog_event);
+  }
+  void add_watchdog_visibility(::flatbuffers::Offset<::flatbuffers::String> watchdog_visibility) {
+    fbb_.AddOffset(AppleTermination::VT_WATCHDOG_VISIBILITY, watchdog_visibility);
+  }
+  explicit AppleTerminationBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  ::flatbuffers::Offset<AppleTermination> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = ::flatbuffers::Offset<AppleTermination>(end);
+    return o;
+  }
+};
+
+inline ::flatbuffers::Offset<AppleTermination> CreateAppleTermination(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    ::flatbuffers::Offset<::flatbuffers::String> domain = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> code = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> explanation = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> process_visibility = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> process_state = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> watchdog_event = 0,
+    ::flatbuffers::Offset<::flatbuffers::String> watchdog_visibility = 0) {
+  AppleTerminationBuilder builder_(_fbb);
+  builder_.add_watchdog_visibility(watchdog_visibility);
+  builder_.add_watchdog_event(watchdog_event);
+  builder_.add_process_state(process_state);
+  builder_.add_process_visibility(process_visibility);
+  builder_.add_explanation(explanation);
+  builder_.add_code(code);
+  builder_.add_domain(domain);
+  return builder_.Finish();
+}
+
+inline ::flatbuffers::Offset<AppleTermination> CreateAppleTerminationDirect(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    const char *domain = nullptr,
+    const char *code = nullptr,
+    const char *explanation = nullptr,
+    const char *process_visibility = nullptr,
+    const char *process_state = nullptr,
+    const char *watchdog_event = nullptr,
+    const char *watchdog_visibility = nullptr) {
+  auto domain__ = domain ? _fbb.CreateString(domain) : 0;
+  auto code__ = code ? _fbb.CreateString(code) : 0;
+  auto explanation__ = explanation ? _fbb.CreateString(explanation) : 0;
+  auto process_visibility__ = process_visibility ? _fbb.CreateString(process_visibility) : 0;
+  auto process_state__ = process_state ? _fbb.CreateString(process_state) : 0;
+  auto watchdog_event__ = watchdog_event ? _fbb.CreateString(watchdog_event) : 0;
+  auto watchdog_visibility__ = watchdog_visibility ? _fbb.CreateString(watchdog_visibility) : 0;
+  return bitdrift_public::fbs::issue_reporting::v1::CreateAppleTermination(
+      _fbb,
+      domain__,
+      code__,
+      explanation__,
+      process_visibility__,
+      process_state__,
+      watchdog_event__,
+      watchdog_visibility__);
+}
+
+struct AppleCrashDetails FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
+  typedef AppleCrashDetailsBuilder Builder;
+  static const ::flatbuffers::TypeTable *MiniReflectTypeTable() {
+    return AppleCrashDetailsTypeTable();
+  }
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_NSEXCEPTION = 4,
+    VT_MACH_EXCEPTION = 6,
+    VT_POSIX_SIGNAL = 8,
+    VT_TERMINATION = 10
+  };
+  const bitdrift_public::fbs::issue_reporting::v1::NSException *nsexception() const {
+    return GetPointer<const bitdrift_public::fbs::issue_reporting::v1::NSException *>(VT_NSEXCEPTION);
+  }
+  const bitdrift_public::fbs::issue_reporting::v1::MachException *mach_exception() const {
+    return GetPointer<const bitdrift_public::fbs::issue_reporting::v1::MachException *>(VT_MACH_EXCEPTION);
+  }
+  const bitdrift_public::fbs::issue_reporting::v1::PosixSignal *posix_signal() const {
+    return GetPointer<const bitdrift_public::fbs::issue_reporting::v1::PosixSignal *>(VT_POSIX_SIGNAL);
+  }
+  const bitdrift_public::fbs::issue_reporting::v1::AppleTermination *termination() const {
+    return GetPointer<const bitdrift_public::fbs::issue_reporting::v1::AppleTermination *>(VT_TERMINATION);
+  }
+  bool Verify(::flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyOffset(verifier, VT_NSEXCEPTION) &&
+           verifier.VerifyTable(nsexception()) &&
+           VerifyOffset(verifier, VT_MACH_EXCEPTION) &&
+           verifier.VerifyTable(mach_exception()) &&
+           VerifyOffset(verifier, VT_POSIX_SIGNAL) &&
+           verifier.VerifyTable(posix_signal()) &&
+           VerifyOffset(verifier, VT_TERMINATION) &&
+           verifier.VerifyTable(termination()) &&
+           verifier.EndTable();
+  }
+};
+
+struct AppleCrashDetailsBuilder {
+  typedef AppleCrashDetails Table;
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_nsexception(::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::NSException> nsexception) {
+    fbb_.AddOffset(AppleCrashDetails::VT_NSEXCEPTION, nsexception);
+  }
+  void add_mach_exception(::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::MachException> mach_exception) {
+    fbb_.AddOffset(AppleCrashDetails::VT_MACH_EXCEPTION, mach_exception);
+  }
+  void add_posix_signal(::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::PosixSignal> posix_signal) {
+    fbb_.AddOffset(AppleCrashDetails::VT_POSIX_SIGNAL, posix_signal);
+  }
+  void add_termination(::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::AppleTermination> termination) {
+    fbb_.AddOffset(AppleCrashDetails::VT_TERMINATION, termination);
+  }
+  explicit AppleCrashDetailsBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  ::flatbuffers::Offset<AppleCrashDetails> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = ::flatbuffers::Offset<AppleCrashDetails>(end);
+    return o;
+  }
+};
+
+inline ::flatbuffers::Offset<AppleCrashDetails> CreateAppleCrashDetails(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    ::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::NSException> nsexception = 0,
+    ::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::MachException> mach_exception = 0,
+    ::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::PosixSignal> posix_signal = 0,
+    ::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::AppleTermination> termination = 0) {
+  AppleCrashDetailsBuilder builder_(_fbb);
+  builder_.add_termination(termination);
+  builder_.add_posix_signal(posix_signal);
+  builder_.add_mach_exception(mach_exception);
+  builder_.add_nsexception(nsexception);
+  return builder_.Finish();
+}
+
+struct CrashInfo FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
+  typedef CrashInfoBuilder Builder;
+  static const ::flatbuffers::TypeTable *MiniReflectTypeTable() {
+    return CrashInfoTypeTable();
+  }
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_REPORTER_SCOPE = 4,
+    VT_REPORTER = 6,
+    VT_OCCURRED_AT = 8,
+    VT_DETAILS_TYPE = 10,
+    VT_DETAILS = 12,
+    VT_THREAD_DETAILS = 14
+  };
+  bitdrift_public::fbs::issue_reporting::v1::CrashReporterScope reporter_scope() const {
+    return static_cast<bitdrift_public::fbs::issue_reporting::v1::CrashReporterScope>(GetField<int8_t>(VT_REPORTER_SCOPE, 0));
+  }
+  bitdrift_public::fbs::issue_reporting::v1::CrashReporter reporter() const {
+    return static_cast<bitdrift_public::fbs::issue_reporting::v1::CrashReporter>(GetField<int8_t>(VT_REPORTER, 0));
+  }
+  const bitdrift_public::fbs::issue_reporting::v1::Timestamp *occurred_at() const {
+    return GetStruct<const bitdrift_public::fbs::issue_reporting::v1::Timestamp *>(VT_OCCURRED_AT);
+  }
+  bitdrift_public::fbs::issue_reporting::v1::CrashInfoDetails details_type() const {
+    return static_cast<bitdrift_public::fbs::issue_reporting::v1::CrashInfoDetails>(GetField<uint8_t>(VT_DETAILS_TYPE, 0));
+  }
+  const void *details() const {
+    return GetPointer<const void *>(VT_DETAILS);
+  }
+  template<typename T> const T *details_as() const;
+  const bitdrift_public::fbs::issue_reporting::v1::AppleCrashDetails *details_as_AppleCrashDetails() const {
+    return details_type() == bitdrift_public::fbs::issue_reporting::v1::CrashInfoDetails_AppleCrashDetails ? static_cast<const bitdrift_public::fbs::issue_reporting::v1::AppleCrashDetails *>(details()) : nullptr;
+  }
+  const bitdrift_public::fbs::issue_reporting::v1::ThreadDetails *thread_details() const {
+    return GetPointer<const bitdrift_public::fbs::issue_reporting::v1::ThreadDetails *>(VT_THREAD_DETAILS);
+  }
+  bool Verify(::flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<int8_t>(verifier, VT_REPORTER_SCOPE, 1) &&
+           VerifyField<int8_t>(verifier, VT_REPORTER, 1) &&
+           VerifyField<bitdrift_public::fbs::issue_reporting::v1::Timestamp>(verifier, VT_OCCURRED_AT, 8) &&
+           VerifyField<uint8_t>(verifier, VT_DETAILS_TYPE, 1) &&
+           VerifyOffset(verifier, VT_DETAILS) &&
+           VerifyCrashInfoDetails(verifier, details(), details_type()) &&
+           VerifyOffset(verifier, VT_THREAD_DETAILS) &&
+           verifier.VerifyTable(thread_details()) &&
+           verifier.EndTable();
+  }
+};
+
+template<> inline const bitdrift_public::fbs::issue_reporting::v1::AppleCrashDetails *CrashInfo::details_as<bitdrift_public::fbs::issue_reporting::v1::AppleCrashDetails>() const {
+  return details_as_AppleCrashDetails();
+}
+
+struct CrashInfoBuilder {
+  typedef CrashInfo Table;
+  ::flatbuffers::FlatBufferBuilder &fbb_;
+  ::flatbuffers::uoffset_t start_;
+  void add_reporter_scope(bitdrift_public::fbs::issue_reporting::v1::CrashReporterScope reporter_scope) {
+    fbb_.AddElement<int8_t>(CrashInfo::VT_REPORTER_SCOPE, static_cast<int8_t>(reporter_scope), 0);
+  }
+  void add_reporter(bitdrift_public::fbs::issue_reporting::v1::CrashReporter reporter) {
+    fbb_.AddElement<int8_t>(CrashInfo::VT_REPORTER, static_cast<int8_t>(reporter), 0);
+  }
+  void add_occurred_at(const bitdrift_public::fbs::issue_reporting::v1::Timestamp *occurred_at) {
+    fbb_.AddStruct(CrashInfo::VT_OCCURRED_AT, occurred_at);
+  }
+  void add_details_type(bitdrift_public::fbs::issue_reporting::v1::CrashInfoDetails details_type) {
+    fbb_.AddElement<uint8_t>(CrashInfo::VT_DETAILS_TYPE, static_cast<uint8_t>(details_type), 0);
+  }
+  void add_details(::flatbuffers::Offset<void> details) {
+    fbb_.AddOffset(CrashInfo::VT_DETAILS, details);
+  }
+  void add_thread_details(::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::ThreadDetails> thread_details) {
+    fbb_.AddOffset(CrashInfo::VT_THREAD_DETAILS, thread_details);
+  }
+  explicit CrashInfoBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  ::flatbuffers::Offset<CrashInfo> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = ::flatbuffers::Offset<CrashInfo>(end);
+    return o;
+  }
+};
+
+inline ::flatbuffers::Offset<CrashInfo> CreateCrashInfo(
+    ::flatbuffers::FlatBufferBuilder &_fbb,
+    bitdrift_public::fbs::issue_reporting::v1::CrashReporterScope reporter_scope = bitdrift_public::fbs::issue_reporting::v1::CrashReporterScope_Unknown,
+    bitdrift_public::fbs::issue_reporting::v1::CrashReporter reporter = bitdrift_public::fbs::issue_reporting::v1::CrashReporter_Unknown,
+    const bitdrift_public::fbs::issue_reporting::v1::Timestamp *occurred_at = nullptr,
+    bitdrift_public::fbs::issue_reporting::v1::CrashInfoDetails details_type = bitdrift_public::fbs::issue_reporting::v1::CrashInfoDetails_NONE,
+    ::flatbuffers::Offset<void> details = 0,
+    ::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::ThreadDetails> thread_details = 0) {
+  CrashInfoBuilder builder_(_fbb);
+  builder_.add_thread_details(thread_details);
+  builder_.add_details(details);
+  builder_.add_occurred_at(occurred_at);
+  builder_.add_details_type(details_type);
+  builder_.add_reporter(reporter);
+  builder_.add_reporter_scope(reporter_scope);
+  return builder_.Finish();
+}
+
 struct BinaryImage FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef BinaryImageBuilder Builder;
   static const ::flatbuffers::TypeTable *MiniReflectTypeTable() {
@@ -2310,7 +3007,8 @@ struct Report FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_BINARY_IMAGES = 16,
     VT_FIELDS = 18,
     VT_FEATURE_FLAGS = 20,
-    VT_PROCESSING_RESULT = 22
+    VT_PROCESSING_RESULT = 22,
+    VT_CRASH_INFO = 24
   };
   const bitdrift_public::fbs::issue_reporting::v1::SDKInfo *sdk() const {
     return GetPointer<const bitdrift_public::fbs::issue_reporting::v1::SDKInfo *>(VT_SDK);
@@ -2342,6 +3040,9 @@ struct Report FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   const bitdrift_public::fbs::issue_reporting::v1::ProcessingResult *processing_result() const {
     return GetPointer<const bitdrift_public::fbs::issue_reporting::v1::ProcessingResult *>(VT_PROCESSING_RESULT);
   }
+  const ::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::CrashInfo>> *crash_info() const {
+    return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::CrashInfo>> *>(VT_CRASH_INFO);
+  }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_SDK) &&
@@ -2367,6 +3068,9 @@ struct Report FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
            verifier.VerifyVectorOfTables(feature_flags()) &&
            VerifyOffset(verifier, VT_PROCESSING_RESULT) &&
            verifier.VerifyTable(processing_result()) &&
+           VerifyOffset(verifier, VT_CRASH_INFO) &&
+           verifier.VerifyVector(crash_info()) &&
+           verifier.VerifyVectorOfTables(crash_info()) &&
            verifier.EndTable();
   }
 };
@@ -2405,6 +3109,9 @@ struct ReportBuilder {
   void add_processing_result(::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::ProcessingResult> processing_result) {
     fbb_.AddOffset(Report::VT_PROCESSING_RESULT, processing_result);
   }
+  void add_crash_info(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::CrashInfo>>> crash_info) {
+    fbb_.AddOffset(Report::VT_CRASH_INFO, crash_info);
+  }
   explicit ReportBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -2427,8 +3134,10 @@ inline ::flatbuffers::Offset<Report> CreateReport(
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::BinaryImage>>> binary_images = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::common::v1::Field>>> fields = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::FeatureFlag>>> feature_flags = 0,
-    ::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::ProcessingResult> processing_result = 0) {
+    ::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::ProcessingResult> processing_result = 0,
+    ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::CrashInfo>>> crash_info = 0) {
   ReportBuilder builder_(_fbb);
+  builder_.add_crash_info(crash_info);
   builder_.add_processing_result(processing_result);
   builder_.add_feature_flags(feature_flags);
   builder_.add_fields(fields);
@@ -2453,11 +3162,13 @@ inline ::flatbuffers::Offset<Report> CreateReportDirect(
     const std::vector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::BinaryImage>> *binary_images = nullptr,
     const std::vector<::flatbuffers::Offset<bitdrift_public::fbs::common::v1::Field>> *fields = nullptr,
     const std::vector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::FeatureFlag>> *feature_flags = nullptr,
-    ::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::ProcessingResult> processing_result = 0) {
+    ::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::ProcessingResult> processing_result = 0,
+    const std::vector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::CrashInfo>> *crash_info = nullptr) {
   auto errors__ = errors ? _fbb.CreateVector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::Error>>(*errors) : 0;
   auto binary_images__ = binary_images ? _fbb.CreateVector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::BinaryImage>>(*binary_images) : 0;
   auto fields__ = fields ? _fbb.CreateVector<::flatbuffers::Offset<bitdrift_public::fbs::common::v1::Field>>(*fields) : 0;
   auto feature_flags__ = feature_flags ? _fbb.CreateVector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::FeatureFlag>>(*feature_flags) : 0;
+  auto crash_info__ = crash_info ? _fbb.CreateVector<::flatbuffers::Offset<bitdrift_public::fbs::issue_reporting::v1::CrashInfo>>(*crash_info) : 0;
   return bitdrift_public::fbs::issue_reporting::v1::CreateReport(
       _fbb,
       sdk,
@@ -2469,7 +3180,33 @@ inline ::flatbuffers::Offset<Report> CreateReportDirect(
       binary_images__,
       fields__,
       feature_flags__,
-      processing_result);
+      processing_result,
+      crash_info__);
+}
+
+inline bool VerifyCrashInfoDetails(::flatbuffers::Verifier &verifier, const void *obj, CrashInfoDetails type) {
+  switch (type) {
+    case CrashInfoDetails_NONE: {
+      return true;
+    }
+    case CrashInfoDetails_AppleCrashDetails: {
+      auto ptr = reinterpret_cast<const bitdrift_public::fbs::issue_reporting::v1::AppleCrashDetails *>(obj);
+      return verifier.VerifyTable(ptr);
+    }
+    default: return true;
+  }
+}
+
+inline bool VerifyCrashInfoDetailsVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types) {
+  if (!values || !types) return !values && !types;
+  if (values->size() != types->size()) return false;
+  for (::flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {
+    if (!VerifyCrashInfoDetails(
+        verifier,  values->Get(i), types->GetEnum<CrashInfoDetails>(i))) {
+      return false;
+    }
+  }
+  return true;
 }
 
 inline const ::flatbuffers::TypeTable *ReportTypeTypeTable() {
@@ -2587,6 +3324,52 @@ inline const ::flatbuffers::TypeTable *ErrorRelationTypeTable() {
   };
   static const ::flatbuffers::TypeTable tt = {
     ::flatbuffers::ST_ENUM, 1, type_codes, type_refs, nullptr, values, names
+  };
+  return &tt;
+}
+
+inline const ::flatbuffers::TypeTable *CrashReporterScopeTypeTable() {
+  static const ::flatbuffers::TypeCode type_codes[] = {
+    { ::flatbuffers::ET_CHAR, 0, 0 },
+    { ::flatbuffers::ET_CHAR, 0, 0 },
+    { ::flatbuffers::ET_CHAR, 0, 0 }
+  };
+  static const ::flatbuffers::TypeFunction type_refs[] = {
+    bitdrift_public::fbs::issue_reporting::v1::CrashReporterScopeTypeTable
+  };
+  static const char * const names[] = {
+    "Unknown",
+    "InProcess",
+    "OutOfProcess"
+  };
+  static const ::flatbuffers::TypeTable tt = {
+    ::flatbuffers::ST_ENUM, 3, type_codes, type_refs, nullptr, nullptr, names
+  };
+  return &tt;
+}
+
+inline const ::flatbuffers::TypeTable *CrashReporterTypeTable() {
+  static const ::flatbuffers::TypeCode type_codes[] = {
+    { ::flatbuffers::ET_CHAR, 0, 0 },
+    { ::flatbuffers::ET_CHAR, 0, 0 },
+    { ::flatbuffers::ET_CHAR, 0, 0 },
+    { ::flatbuffers::ET_CHAR, 0, 0 },
+    { ::flatbuffers::ET_CHAR, 0, 0 },
+    { ::flatbuffers::ET_CHAR, 0, 0 }
+  };
+  static const ::flatbuffers::TypeFunction type_refs[] = {
+    bitdrift_public::fbs::issue_reporting::v1::CrashReporterTypeTable
+  };
+  static const char * const names[] = {
+    "Unknown",
+    "AppleMetricKit",
+    "AppleKSCrash",
+    "AppleBitdriftCrashReporter",
+    "AndroidUncaughtExceptionHandler",
+    "AndroidApplicationExitInfo"
+  };
+  static const ::flatbuffers::TypeTable tt = {
+    ::flatbuffers::ST_ENUM, 6, type_codes, type_refs, nullptr, nullptr, names
   };
   return &tt;
 }
@@ -2723,6 +3506,24 @@ inline const ::flatbuffers::TypeTable *FrameStatusTypeTable() {
   };
   static const ::flatbuffers::TypeTable tt = {
     ::flatbuffers::ST_ENUM, 5, type_codes, type_refs, nullptr, nullptr, names
+  };
+  return &tt;
+}
+
+inline const ::flatbuffers::TypeTable *CrashInfoDetailsTypeTable() {
+  static const ::flatbuffers::TypeCode type_codes[] = {
+    { ::flatbuffers::ET_SEQUENCE, 0, -1 },
+    { ::flatbuffers::ET_SEQUENCE, 0, 0 }
+  };
+  static const ::flatbuffers::TypeFunction type_refs[] = {
+    bitdrift_public::fbs::issue_reporting::v1::AppleCrashDetailsTypeTable
+  };
+  static const char * const names[] = {
+    "NONE",
+    "AppleCrashDetails"
+  };
+  static const ::flatbuffers::TypeTable tt = {
+    ::flatbuffers::ST_UNION, 2, type_codes, type_refs, nullptr, nullptr, names
   };
   return &tt;
 }
@@ -3085,6 +3886,144 @@ inline const ::flatbuffers::TypeTable *ErrorTypeTable() {
   return &tt;
 }
 
+inline const ::flatbuffers::TypeTable *NSExceptionTypeTable() {
+  static const ::flatbuffers::TypeCode type_codes[] = {
+    { ::flatbuffers::ET_STRING, 0, -1 },
+    { ::flatbuffers::ET_STRING, 0, -1 },
+    { ::flatbuffers::ET_SEQUENCE, 1, 0 }
+  };
+  static const ::flatbuffers::TypeFunction type_refs[] = {
+    bitdrift_public::fbs::common::v1::FieldTypeTable
+  };
+  static const char * const names[] = {
+    "name",
+    "reason",
+    "user_info"
+  };
+  static const ::flatbuffers::TypeTable tt = {
+    ::flatbuffers::ST_TABLE, 3, type_codes, type_refs, nullptr, nullptr, names
+  };
+  return &tt;
+}
+
+inline const ::flatbuffers::TypeTable *MachExceptionTypeTable() {
+  static const ::flatbuffers::TypeCode type_codes[] = {
+    { ::flatbuffers::ET_UINT, 0, -1 },
+    { ::flatbuffers::ET_ULONG, 0, -1 },
+    { ::flatbuffers::ET_ULONG, 0, -1 }
+  };
+  static const char * const names[] = {
+    "type",
+    "code",
+    "subcode"
+  };
+  static const ::flatbuffers::TypeTable tt = {
+    ::flatbuffers::ST_TABLE, 3, type_codes, nullptr, nullptr, nullptr, names
+  };
+  return &tt;
+}
+
+inline const ::flatbuffers::TypeTable *PosixSignalTypeTable() {
+  static const ::flatbuffers::TypeCode type_codes[] = {
+    { ::flatbuffers::ET_INT, 0, -1 },
+    { ::flatbuffers::ET_INT, 0, -1 },
+    { ::flatbuffers::ET_INT, 0, -1 },
+    { ::flatbuffers::ET_BOOL, 0, -1 },
+    { ::flatbuffers::ET_ULONG, 0, -1 }
+  };
+  static const char * const names[] = {
+    "number",
+    "code",
+    "errno",
+    "has_fault_address",
+    "fault_address"
+  };
+  static const ::flatbuffers::TypeTable tt = {
+    ::flatbuffers::ST_TABLE, 5, type_codes, nullptr, nullptr, nullptr, names
+  };
+  return &tt;
+}
+
+inline const ::flatbuffers::TypeTable *AppleTerminationTypeTable() {
+  static const ::flatbuffers::TypeCode type_codes[] = {
+    { ::flatbuffers::ET_STRING, 0, -1 },
+    { ::flatbuffers::ET_STRING, 0, -1 },
+    { ::flatbuffers::ET_STRING, 0, -1 },
+    { ::flatbuffers::ET_STRING, 0, -1 },
+    { ::flatbuffers::ET_STRING, 0, -1 },
+    { ::flatbuffers::ET_STRING, 0, -1 },
+    { ::flatbuffers::ET_STRING, 0, -1 }
+  };
+  static const char * const names[] = {
+    "domain",
+    "code",
+    "explanation",
+    "process_visibility",
+    "process_state",
+    "watchdog_event",
+    "watchdog_visibility"
+  };
+  static const ::flatbuffers::TypeTable tt = {
+    ::flatbuffers::ST_TABLE, 7, type_codes, nullptr, nullptr, nullptr, names
+  };
+  return &tt;
+}
+
+inline const ::flatbuffers::TypeTable *AppleCrashDetailsTypeTable() {
+  static const ::flatbuffers::TypeCode type_codes[] = {
+    { ::flatbuffers::ET_SEQUENCE, 0, 0 },
+    { ::flatbuffers::ET_SEQUENCE, 0, 1 },
+    { ::flatbuffers::ET_SEQUENCE, 0, 2 },
+    { ::flatbuffers::ET_SEQUENCE, 0, 3 }
+  };
+  static const ::flatbuffers::TypeFunction type_refs[] = {
+    bitdrift_public::fbs::issue_reporting::v1::NSExceptionTypeTable,
+    bitdrift_public::fbs::issue_reporting::v1::MachExceptionTypeTable,
+    bitdrift_public::fbs::issue_reporting::v1::PosixSignalTypeTable,
+    bitdrift_public::fbs::issue_reporting::v1::AppleTerminationTypeTable
+  };
+  static const char * const names[] = {
+    "nsexception",
+    "mach_exception",
+    "posix_signal",
+    "termination"
+  };
+  static const ::flatbuffers::TypeTable tt = {
+    ::flatbuffers::ST_TABLE, 4, type_codes, type_refs, nullptr, nullptr, names
+  };
+  return &tt;
+}
+
+inline const ::flatbuffers::TypeTable *CrashInfoTypeTable() {
+  static const ::flatbuffers::TypeCode type_codes[] = {
+    { ::flatbuffers::ET_CHAR, 0, 0 },
+    { ::flatbuffers::ET_CHAR, 0, 1 },
+    { ::flatbuffers::ET_SEQUENCE, 0, 2 },
+    { ::flatbuffers::ET_UTYPE, 0, 3 },
+    { ::flatbuffers::ET_SEQUENCE, 0, 3 },
+    { ::flatbuffers::ET_SEQUENCE, 0, 4 }
+  };
+  static const ::flatbuffers::TypeFunction type_refs[] = {
+    bitdrift_public::fbs::issue_reporting::v1::CrashReporterScopeTypeTable,
+    bitdrift_public::fbs::issue_reporting::v1::CrashReporterTypeTable,
+    bitdrift_public::fbs::issue_reporting::v1::TimestampTypeTable,
+    bitdrift_public::fbs::issue_reporting::v1::CrashInfoDetailsTypeTable,
+    bitdrift_public::fbs::issue_reporting::v1::ThreadDetailsTypeTable
+  };
+  static const char * const names[] = {
+    "reporter_scope",
+    "reporter",
+    "occurred_at",
+    "details_type",
+    "details",
+    "thread_details"
+  };
+  static const ::flatbuffers::TypeTable tt = {
+    ::flatbuffers::ST_TABLE, 6, type_codes, type_refs, nullptr, nullptr, names
+  };
+  return &tt;
+}
+
 inline const ::flatbuffers::TypeTable *BinaryImageTypeTable() {
   static const ::flatbuffers::TypeCode type_codes[] = {
     { ::flatbuffers::ET_STRING, 0, -1 },
@@ -3161,7 +4100,8 @@ inline const ::flatbuffers::TypeTable *ReportTypeTable() {
     { ::flatbuffers::ET_SEQUENCE, 1, 6 },
     { ::flatbuffers::ET_SEQUENCE, 1, 7 },
     { ::flatbuffers::ET_SEQUENCE, 1, 8 },
-    { ::flatbuffers::ET_SEQUENCE, 0, 9 }
+    { ::flatbuffers::ET_SEQUENCE, 0, 9 },
+    { ::flatbuffers::ET_SEQUENCE, 1, 10 }
   };
   static const ::flatbuffers::TypeFunction type_refs[] = {
     bitdrift_public::fbs::issue_reporting::v1::SDKInfoTypeTable,
@@ -3173,7 +4113,8 @@ inline const ::flatbuffers::TypeTable *ReportTypeTable() {
     bitdrift_public::fbs::issue_reporting::v1::BinaryImageTypeTable,
     bitdrift_public::fbs::common::v1::FieldTypeTable,
     bitdrift_public::fbs::issue_reporting::v1::FeatureFlagTypeTable,
-    bitdrift_public::fbs::issue_reporting::v1::ProcessingResultTypeTable
+    bitdrift_public::fbs::issue_reporting::v1::ProcessingResultTypeTable,
+    bitdrift_public::fbs::issue_reporting::v1::CrashInfoTypeTable
   };
   static const char * const names[] = {
     "sdk",
@@ -3185,10 +4126,11 @@ inline const ::flatbuffers::TypeTable *ReportTypeTable() {
     "binary_images",
     "fields",
     "feature_flags",
-    "processing_result"
+    "processing_result",
+    "crash_info"
   };
   static const ::flatbuffers::TypeTable tt = {
-    ::flatbuffers::ST_TABLE, 10, type_codes, type_refs, nullptr, nullptr, names
+    ::flatbuffers::ST_TABLE, 11, type_codes, type_refs, nullptr, nullptr, names
   };
   return &tt;
 }

--- a/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_blocking_get_test.snap
+++ b/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_blocking_get_test.snap
@@ -18255,4 +18255,5 @@ Report {
     fields: None,
     feature_flags: None,
     processing_result: None,
+    crash_info: None,
 }

--- a/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_broadcast_receiver_test.snap
+++ b/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_broadcast_receiver_test.snap
@@ -18202,4 +18202,5 @@ Report {
     fields: None,
     feature_flags: None,
     processing_result: None,
+    crash_info: None,
 }

--- a/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_coroutines_test.snap
+++ b/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_coroutines_test.snap
@@ -19115,4 +19115,5 @@ Report {
     fields: None,
     feature_flags: None,
     processing_result: None,
+    crash_info: None,
 }

--- a/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_deadlock_test.snap
+++ b/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_deadlock_test.snap
@@ -17655,4 +17655,5 @@ Report {
     fields: None,
     feature_flags: None,
     processing_result: None,
+    crash_info: None,
 }

--- a/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_latency_test.snap
+++ b/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_latency_test.snap
@@ -19568,4 +19568,5 @@ Report {
     fields: None,
     feature_flags: None,
     processing_result: None,
+    crash_info: None,
 }

--- a/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_sleep_main_thread_test.snap
+++ b/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__anr_sleep_main_thread_test.snap
@@ -18745,4 +18745,5 @@ Report {
     fields: None,
     feature_flags: None,
     processing_result: None,
+    crash_info: None,
 }

--- a/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__full_anr1_test.snap
+++ b/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__full_anr1_test.snap
@@ -12341,4 +12341,5 @@ Report {
     fields: None,
     feature_flags: None,
     processing_result: None,
+    crash_info: None,
 }

--- a/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__full_anr2_test.snap
+++ b/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__full_anr2_test.snap
@@ -16654,4 +16654,5 @@ Report {
     fields: None,
     feature_flags: None,
     processing_result: None,
+    crash_info: None,
 }

--- a/bd-report-writer-tests/src/ffi_tests.c
+++ b/bd-report-writer-tests/src/ffi_tests.c
@@ -1,12 +1,12 @@
 // shared-core - bitdrift's common client/server libraries
 // Copyright Bitdrift, Inc. All rights reserved.
 //
-// Use of this source code is governed by a source available license that can be found in the
-// LICENSE file or at:
+// Use of this source code is governed by a source available license that can be
+// found in the LICENSE file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include <bd-report-writer/ffi.h>
 
@@ -48,14 +48,16 @@ const uint8_t *load_full_report(BDProcessorHandle handle, uint64_t *len) {
   return bdrw_get_completed_buffer(handle, len);
 }
 
-const uint8_t *load_current_threads_crash_info_only(BDProcessorHandle handle, uint64_t *len) {
+const uint8_t *load_current_threads_crash_info_only(BDProcessorHandle handle,
+                                                    uint64_t *len) {
   add_threads(handle);
   add_current_threads_crash_info(handle);
   return bdrw_get_completed_buffer(handle, len);
 }
 
 void create_handle(BDProcessorHandle handle) {
-  bdrw_create_buffer_handle(handle, NATIVE_CRASH, "com.example.core-tests", "1.0.2x", true);
+  bdrw_create_buffer_handle(handle, NATIVE_CRASH, "com.example.core-tests",
+                            "1.0.2x", true);
 }
 
 void dispose_handle(BDProcessorHandle handle) {
@@ -64,14 +66,14 @@ void dispose_handle(BDProcessorHandle handle) {
 
 static void add_binary_images(BDProcessorHandle handle) {
   BDBinaryImage image1 = {
-    .load_address = 640393727,
-    .path = "path/to/other",
-    .id = "02160235-06f6-4677-ba14-e76de7460481",
+      .load_address = 640393727,
+      .path = "path/to/other",
+      .id = "02160235-06f6-4677-ba14-e76de7460481",
   };
   BDBinaryImage image2 = {
-    .load_address = 2652165712,
-    .path = "path/to/something",
-    .id = "4a684168-7d9e-4296-9145-72c82f2208a7",
+      .load_address = 2652165712,
+      .path = "path/to/something",
+      .id = "4a684168-7d9e-4296-9145-72c82f2208a7",
   };
   bdrw_add_binary_image(handle, &image1);
   bdrw_add_binary_image(handle, &image2);
@@ -83,31 +85,31 @@ static BDStackFrame *make_frame_data(int *count) {
   state[0] = "awaiting lock";
   state[1] = "holding lock";
   BDCPURegister *regs = calloc(4, sizeof(BDCPURegister));
-  regs[0] = (BDCPURegister) {"x0", 65372};
-  regs[1] = (BDCPURegister) {"x1", 918612};
-  regs[2] = (BDCPURegister) {"x2", 3786423942};
-  regs[3] = (BDCPURegister) {"x9", 1261267};
+  regs[0] = (BDCPURegister){"x0", 65372};
+  regs[1] = (BDCPURegister){"x1", 918612};
+  regs[2] = (BDCPURegister){"x2", 3786423942};
+  regs[3] = (BDCPURegister){"x9", 1261267};
   BDStackFrame *frames = calloc(2, sizeof(BDStackFrame));
-  frames[0] = (BDStackFrame) {
-    .frame_address = 39762317,
-    .symbol_address = 39995736,
-    .symbol_name = "get_stuff",
-    .file_name = "stuff.cpp",
-    .image_id = "08048567-2523-4bf9-a4e4-38ac6f8e9fb9",
-    .line = 63,
-    .column = 0,
-    .type_ = 2,
-    .state_count = 2,
-    .state = state,
-    .reg_count = 4,
-    .regs = regs,
+  frames[0] = (BDStackFrame){
+      .frame_address = 39762317,
+      .symbol_address = 39995736,
+      .symbol_name = "get_stuff",
+      .file_name = "stuff.cpp",
+      .image_id = "08048567-2523-4bf9-a4e4-38ac6f8e9fb9",
+      .line = 63,
+      .column = 0,
+      .type_ = 2,
+      .state_count = 2,
+      .state = state,
+      .reg_count = 4,
+      .regs = regs,
   };
-  frames[1] = (BDStackFrame) {
-    .frame_address = 1891926278,
-    .symbol_address = 1778616897,
-    .symbol_name = "pull",
-    .image_id = "7feb183e-a826-42a5-824a-cf49c2df834d",
-    .type_ = 2,
+  frames[1] = (BDStackFrame){
+      .frame_address = 1891926278,
+      .symbol_address = 1778616897,
+      .symbol_name = "pull",
+      .image_id = "7feb183e-a826-42a5-824a-cf49c2df834d",
+      .type_ = 2,
   };
   *count = 2;
   return frames;
@@ -115,11 +117,11 @@ static BDStackFrame *make_frame_data(int *count) {
 
 static void add_threads(BDProcessorHandle handle) {
   BDThread thread = {
-    .active = true,
-    .index = 56,
-    .name = "com.example.stuff.queue",
-    .quality_of_service = 2,
-    .priority = 0.8,
+      .active = true,
+      .index = 56,
+      .name = "com.example.stuff.queue",
+      .quality_of_service = 2,
+      .priority = 0.8,
   };
   int count = 0;
   BDStackFrame *frames = make_frame_data(&count);
@@ -132,13 +134,8 @@ static void add_threads(BDProcessorHandle handle) {
 static void add_errors(BDProcessorHandle handle) {
   int count = 0;
   BDStackFrame *frames1 = make_frame_data(&count);
-  bdrw_add_error(
-    handle,
-    "resource allocation failure",
-    "unable to secure resource lock",
-    1,
-    count,
-    frames1);
+  bdrw_add_error(handle, "resource allocation failure",
+                 "unable to secure resource lock", 1, count, frames1);
   free((void *)frames1[0].regs);
   free((void *)frames1[0].state);
   free((void *)frames1);
@@ -148,14 +145,14 @@ static void add_errors(BDProcessorHandle handle) {
 
 static void add_app(BDProcessorHandle handle) {
   BDAppMetrics app = {
-    .app_id = "com.example.my-app",
-    .cf_bundle_version = "5.0.2.32",
-    .version = "5.0.2",
-    .memory_free = 3627,
-    .memory_used = 640,
-    .memory_total = 23872786,
-    .running_state = "inactive",
-    .region_format = "US",
+      .app_id = "com.example.my-app",
+      .cf_bundle_version = "5.0.2.32",
+      .version = "5.0.2",
+      .memory_free = 3627,
+      .memory_used = 640,
+      .memory_total = 23872786,
+      .running_state = "inactive",
+      .region_format = "US",
   };
   bdrw_add_app(handle, &app);
 }
@@ -165,26 +162,26 @@ static void add_device(BDProcessorHandle handle) {
   abis[0] = "armv7";
   abis[1] = "arm64";
   BDDeviceMetrics device = {
-    .architecture = 2,
-    .cpu_abi_count = 2,
-    .cpu_abis = abis,
-    .display_height = 640,
-    .display_width = 480,
-    .display_density_dpi = 300,
-    .network_state = 3,
-    .low_power_mode_enabled = true,
-    .manufacturer = "DynaTouch",
-    .model = "Mini II",
-    .os_brand = "waveOS",
-    .os_version = "21.2.0",
-    .os_fingerprint = "65457405-ec5b-4f46-9bcc-0d98dd4584fb",
-    .power_charge_percent = 20,
-    .power_state = 1,
-    .platform = 1,
-    .rotation = 2,
-    .time_seconds = 1746205766,
-    .time_nanos = 3278,
-    .timezone = "TVT",
+      .architecture = 2,
+      .cpu_abi_count = 2,
+      .cpu_abis = abis,
+      .display_height = 640,
+      .display_width = 480,
+      .display_density_dpi = 300,
+      .network_state = 3,
+      .low_power_mode_enabled = true,
+      .manufacturer = "DynaTouch",
+      .model = "Mini II",
+      .os_brand = "waveOS",
+      .os_version = "21.2.0",
+      .os_fingerprint = "65457405-ec5b-4f46-9bcc-0d98dd4584fb",
+      .power_charge_percent = 20,
+      .power_state = 1,
+      .platform = 1,
+      .rotation = 2,
+      .time_seconds = 1746205766,
+      .time_nanos = 3278,
+      .timezone = "TVT",
   };
   bdrw_add_device(handle, &device);
   free((void *)abis);
@@ -192,35 +189,40 @@ static void add_device(BDProcessorHandle handle) {
 
 static void add_current_threads_crash_info(BDProcessorHandle handle) {
   BDAppleCrashInfoPayload payload = {
-    .has_nsexception = true,
-    .nsexception = (BDNSException) {
-      .name = "NSRangeException",
-      .reason = "index 9 beyond bounds 8",
-    },
-    .has_mach_exception = true,
-    .mach_exception = (BDMachException) {
-      .type_ = 10,
-      .code = 1,
-      .subcode = 2,
-    },
-    .has_posix_signal = true,
-    .posix_signal = (BDPosixSignal) {
-      .number = 11,
-      .code = 3,
-      .errno_ = 4,
-      .has_fault_address = true,
-      .fault_address = 0x1234,
-    },
-    .has_termination = true,
-    .termination = (BDAppleTermination) {
-      .domain = "10",
-      .code = "0x8BADF00D",
-      .explanation = "Failed to terminate gracefully after 5.0s",
-      .process_visibility = "Unknown",
-      .process_state = "Running",
-      .watchdog_event = "process-exit",
-      .watchdog_visibility = "Foreground",
-    },
+      .has_nsexception = true,
+      .nsexception =
+          (BDNSException){
+              .name = "NSRangeException",
+              .reason = "index 9 beyond bounds 8",
+          },
+      .has_mach_exception = true,
+      .mach_exception =
+          (BDMachException){
+              .type_ = 10,
+              .code = 1,
+              .subcode = 2,
+          },
+      .has_posix_signal = true,
+      .posix_signal =
+          (BDPosixSignal){
+              .number = 11,
+              .code = 3,
+              .errno_value = 4,
+              .has_fault_address = true,
+              .fault_address = 0x1234,
+          },
+      .has_termination = true,
+      .termination =
+          (BDAppleTermination){
+              .domain = "10",
+              .code = "0x8BADF00D",
+              .explanation = "Failed to terminate gracefully after 5.0s",
+              .process_visibility = "Unknown",
+              .process_state = "Running",
+              .watchdog_event = "process-exit",
+              .watchdog_visibility = "Foreground",
+          },
   };
-  bdrw_add_apple_crash_info_with_current_threads(handle, 2, 1, 1700000000, 55, &payload);
+  bdrw_add_apple_crash_info_with_current_threads(handle, 2, 1, 1700000000, 55,
+                                                 &payload);
 }

--- a/bd-report-writer-tests/src/ffi_tests.c
+++ b/bd-report-writer-tests/src/ffi_tests.c
@@ -21,6 +21,7 @@ static void add_errors(BDProcessorHandle handle);
 static void add_device(BDProcessorHandle handle);
 static void add_app(BDProcessorHandle handle);
 static void add_current_threads_crash_info(BDProcessorHandle handle);
+static void add_threadless_crash_info(BDProcessorHandle handle);
 
 /* Test function hooks */
 
@@ -52,6 +53,12 @@ const uint8_t *load_current_threads_crash_info_only(BDProcessorHandle handle,
                                                     uint64_t *len) {
   add_threads(handle);
   add_current_threads_crash_info(handle);
+  return bdrw_get_completed_buffer(handle, len);
+}
+
+const uint8_t *load_threadless_crash_info_only(BDProcessorHandle handle,
+                                               uint64_t *len) {
+  add_threadless_crash_info(handle);
   return bdrw_get_completed_buffer(handle, len);
 }
 
@@ -188,6 +195,27 @@ static void add_device(BDProcessorHandle handle) {
 }
 
 static void add_current_threads_crash_info(BDProcessorHandle handle) {
+  int count = 0;
+  BDStackFrame *stack = make_frame_data(&count);
+  BDCrashInfoThread threads[] = {
+      {
+          .thread =
+              (BDThread){
+                  .active = true,
+                  .index = 56,
+                  .name = "com.example.stuff.queue",
+                  .quality_of_service = 2,
+                  .priority = 0.8,
+              },
+          .stack_count = count,
+          .stack = stack,
+      },
+  };
+  BDCrashInfoThreadDetails thread_details = {
+      .count = 5,
+      .threads_count = 1,
+      .threads = threads,
+  };
   BDAppleCrashInfoPayload payload = {
       .has_nsexception = true,
       .nsexception =
@@ -223,6 +251,21 @@ static void add_current_threads_crash_info(BDProcessorHandle handle) {
               .watchdog_visibility = "Foreground",
           },
   };
-  bdrw_add_apple_crash_info_with_current_threads(handle, 2, 1, 1700000000, 55,
-                                                 &payload);
+  bdrw_add_apple_crash_info(handle, 2, 1, 1700000000, 55, &payload,
+                            &thread_details);
+  free((void *)stack[0].regs);
+  free((void *)stack[0].state);
+  free((void *)stack);
+}
+
+static void add_threadless_crash_info(BDProcessorHandle handle) {
+  BDAppleCrashInfoPayload payload = {
+      .has_nsexception = true,
+      .nsexception =
+          (BDNSException){
+              .name = "CapturedException",
+              .reason = "captured reason",
+          },
+  };
+  bdrw_add_apple_crash_info(handle, 1, 3, 1700000123, 77, &payload, NULL);
 }

--- a/bd-report-writer-tests/src/ffi_tests.c
+++ b/bd-report-writer-tests/src/ffi_tests.c
@@ -20,6 +20,7 @@ static void add_threads(BDProcessorHandle handle);
 static void add_errors(BDProcessorHandle handle);
 static void add_device(BDProcessorHandle handle);
 static void add_app(BDProcessorHandle handle);
+static void add_current_threads_crash_info(BDProcessorHandle handle);
 
 /* Test function hooks */
 
@@ -44,6 +45,12 @@ const uint8_t *load_full_report(BDProcessorHandle handle, uint64_t *len) {
   add_errors(handle);
   add_binary_images(handle);
   add_threads(handle);
+  return bdrw_get_completed_buffer(handle, len);
+}
+
+const uint8_t *load_current_threads_crash_info_only(BDProcessorHandle handle, uint64_t *len) {
+  add_threads(handle);
+  add_current_threads_crash_info(handle);
   return bdrw_get_completed_buffer(handle, len);
 }
 
@@ -181,4 +188,39 @@ static void add_device(BDProcessorHandle handle) {
   };
   bdrw_add_device(handle, &device);
   free((void *)abis);
+}
+
+static void add_current_threads_crash_info(BDProcessorHandle handle) {
+  BDAppleCrashInfoPayload payload = {
+    .has_nsexception = true,
+    .nsexception = (BDNSException) {
+      .name = "NSRangeException",
+      .reason = "index 9 beyond bounds 8",
+    },
+    .has_mach_exception = true,
+    .mach_exception = (BDMachException) {
+      .type_ = 10,
+      .code = 1,
+      .subcode = 2,
+    },
+    .has_posix_signal = true,
+    .posix_signal = (BDPosixSignal) {
+      .number = 11,
+      .code = 3,
+      .errno_ = 4,
+      .has_fault_address = true,
+      .fault_address = 0x1234,
+    },
+    .has_termination = true,
+    .termination = (BDAppleTermination) {
+      .domain = "10",
+      .code = "0x8BADF00D",
+      .explanation = "Failed to terminate gracefully after 5.0s",
+      .process_visibility = "Unknown",
+      .process_state = "Running",
+      .watchdog_event = "process-exit",
+      .watchdog_visibility = "Foreground",
+    },
+  };
+  bdrw_add_apple_crash_info_with_current_threads(handle, 2, 1, 1700000000, 55, &payload);
 }

--- a/bd-report-writer-tests/src/ffi_tests.rs
+++ b/bd-report-writer-tests/src/ffi_tests.rs
@@ -17,6 +17,7 @@ unsafe extern "C-unwind" {
   fn dispose_handle(handle: BDProcessorHandle);
   fn load_binary_data_only(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
   fn load_current_threads_crash_info_only(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
+  fn load_threadless_crash_info_only(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
   fn load_thread_data_only(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
   fn load_error_data_only(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
   fn load_full_report(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
@@ -267,6 +268,40 @@ fn current_threads_crash_info_test() {
   let thread_details = entry.thread_details().unwrap();
   assert_eq!(5, thread_details.count());
   assert_eq!(1, thread_details.threads().unwrap().len());
+
+  unsafe {
+    dispose_handle(&raw mut handle);
+  }
+}
+
+#[test]
+fn threadless_crash_info_test() {
+  let mut handle = null();
+  let report = unsafe {
+    create_handle(&raw mut handle);
+    let mut len = 0;
+    let buf = load_threadless_crash_info_only(&raw mut handle, &raw mut len);
+    assert!(!buf.is_null());
+    assert_ne!(0, len);
+
+    let data = slice::from_raw_parts(buf, usize::try_from(len).unwrap());
+    root_as_report_unchecked(data)
+  };
+
+  let crash_info = report.crash_info().unwrap();
+  assert_eq!(1, crash_info.len());
+
+  let entry = crash_info.get(0);
+  assert_eq!(CrashReporterScope::InProcess, entry.reporter_scope());
+  assert_eq!(CrashReporter::AppleBitdriftCrashReporter, entry.reporter());
+  assert_eq!(1_700_000_123, entry.occurred_at().unwrap().seconds());
+  assert_eq!(77, entry.occurred_at().unwrap().nanos());
+  assert!(entry.thread_details().is_none());
+
+  let details = entry.details_as_apple_crash_details().unwrap();
+  let nsexception = details.nsexception().unwrap();
+  assert_eq!(Some("CapturedException"), nsexception.name());
+  assert_eq!(Some("captured reason"), nsexception.reason());
 
   unsafe {
     dispose_handle(&raw mut handle);

--- a/bd-report-writer-tests/src/ffi_tests.rs
+++ b/bd-report-writer-tests/src/ffi_tests.rs
@@ -16,6 +16,7 @@ unsafe extern "C-unwind" {
   fn create_handle(handle: BDProcessorHandle);
   fn dispose_handle(handle: BDProcessorHandle);
   fn load_binary_data_only(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
+  fn load_current_threads_crash_info_only(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
   fn load_thread_data_only(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
   fn load_error_data_only(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
   fn load_full_report(handle: BDProcessorHandle, len: *mut u64) -> *const u8;
@@ -204,6 +205,68 @@ fn full_report_device_test() {
   assert_eq!(2, abis.len());
   assert_eq!("armv7", abis.get(0));
   assert_eq!("arm64", abis.get(1));
+
+  unsafe {
+    dispose_handle(&raw mut handle);
+  }
+}
+
+#[test]
+fn current_threads_crash_info_test() {
+  let mut handle = null();
+  let report = unsafe {
+    create_handle(&raw mut handle);
+    let mut len = 0;
+    let buf = load_current_threads_crash_info_only(&raw mut handle, &raw mut len);
+    assert!(!buf.is_null());
+    assert_ne!(0, len);
+
+    let data = slice::from_raw_parts(buf, usize::try_from(len).unwrap());
+    root_as_report_unchecked(data)
+  };
+
+  let crash_info = report.crash_info().unwrap();
+  assert_eq!(1, crash_info.len());
+
+  let entry = crash_info.get(0);
+  assert_eq!(CrashReporterScope::OutOfProcess, entry.reporter_scope());
+  assert_eq!(CrashReporter::AppleMetricKit, entry.reporter());
+  assert_eq!(CrashInfoDetails::AppleCrashDetails, entry.details_type());
+  assert_eq!(1_700_000_000, entry.occurred_at().unwrap().seconds());
+  assert_eq!(55, entry.occurred_at().unwrap().nanos());
+
+  let details = entry.details_as_apple_crash_details().unwrap();
+  let nsexception = details.nsexception().unwrap();
+  assert_eq!(Some("NSRangeException"), nsexception.name());
+  assert_eq!(Some("index 9 beyond bounds 8"), nsexception.reason());
+
+  let mach_exception = details.mach_exception().unwrap();
+  assert_eq!(10, mach_exception.type_());
+  assert_eq!(1, mach_exception.code());
+  assert_eq!(2, mach_exception.subcode());
+
+  let posix_signal = details.posix_signal().unwrap();
+  assert_eq!(11, posix_signal.number());
+  assert_eq!(3, posix_signal.code());
+  assert_eq!(4, posix_signal.errno());
+  assert!(posix_signal.has_fault_address());
+  assert_eq!(0x1234, posix_signal.fault_address());
+
+  let termination = details.termination().unwrap();
+  assert_eq!(Some("10"), termination.domain());
+  assert_eq!(Some("0x8BADF00D"), termination.code());
+  assert_eq!(
+    Some("Failed to terminate gracefully after 5.0s"),
+    termination.explanation()
+  );
+  assert_eq!(Some("Unknown"), termination.process_visibility());
+  assert_eq!(Some("Running"), termination.process_state());
+  assert_eq!(Some("process-exit"), termination.watchdog_event());
+  assert_eq!(Some("Foreground"), termination.watchdog_visibility());
+
+  let thread_details = entry.thread_details().unwrap();
+  assert_eq!(5, thread_details.count());
+  assert_eq!(1, thread_details.threads().unwrap().len());
 
   unsafe {
     dispose_handle(&raw mut handle);

--- a/bd-report-writer-tests/src/ffi_tests.rs
+++ b/bd-report-writer-tests/src/ffi_tests.rs
@@ -248,7 +248,7 @@ fn current_threads_crash_info_test() {
   let posix_signal = details.posix_signal().unwrap();
   assert_eq!(11, posix_signal.number());
   assert_eq!(3, posix_signal.code());
-  assert_eq!(4, posix_signal.errno());
+  assert_eq!(4, posix_signal.errno_value());
   assert!(posix_signal.has_fault_address());
   assert_eq!(0x1234, posix_signal.fault_address());
 

--- a/bd-report-writer/include/bd-report-writer/ffi.h
+++ b/bd-report-writer/include/bd-report-writer/ffi.h
@@ -129,6 +129,18 @@ typedef struct BDAppleCrashInfoPayload {
   struct BDAppleTermination termination;
 } BDAppleCrashInfoPayload;
 
+typedef struct BDCrashInfoThread {
+  struct BDThread thread;
+  uint32_t stack_count;
+  const struct BDStackFrame *stack;
+} BDCrashInfoThread;
+
+typedef struct BDCrashInfoThreadDetails {
+  uint16_t count;
+  uintptr_t threads_count;
+  const struct BDCrashInfoThread *threads;
+} BDCrashInfoThreadDetails;
+
 /**
  * Entry point to creating a new Report
  *
@@ -226,9 +238,10 @@ bool bdrw_add_device(BDProcessorHandle handle, const struct BDDeviceMetrics *dev
  */
 bool bdrw_add_app(BDProcessorHandle handle, const struct BDAppMetrics *app_ptr);
 
-bool bdrw_add_apple_crash_info_with_current_threads(BDProcessorHandle handle,
-                                                    int8_t reporter_scope,
-                                                    int8_t reporter,
-                                                    uint64_t occurred_at_seconds,
-                                                    uint32_t occurred_at_nanos,
-                                                    const struct BDAppleCrashInfoPayload *payload_ptr);
+bool bdrw_add_apple_crash_info(BDProcessorHandle handle,
+                               int8_t reporter_scope,
+                               int8_t reporter,
+                               uint64_t occurred_at_seconds,
+                               uint32_t occurred_at_nanos,
+                               const struct BDAppleCrashInfoPayload *payload_ptr,
+                               const struct BDCrashInfoThreadDetails *thread_details_ptr);

--- a/bd-report-writer/include/bd-report-writer/ffi.h
+++ b/bd-report-writer/include/bd-report-writer/ffi.h
@@ -103,7 +103,7 @@ typedef struct BDMachException {
 typedef struct BDPosixSignal {
   int32_t number;
   int32_t code;
-  int32_t errno_;
+  int32_t errno_value;
   bool has_fault_address;
   uint64_t fault_address;
 } BDPosixSignal;

--- a/bd-report-writer/include/bd-report-writer/ffi.h
+++ b/bd-report-writer/include/bd-report-writer/ffi.h
@@ -89,6 +89,46 @@ typedef struct BDAppMetrics {
   const char *region_format;
 } BDAppMetrics;
 
+typedef struct BDNSException {
+  const char *name;
+  const char *reason;
+} BDNSException;
+
+typedef struct BDMachException {
+  uint32_t type_;
+  uint64_t code;
+  uint64_t subcode;
+} BDMachException;
+
+typedef struct BDPosixSignal {
+  int32_t number;
+  int32_t code;
+  int32_t errno_;
+  bool has_fault_address;
+  uint64_t fault_address;
+} BDPosixSignal;
+
+typedef struct BDAppleTermination {
+  const char *domain;
+  const char *code;
+  const char *explanation;
+  const char *process_visibility;
+  const char *process_state;
+  const char *watchdog_event;
+  const char *watchdog_visibility;
+} BDAppleTermination;
+
+typedef struct BDAppleCrashInfoPayload {
+  bool has_nsexception;
+  struct BDNSException nsexception;
+  bool has_mach_exception;
+  struct BDMachException mach_exception;
+  bool has_posix_signal;
+  struct BDPosixSignal posix_signal;
+  bool has_termination;
+  struct BDAppleTermination termination;
+} BDAppleCrashInfoPayload;
+
 /**
  * Entry point to creating a new Report
  *
@@ -185,3 +225,10 @@ bool bdrw_add_device(BDProcessorHandle handle, const struct BDDeviceMetrics *dev
  * a report processor, created with `bdrw_create_buffer_handle`
  */
 bool bdrw_add_app(BDProcessorHandle handle, const struct BDAppMetrics *app_ptr);
+
+bool bdrw_add_apple_crash_info_with_current_threads(BDProcessorHandle handle,
+                                                    int8_t reporter_scope,
+                                                    int8_t reporter,
+                                                    uint64_t occurred_at_seconds,
+                                                    uint32_t occurred_at_nanos,
+                                                    const struct BDAppleCrashInfoPayload *payload_ptr);

--- a/bd-report-writer/src/ffi.rs
+++ b/bd-report-writer/src/ffi.rs
@@ -98,7 +98,7 @@ pub struct BDMachException {
 pub struct BDPosixSignal {
   number: i32,
   code: i32,
-  errno_: i32,
+  errno_value: i32,
   has_fault_address: bool,
   fault_address: u64,
 }
@@ -282,7 +282,11 @@ extern "C-unwind" fn bdrw_get_completed_buffer(
   let crash_info = if processor.crash_info.is_empty() {
     None
   } else {
-    Some(processor.builder.create_vector(processor.crash_info.as_slice()))
+    Some(
+      processor
+        .builder
+        .create_vector(processor.crash_info.as_slice()),
+    )
   };
   let report = Report::create(
     &mut processor.builder,
@@ -717,7 +721,9 @@ fn build_current_thread_details<'a>(
     return None;
   }
 
-  let threads = processor.builder.create_vector(processor.threads.as_slice());
+  let threads = processor
+    .builder
+    .create_vector(processor.threads.as_slice());
   Some(ThreadDetails::create(
     &mut processor.builder,
     &ThreadDetailsArgs {
@@ -759,7 +765,7 @@ fn build_apple_crash_details<'a>(
       &PosixSignalArgs {
         number: payload.posix_signal.number,
         code: payload.posix_signal.code,
-        errno: payload.posix_signal.errno_,
+        errno_value: payload.posix_signal.errno_value,
         has_fault_address: payload.posix_signal.has_fault_address,
         fault_address: payload.posix_signal.fault_address,
       },

--- a/bd-report-writer/src/ffi.rs
+++ b/bd-report-writer/src/ffi.rs
@@ -30,6 +30,7 @@ type FrameVectorOffset<'a> = WIPOffset<Vector<'a, ForwardsUOffset<Frame<'a>>>>;
 pub struct ReportProcessor<'a> {
   builder: FlatBufferBuilder<'a>,
   binary_images: Vec<WIPOffset<BinaryImage<'a>>>,
+  crash_info: Vec<WIPOffset<CrashInfo<'a>>>,
   is_file_size_optimization_enabled: bool,
   stack_trace_offsets: HashMap<FrameOffsetSequence, FrameVectorOffset<'a>>,
   system_thread_count: u16,
@@ -78,6 +79,51 @@ pub struct BDAppMetrics {
   memory_total: u64,
   memory_pressure_level: i8,
   region_format: *const c_char,
+}
+
+#[repr(C)]
+pub struct BDNSException {
+  name: *const c_char,
+  reason: *const c_char,
+}
+
+#[repr(C)]
+pub struct BDMachException {
+  type_: u32,
+  code: u64,
+  subcode: u64,
+}
+
+#[repr(C)]
+pub struct BDPosixSignal {
+  number: i32,
+  code: i32,
+  errno_: i32,
+  has_fault_address: bool,
+  fault_address: u64,
+}
+
+#[repr(C)]
+pub struct BDAppleTermination {
+  domain: *const c_char,
+  code: *const c_char,
+  explanation: *const c_char,
+  process_visibility: *const c_char,
+  process_state: *const c_char,
+  watchdog_event: *const c_char,
+  watchdog_visibility: *const c_char,
+}
+
+#[repr(C)]
+pub struct BDAppleCrashInfoPayload {
+  has_nsexception: bool,
+  nsexception: BDNSException,
+  has_mach_exception: bool,
+  mach_exception: BDMachException,
+  has_posix_signal: bool,
+  posix_signal: BDPosixSignal,
+  has_termination: bool,
+  termination: BDAppleTermination,
 }
 
 #[repr(C)]
@@ -172,6 +218,7 @@ extern "C-unwind" fn bdrw_create_buffer_handle(
     sdk,
     report_type: ReportType(report_type),
     binary_images: vec![],
+    crash_info: vec![],
     is_file_size_optimization_enabled,
     stack_trace_offsets: HashMap::new(),
     system_thread_count: 0,
@@ -232,6 +279,11 @@ extern "C-unwind" fn bdrw_get_completed_buffer(
     None
   };
   let errors = processor.builder.create_vector(processor.errors.as_slice());
+  let crash_info = if processor.crash_info.is_empty() {
+    None
+  } else {
+    Some(processor.builder.create_vector(processor.crash_info.as_slice()))
+  };
   let report = Report::create(
     &mut processor.builder,
     &ReportArgs {
@@ -245,6 +297,7 @@ extern "C-unwind" fn bdrw_get_completed_buffer(
       feature_flags: None,
       fields: None,
       processing_result: None,
+      crash_info,
     },
   );
   processor.builder.finish(report, None);
@@ -529,6 +582,41 @@ extern "C-unwind" fn bdrw_add_app(handle: BDProcessorHandle, app_ptr: *const BDA
   true
 }
 
+#[unsafe(no_mangle)]
+extern "C-unwind" fn bdrw_add_apple_crash_info_with_current_threads(
+  handle: BDProcessorHandle,
+  reporter_scope: i8,
+  reporter: i8,
+  occurred_at_seconds: u64,
+  occurred_at_nanos: u32,
+  payload_ptr: *const BDAppleCrashInfoPayload,
+) -> bool {
+  let processor = try_into_processor!(handle, false);
+  let payload = match unsafe { payload_ptr.as_ref() } {
+    Some(payload) => payload,
+    None => return false,
+  };
+  let details = match build_apple_crash_details(&mut processor.builder, payload) {
+    Some(details) => details,
+    None => return false,
+  };
+  let thread_details = build_current_thread_details(processor);
+  let occurred_at = Timestamp::new(occurred_at_seconds, occurred_at_nanos);
+  let crash_info = CrashInfo::create(
+    &mut processor.builder,
+    &CrashInfoArgs {
+      reporter_scope: CrashReporterScope(reporter_scope),
+      reporter: CrashReporter(reporter),
+      occurred_at: Some(&occurred_at),
+      details_type: CrashInfoDetails::AppleCrashDetails,
+      details: Some(details.as_union_value()),
+      thread_details,
+    },
+  );
+  processor.crash_info.push(crash_info);
+  true
+}
+
 /// Validate whether the pointer is non-null, copying the string into the
 /// in-progress report buffer if so
 fn append_string<'a>(
@@ -622,6 +710,102 @@ fn optional_slice_from_raw_parts<'a, T>(raw_parts: *const T, count: usize) -> Op
     return None;
   }
   Some(unsafe { slice::from_raw_parts(raw_parts, count) })
+}
+
+fn build_current_thread_details<'a>(
+  processor: &mut ReportProcessor<'a>,
+) -> Option<WIPOffset<ThreadDetails<'a>>> {
+  if processor.system_thread_count == 0 && processor.threads.is_empty() {
+    return None;
+  }
+
+  let threads = processor.builder.create_vector(processor.threads.as_slice());
+  Some(ThreadDetails::create(
+    &mut processor.builder,
+    &ThreadDetailsArgs {
+      count: processor.system_thread_count,
+      threads: Some(threads),
+    },
+  ))
+}
+
+fn build_apple_crash_details<'a>(
+  builder: &mut FlatBufferBuilder<'a>,
+  payload: &BDAppleCrashInfoPayload,
+) -> Option<WIPOffset<AppleCrashDetails<'a>>> {
+  let nsexception = payload.has_nsexception.then(|| {
+    let name = append_string(builder, payload.nsexception.name);
+    let reason = append_string(builder, payload.nsexception.reason);
+    NSException::create(
+      builder,
+      &NSExceptionArgs {
+        name,
+        reason,
+        user_info: None,
+      },
+    )
+  });
+  let mach_exception = payload.has_mach_exception.then(|| {
+    MachException::create(
+      builder,
+      &MachExceptionArgs {
+        type_: payload.mach_exception.type_,
+        code: payload.mach_exception.code,
+        subcode: payload.mach_exception.subcode,
+      },
+    )
+  });
+  let posix_signal = payload.has_posix_signal.then(|| {
+    PosixSignal::create(
+      builder,
+      &PosixSignalArgs {
+        number: payload.posix_signal.number,
+        code: payload.posix_signal.code,
+        errno: payload.posix_signal.errno_,
+        has_fault_address: payload.posix_signal.has_fault_address,
+        fault_address: payload.posix_signal.fault_address,
+      },
+    )
+  });
+  let termination = payload.has_termination.then(|| {
+    let domain = append_string(builder, payload.termination.domain);
+    let code = append_string(builder, payload.termination.code);
+    let explanation = append_string(builder, payload.termination.explanation);
+    let process_visibility = append_string(builder, payload.termination.process_visibility);
+    let process_state = append_string(builder, payload.termination.process_state);
+    let watchdog_event = append_string(builder, payload.termination.watchdog_event);
+    let watchdog_visibility = append_string(builder, payload.termination.watchdog_visibility);
+    AppleTermination::create(
+      builder,
+      &AppleTerminationArgs {
+        domain,
+        code,
+        explanation,
+        process_visibility,
+        process_state,
+        watchdog_event,
+        watchdog_visibility,
+      },
+    )
+  });
+
+  if nsexception.is_none()
+    && mach_exception.is_none()
+    && posix_signal.is_none()
+    && termination.is_none()
+  {
+    return None;
+  }
+
+  Some(AppleCrashDetails::create(
+    builder,
+    &AppleCrashDetailsArgs {
+      nsexception,
+      mach_exception,
+      posix_signal,
+      termination,
+    },
+  ))
 }
 
 fn create_or_reuse_stack_trace<'a>(

--- a/bd-report-writer/src/ffi.rs
+++ b/bd-report-writer/src/ffi.rs
@@ -592,13 +592,11 @@ extern "C-unwind" fn bdrw_add_apple_crash_info_with_current_threads(
   payload_ptr: *const BDAppleCrashInfoPayload,
 ) -> bool {
   let processor = try_into_processor!(handle, false);
-  let payload = match unsafe { payload_ptr.as_ref() } {
-    Some(payload) => payload,
-    None => return false,
+  let Some(payload) = (unsafe { payload_ptr.as_ref() }) else {
+    return false;
   };
-  let details = match build_apple_crash_details(&mut processor.builder, payload) {
-    Some(details) => details,
-    None => return false,
+  let Some(details) = build_apple_crash_details(&mut processor.builder, payload) else {
+    return false;
   };
   let thread_details = build_current_thread_details(processor);
   let occurred_at = Timestamp::new(occurred_at_seconds, occurred_at_nanos);

--- a/bd-report-writer/src/ffi.rs
+++ b/bd-report-writer/src/ffi.rs
@@ -746,9 +746,7 @@ fn build_crash_info_thread_details<'a>(
   processor: &mut ReportProcessor<'a>,
   thread_details_ptr: *const BDCrashInfoThreadDetails,
 ) -> Option<WIPOffset<ThreadDetails<'a>>> {
-  let Some(thread_details) = (unsafe { thread_details_ptr.as_ref() }) else {
-    return None;
-  };
+  let thread_details = (unsafe { thread_details_ptr.as_ref() })?;
 
   let threads = optional_slice_from_raw_parts(thread_details.threads, thread_details.threads_count)
     .unwrap_or_default()

--- a/bd-report-writer/src/ffi.rs
+++ b/bd-report-writer/src/ffi.rs
@@ -279,7 +279,9 @@ extern "C-unwind" fn bdrw_get_completed_buffer(
     .builder
     .create_vector(processor.binary_images.as_slice());
   let thread_details = if processor.system_thread_count > 0 || !processor.threads.is_empty() {
-    let threads = processor.builder.create_vector(processor.threads.as_slice());
+    let threads = processor
+      .builder
+      .create_vector(processor.threads.as_slice());
     Some(ThreadDetails::create(
       &mut processor.builder,
       &ThreadDetailsArgs {

--- a/bd-report-writer/src/ffi.rs
+++ b/bd-report-writer/src/ffi.rs
@@ -127,6 +127,20 @@ pub struct BDAppleCrashInfoPayload {
 }
 
 #[repr(C)]
+pub struct BDCrashInfoThread {
+  thread: BDThread,
+  stack_count: u32,
+  stack: *const BDStackFrame,
+}
+
+#[repr(C)]
+pub struct BDCrashInfoThreadDetails {
+  count: u16,
+  threads_count: usize,
+  threads: *const BDCrashInfoThread,
+}
+
+#[repr(C)]
 pub struct BDDeviceMetrics {
   time_seconds: u64,
   time_nanos: u32,
@@ -264,10 +278,8 @@ extern "C-unwind" fn bdrw_get_completed_buffer(
   let binary_images = processor
     .builder
     .create_vector(processor.binary_images.as_slice());
-  let threads = processor
-    .builder
-    .create_vector(processor.threads.as_slice());
   let thread_details = if processor.system_thread_count > 0 || !processor.threads.is_empty() {
+    let threads = processor.builder.create_vector(processor.threads.as_slice());
     Some(ThreadDetails::create(
       &mut processor.builder,
       &ThreadDetailsArgs {
@@ -388,12 +400,6 @@ extern "C-unwind" fn bdrw_add_thread(
   processor.system_thread_count = system_thread_count;
 
   if let Some(thread) = unsafe { thread_ptr.as_ref() } {
-    let name = append_string(&mut processor.builder, thread.name);
-    let state = if processor.is_file_size_optimization_enabled {
-      append_shared_string(&mut processor.builder, thread.state)
-    } else {
-      append_string(&mut processor.builder, thread.state)
-    };
     let frames = append_frames(
       &mut processor.builder,
       stack_count,
@@ -401,18 +407,11 @@ extern "C-unwind" fn bdrw_add_thread(
       processor.is_file_size_optimization_enabled,
     );
     let stack_trace = create_or_reuse_stack_trace(processor, &frames);
-    let thread = Thread::create(
+    let thread = build_thread(
       &mut processor.builder,
-      &ThreadArgs {
-        name,
-        active: thread.active,
-        index: thread.index,
-        state,
-        priority: thread.priority,
-        quality_of_service: thread.quality_of_service,
-        stack_trace: Some(stack_trace),
-        summary: None,
-      },
+      thread,
+      stack_trace,
+      processor.is_file_size_optimization_enabled,
     );
     processor.threads.push(thread);
     true
@@ -587,13 +586,14 @@ extern "C-unwind" fn bdrw_add_app(handle: BDProcessorHandle, app_ptr: *const BDA
 }
 
 #[unsafe(no_mangle)]
-extern "C-unwind" fn bdrw_add_apple_crash_info_with_current_threads(
+extern "C-unwind" fn bdrw_add_apple_crash_info(
   handle: BDProcessorHandle,
   reporter_scope: i8,
   reporter: i8,
   occurred_at_seconds: u64,
   occurred_at_nanos: u32,
   payload_ptr: *const BDAppleCrashInfoPayload,
+  thread_details_ptr: *const BDCrashInfoThreadDetails,
 ) -> bool {
   let processor = try_into_processor!(handle, false);
   let Some(payload) = (unsafe { payload_ptr.as_ref() }) else {
@@ -602,7 +602,7 @@ extern "C-unwind" fn bdrw_add_apple_crash_info_with_current_threads(
   let Some(details) = build_apple_crash_details(&mut processor.builder, payload) else {
     return false;
   };
-  let thread_details = build_current_thread_details(processor);
+  let thread_details = build_crash_info_thread_details(processor, thread_details_ptr);
   let occurred_at = Timestamp::new(occurred_at_seconds, occurred_at_nanos);
   let crash_info = CrashInfo::create(
     &mut processor.builder,
@@ -714,21 +714,72 @@ fn optional_slice_from_raw_parts<'a, T>(raw_parts: *const T, count: usize) -> Op
   Some(unsafe { slice::from_raw_parts(raw_parts, count) })
 }
 
-fn build_current_thread_details<'a>(
+fn build_thread<'a>(
+  builder: &mut FlatBufferBuilder<'a>,
+  thread: &BDThread,
+  stack_trace: WIPOffset<Vector<'a, ForwardsUOffset<Frame<'a>>>>,
+  is_file_size_optimization_enabled: bool,
+) -> WIPOffset<Thread<'a>> {
+  let name = append_string(builder, thread.name);
+  let state = if is_file_size_optimization_enabled {
+    append_shared_string(builder, thread.state)
+  } else {
+    append_string(builder, thread.state)
+  };
+
+  Thread::create(
+    builder,
+    &ThreadArgs {
+      name,
+      active: thread.active,
+      index: thread.index,
+      state,
+      priority: thread.priority,
+      quality_of_service: thread.quality_of_service,
+      stack_trace: Some(stack_trace),
+      summary: None,
+    },
+  )
+}
+
+fn build_crash_info_thread_details<'a>(
   processor: &mut ReportProcessor<'a>,
+  thread_details_ptr: *const BDCrashInfoThreadDetails,
 ) -> Option<WIPOffset<ThreadDetails<'a>>> {
-  if processor.system_thread_count == 0 && processor.threads.is_empty() {
+  let Some(thread_details) = (unsafe { thread_details_ptr.as_ref() }) else {
+    return None;
+  };
+
+  let threads = optional_slice_from_raw_parts(thread_details.threads, thread_details.threads_count)
+    .unwrap_or_default()
+    .iter()
+    .map(|thread| {
+      let frames = append_frames(
+        &mut processor.builder,
+        thread.stack_count,
+        thread.stack,
+        processor.is_file_size_optimization_enabled,
+      );
+      let stack_trace = processor.builder.create_vector(frames.as_slice());
+      build_thread(
+        &mut processor.builder,
+        &thread.thread,
+        stack_trace,
+        processor.is_file_size_optimization_enabled,
+      )
+    })
+    .collect::<Vec<_>>();
+
+  if thread_details.count == 0 && threads.is_empty() {
     return None;
   }
 
-  let threads = processor
-    .builder
-    .create_vector(processor.threads.as_slice());
+  let threads = (!threads.is_empty()).then(|| processor.builder.create_vector(threads.as_slice()));
   Some(ThreadDetails::create(
     &mut processor.builder,
     &ThreadDetailsArgs {
-      count: processor.system_thread_count,
-      threads: Some(threads),
+      count: thread_details.count,
+      threads,
     },
   ))
 }

--- a/bd-script/src/report/generated/mod.rs
+++ b/bd-script/src/report/generated/mod.rs
@@ -353,6 +353,125 @@ impl Scriptable for AppMetrics<'_> {
   }
 }
 
+impl From<AppleCrashDetails<'_>> for ScriptValue {
+  fn from(value: AppleCrashDetails<'_>) -> Self {
+    let script_values: Vec<(&str, Self)> = vec![
+      ("mach_exception", value.mach_exception().into()),
+      ("nsexception", value.nsexception().into()),
+      ("posix_signal", value.posix_signal().into()),
+      ("termination", value.termination().into()),
+    ];
+    Value::Object(
+      script_values
+        .iter()
+        .map(|(key, value)| (key.to_string().into(), value.0.clone()))
+        .collect::<BTreeMap<KeyString, Value>>(),
+    )
+    .into()
+  }
+}
+
+impl Scriptable for AppleCrashDetails<'_> {
+  fn resolve(&self, path: &[OwnedSegment]) -> Result<Option<ScriptValue>, PathError> {
+    if path.is_empty() {
+      return Ok(Some((*self).into()));
+    }
+    let Some(OwnedSegment::Field(base)) = path.first() else {
+      return Err(PathError::NotAnArray(
+        OwnedValuePath::from(path.to_vec()).to_string(),
+      ));
+    };
+
+    match base.as_str() {
+      "mach_exception" => self.mach_exception().resolve(&path[1 ..]),
+      "nsexception" => self.nsexception().resolve(&path[1 ..]),
+      "posix_signal" => self.posix_signal().resolve(&path[1 ..]),
+      "termination" => self.termination().resolve(&path[1 ..]),
+      _ => Err(PathError::UnknownKey(
+        OwnedValuePath::from(path.to_vec()).into(),
+      )),
+    }
+  }
+
+  fn schema() -> Kind {
+    Kind::object(Collection::empty())
+  }
+}
+
+impl From<AppleTermination<'_>> for ScriptValue {
+  fn from(value: AppleTermination<'_>) -> Self {
+    let script_values: Vec<(&str, Self)> = vec![
+      ("code", value.code().into()),
+      ("domain", value.domain().into()),
+      ("explanation", value.explanation().into()),
+      ("process_state", value.process_state().into()),
+      ("process_visibility", value.process_visibility().into()),
+      ("watchdog_event", value.watchdog_event().into()),
+      ("watchdog_visibility", value.watchdog_visibility().into()),
+    ];
+    Value::Object(
+      script_values
+        .iter()
+        .map(|(key, value)| (key.to_string().into(), value.0.clone()))
+        .collect::<BTreeMap<KeyString, Value>>(),
+    )
+    .into()
+  }
+}
+
+impl Scriptable for AppleTermination<'_> {
+  fn resolve(&self, path: &[OwnedSegment]) -> Result<Option<ScriptValue>, PathError> {
+    if path.is_empty() {
+      return Ok(Some((*self).into()));
+    }
+    let Some(OwnedSegment::Field(base)) = path.first() else {
+      return Err(PathError::NotAnArray(
+        OwnedValuePath::from(path.to_vec()).to_string(),
+      ));
+    };
+
+    match base.as_str() {
+      "code" => self
+        .code()
+        .map_or(Ok(None), |value| value.resolve(&path[1 ..])),
+      "domain" => self
+        .domain()
+        .map_or(Ok(None), |value| value.resolve(&path[1 ..])),
+      "explanation" => self
+        .explanation()
+        .map_or(Ok(None), |value| value.resolve(&path[1 ..])),
+      "process_state" => self
+        .process_state()
+        .map_or(Ok(None), |value| value.resolve(&path[1 ..])),
+      "process_visibility" => self
+        .process_visibility()
+        .map_or(Ok(None), |value| value.resolve(&path[1 ..])),
+      "watchdog_event" => self
+        .watchdog_event()
+        .map_or(Ok(None), |value| value.resolve(&path[1 ..])),
+      "watchdog_visibility" => self
+        .watchdog_visibility()
+        .map_or(Ok(None), |value| value.resolve(&path[1 ..])),
+      _ => Err(PathError::UnknownKey(
+        OwnedValuePath::from(path.to_vec()).into(),
+      )),
+    }
+  }
+
+  fn schema() -> Kind {
+    Kind::object(
+      Collection::empty()
+        .with_known("code", Kind::bytes())
+        .with_known("domain", Kind::bytes())
+        .with_known("explanation", Kind::bytes())
+        .with_known("process_state", Kind::bytes())
+        .with_known("process_visibility", Kind::bytes())
+        .with_known("watchdog_event", Kind::bytes())
+        .with_known("watchdog_visibility", Kind::bytes()),
+    )
+  }
+}
+
 impl From<Architecture> for ScriptValue {
   fn from(value: Architecture) -> Self {
     value.variant_name().map_or(Value::Null.into(), Into::into)
@@ -471,6 +590,124 @@ impl Scriptable for CPURegister<'_> {
         .with_known("name", Kind::bytes())
         .with_known("value", Kind::integer()),
     )
+  }
+}
+
+impl From<CrashInfo<'_>> for ScriptValue {
+  fn from(value: CrashInfo<'_>) -> Self {
+    let script_values: Vec<(&str, Self)> = vec![
+      ("details_type", value.details_type().into()),
+      ("occurred_at", value.occurred_at().into()),
+      ("reporter", value.reporter().into()),
+      ("reporter_scope", value.reporter_scope().into()),
+      ("thread_details", value.thread_details().into()),
+    ];
+    Value::Object(
+      script_values
+        .iter()
+        .map(|(key, value)| (key.to_string().into(), value.0.clone()))
+        .collect::<BTreeMap<KeyString, Value>>(),
+    )
+    .into()
+  }
+}
+
+impl Scriptable for CrashInfo<'_> {
+  fn resolve(&self, path: &[OwnedSegment]) -> Result<Option<ScriptValue>, PathError> {
+    if path.is_empty() {
+      return Ok(Some((*self).into()));
+    }
+    let Some(OwnedSegment::Field(base)) = path.first() else {
+      return Err(PathError::NotAnArray(
+        OwnedValuePath::from(path.to_vec()).to_string(),
+      ));
+    };
+
+    match base.as_str() {
+      "details_type" => self.details_type().resolve(&path[1 ..]),
+      "occurred_at" => self.occurred_at().resolve(&path[1 ..]),
+      "reporter" => self.reporter().resolve(&path[1 ..]),
+      "reporter_scope" => self.reporter_scope().resolve(&path[1 ..]),
+      "thread_details" => self.thread_details().resolve(&path[1 ..]),
+      _ => Err(PathError::UnknownKey(
+        OwnedValuePath::from(path.to_vec()).into(),
+      )),
+    }
+  }
+
+  fn schema() -> Kind {
+    Kind::object(
+      Collection::empty()
+        .with_known("details_type", Kind::bytes())
+        .with_known("reporter", Kind::bytes())
+        .with_known("reporter_scope", Kind::bytes()),
+    )
+  }
+}
+
+impl From<CrashInfoDetails> for ScriptValue {
+  fn from(value: CrashInfoDetails) -> Self {
+    value.variant_name().map_or(Value::Null.into(), Into::into)
+  }
+}
+
+impl Scriptable for CrashInfoDetails {
+  fn resolve(&self, path: &[OwnedSegment]) -> Result<Option<ScriptValue>, PathError> {
+    if path.is_empty() {
+      Ok(Some((*self).into()))
+    } else {
+      Err(PathError::UnknownKey(
+        OwnedValuePath::from(path.to_vec()).to_string(),
+      ))
+    }
+  }
+
+  fn schema() -> Kind {
+    Kind::bytes()
+  }
+}
+
+impl From<CrashReporter> for ScriptValue {
+  fn from(value: CrashReporter) -> Self {
+    value.variant_name().map_or(Value::Null.into(), Into::into)
+  }
+}
+
+impl Scriptable for CrashReporter {
+  fn resolve(&self, path: &[OwnedSegment]) -> Result<Option<ScriptValue>, PathError> {
+    if path.is_empty() {
+      Ok(Some((*self).into()))
+    } else {
+      Err(PathError::UnknownKey(
+        OwnedValuePath::from(path.to_vec()).to_string(),
+      ))
+    }
+  }
+
+  fn schema() -> Kind {
+    Kind::bytes()
+  }
+}
+
+impl From<CrashReporterScope> for ScriptValue {
+  fn from(value: CrashReporterScope) -> Self {
+    value.variant_name().map_or(Value::Null.into(), Into::into)
+  }
+}
+
+impl Scriptable for CrashReporterScope {
+  fn resolve(&self, path: &[OwnedSegment]) -> Result<Option<ScriptValue>, PathError> {
+    if path.is_empty() {
+      Ok(Some((*self).into()))
+    } else {
+      Err(PathError::UnknownKey(
+        OwnedValuePath::from(path.to_vec()).to_string(),
+      ))
+    }
+  }
+
+  fn schema() -> Kind {
+    Kind::bytes()
   }
 }
 
@@ -926,6 +1163,54 @@ impl Scriptable for JavaScriptEngine {
   }
 }
 
+impl From<MachException<'_>> for ScriptValue {
+  fn from(value: MachException<'_>) -> Self {
+    let script_values: Vec<(&str, Self)> = vec![
+      ("code", value.code().into()),
+      ("subcode", value.subcode().into()),
+      ("type", value.type_().into()),
+    ];
+    Value::Object(
+      script_values
+        .iter()
+        .map(|(key, value)| (key.to_string().into(), value.0.clone()))
+        .collect::<BTreeMap<KeyString, Value>>(),
+    )
+    .into()
+  }
+}
+
+impl Scriptable for MachException<'_> {
+  fn resolve(&self, path: &[OwnedSegment]) -> Result<Option<ScriptValue>, PathError> {
+    if path.is_empty() {
+      return Ok(Some((*self).into()));
+    }
+    let Some(OwnedSegment::Field(base)) = path.first() else {
+      return Err(PathError::NotAnArray(
+        OwnedValuePath::from(path.to_vec()).to_string(),
+      ));
+    };
+
+    match base.as_str() {
+      "code" => self.code().resolve(&path[1 ..]),
+      "subcode" => self.subcode().resolve(&path[1 ..]),
+      "type" => self.type_().resolve(&path[1 ..]),
+      _ => Err(PathError::UnknownKey(
+        OwnedValuePath::from(path.to_vec()).into(),
+      )),
+    }
+  }
+
+  fn schema() -> Kind {
+    Kind::object(
+      Collection::empty()
+        .with_known("code", Kind::integer())
+        .with_known("subcode", Kind::integer())
+        .with_known("type", Kind::integer()),
+    )
+  }
+}
+
 impl From<Memory> for ScriptValue {
   fn from(value: Memory) -> Self {
     let script_values: Vec<(&str, Self)> = vec![
@@ -1010,6 +1295,66 @@ impl Scriptable for MemoryPressureLevel {
 
   fn schema() -> Kind {
     Kind::bytes()
+  }
+}
+
+impl From<NSException<'_>> for ScriptValue {
+  fn from(value: NSException<'_>) -> Self {
+    let script_values: Vec<(&str, Self)> = vec![
+      ("name", value.name().into()),
+      ("reason", value.reason().into()),
+      ("user_info", value.user_info().into()),
+    ];
+    Value::Object(
+      script_values
+        .iter()
+        .map(|(key, value)| (key.to_string().into(), value.0.clone()))
+        .collect::<BTreeMap<KeyString, Value>>(),
+    )
+    .into()
+  }
+}
+
+impl Scriptable for NSException<'_> {
+  fn resolve(&self, path: &[OwnedSegment]) -> Result<Option<ScriptValue>, PathError> {
+    if path.is_empty() {
+      return Ok(Some((*self).into()));
+    }
+    let Some(OwnedSegment::Field(base)) = path.first() else {
+      return Err(PathError::NotAnArray(
+        OwnedValuePath::from(path.to_vec()).to_string(),
+      ));
+    };
+
+    match base.as_str() {
+      "name" => self
+        .name()
+        .map_or(Ok(None), |value| value.resolve(&path[1 ..])),
+      "reason" => self
+        .reason()
+        .map_or(Ok(None), |value| value.resolve(&path[1 ..])),
+      "user_info" => {
+        let Some(values) = self.user_info() else {
+          return Ok(None);
+        };
+        values.resolve(&path[1 ..])
+      },
+      _ => Err(PathError::UnknownKey(
+        OwnedValuePath::from(path.to_vec()).into(),
+      )),
+    }
+  }
+
+  fn schema() -> Kind {
+    Kind::object(
+      Collection::empty()
+        .with_known("name", Kind::bytes())
+        .with_known("reason", Kind::bytes())
+        .with_known(
+          "user_info",
+          Kind::array(Collection::empty().with_unknown(Field::schema())),
+        ),
+    )
   }
 }
 
@@ -1113,6 +1458,60 @@ impl Scriptable for Platform {
 
   fn schema() -> Kind {
     Kind::bytes()
+  }
+}
+
+impl From<PosixSignal<'_>> for ScriptValue {
+  fn from(value: PosixSignal<'_>) -> Self {
+    let script_values: Vec<(&str, Self)> = vec![
+      ("code", value.code().into()),
+      ("errno", value.errno().into()),
+      ("fault_address", value.fault_address().into()),
+      ("has_fault_address", value.has_fault_address().into()),
+      ("number", value.number().into()),
+    ];
+    Value::Object(
+      script_values
+        .iter()
+        .map(|(key, value)| (key.to_string().into(), value.0.clone()))
+        .collect::<BTreeMap<KeyString, Value>>(),
+    )
+    .into()
+  }
+}
+
+impl Scriptable for PosixSignal<'_> {
+  fn resolve(&self, path: &[OwnedSegment]) -> Result<Option<ScriptValue>, PathError> {
+    if path.is_empty() {
+      return Ok(Some((*self).into()));
+    }
+    let Some(OwnedSegment::Field(base)) = path.first() else {
+      return Err(PathError::NotAnArray(
+        OwnedValuePath::from(path.to_vec()).to_string(),
+      ));
+    };
+
+    match base.as_str() {
+      "code" => self.code().resolve(&path[1 ..]),
+      "errno" => self.errno().resolve(&path[1 ..]),
+      "fault_address" => self.fault_address().resolve(&path[1 ..]),
+      "has_fault_address" => self.has_fault_address().resolve(&path[1 ..]),
+      "number" => self.number().resolve(&path[1 ..]),
+      _ => Err(PathError::UnknownKey(
+        OwnedValuePath::from(path.to_vec()).into(),
+      )),
+    }
+  }
+
+  fn schema() -> Kind {
+    Kind::object(
+      Collection::empty()
+        .with_known("code", Kind::integer())
+        .with_known("errno", Kind::integer())
+        .with_known("fault_address", Kind::integer())
+        .with_known("has_fault_address", Kind::boolean())
+        .with_known("number", Kind::integer()),
+    )
   }
 }
 
@@ -1270,6 +1669,7 @@ impl From<Report<'_>> for ScriptValue {
     let script_values: Vec<(&str, Self)> = vec![
       ("app_metrics", value.app_metrics().into()),
       ("binary_images", value.binary_images().into()),
+      ("crash_info", value.crash_info().into()),
       ("device_metrics", value.device_metrics().into()),
       ("errors", value.errors().into()),
       ("feature_flags", value.feature_flags().into()),
@@ -1304,6 +1704,12 @@ impl Scriptable for Report<'_> {
       "app_metrics" => self.app_metrics().resolve(&path[1 ..]),
       "binary_images" => {
         let Some(values) = self.binary_images() else {
+          return Ok(None);
+        };
+        values.resolve(&path[1 ..])
+      },
+      "crash_info" => {
+        let Some(values) = self.crash_info() else {
           return Ok(None);
         };
         values.resolve(&path[1 ..])
@@ -1343,6 +1749,10 @@ impl Scriptable for Report<'_> {
         .with_known(
           "binary_images",
           Kind::array(Collection::empty().with_unknown(BinaryImage::schema())),
+        )
+        .with_known(
+          "crash_info",
+          Kind::array(Collection::empty().with_unknown(CrashInfo::schema())),
         )
         .with_known(
           "errors",

--- a/bd-script/src/report/generated/mod.rs
+++ b/bd-script/src/report/generated/mod.rs
@@ -1465,7 +1465,7 @@ impl From<PosixSignal<'_>> for ScriptValue {
   fn from(value: PosixSignal<'_>) -> Self {
     let script_values: Vec<(&str, Self)> = vec![
       ("code", value.code().into()),
-      ("errno", value.errno().into()),
+      ("errno_value", value.errno_value().into()),
       ("fault_address", value.fault_address().into()),
       ("has_fault_address", value.has_fault_address().into()),
       ("number", value.number().into()),
@@ -1493,7 +1493,7 @@ impl Scriptable for PosixSignal<'_> {
 
     match base.as_str() {
       "code" => self.code().resolve(&path[1 ..]),
-      "errno" => self.errno().resolve(&path[1 ..]),
+      "errno_value" => self.errno_value().resolve(&path[1 ..]),
       "fault_address" => self.fault_address().resolve(&path[1 ..]),
       "has_fault_address" => self.has_fault_address().resolve(&path[1 ..]),
       "number" => self.number().resolve(&path[1 ..]),
@@ -1507,7 +1507,7 @@ impl Scriptable for PosixSignal<'_> {
     Kind::object(
       Collection::empty()
         .with_known("code", Kind::integer())
-        .with_known("errno", Kind::integer())
+        .with_known("errno_value", Kind::integer())
         .with_known("fault_address", Kind::integer())
         .with_known("has_fault_address", Kind::boolean())
         .with_known("number", Kind::integer()),


### PR DESCRIPTION
# Overview

This PR adds `crash_info` support in `shared-core` for Apple crash metadata. It updates the report writer ffi so Apple crash details can be attached to a report, and adds fbs serialization support for the new `crash_info` model.

Realted to [this other PR](https://github.com/bitdriftlabs/api/pull/181)