### PR TITLE
(bd-workflows) add feature for cloneable config structs

### DIFF
--- a/bd-workflows/Cargo.toml
+++ b/bd-workflows/Cargo.toml
@@ -45,6 +45,7 @@ uuid.workspace              = true
 
 [features]
 fuzzing = ["dep:arbitrary", "bd-stats-common/fuzzing"]
+cloneable-config = []
 
 [dev-dependencies]
 assert_matches.workspace    = true

--- a/bd-workflows/src/config.rs
+++ b/bd-workflows/src/config.rs
@@ -71,7 +71,7 @@ impl Execution {
 // WorkflowsConfiguration
 //
 
-#[cfg_attr(test, derive(Clone))]
+#[cfg_attr(any(test, feature = "cloneable-config"), derive(Clone))]
 #[derive(Debug, Default, PartialEq)]
 pub struct WorkflowsConfiguration {
   pub(crate) workflows: Vec<Config>,
@@ -144,7 +144,7 @@ pub enum WorkflowDebugMode {
 // ConfigWithMode
 //
 
-#[cfg_attr(test, derive(Clone))]
+#[cfg_attr(any(test, feature = "cloneable-config"), derive(Clone))]
 #[derive(Debug, PartialEq)]
 pub struct Config {
   inner: InnerConfig,
@@ -223,7 +223,7 @@ impl Config {
 // InnerConfig is split out from mode because there are places where we compare the known config
 // to the new config and we do not want to include debug more in that comparison. This makes that
 // cleaner.
-#[cfg_attr(test, derive(Clone))]
+#[cfg_attr(any(test, feature = "cloneable-config"), derive(Clone))]
 #[derive(Debug, PartialEq)]
 pub struct InnerConfig {
   id: String,

--- a/bd-workflows/src/engine.rs
+++ b/bd-workflows/src/engine.rs
@@ -1232,7 +1232,7 @@ impl PrecedingEventCarryover {
 // WorkflowsEngineConfig
 //
 
-#[cfg_attr(test, derive(Clone))]
+#[cfg_attr(any(test, feature = "cloneable-config"), derive(Clone))]
 #[derive(Debug, PartialEq)]
 pub struct WorkflowsEngineConfig {
   pub(crate) workflows_configuration: WorkflowsConfiguration,


### PR DESCRIPTION
adds option to clone configuration structs without unintentionally spreading the functionality to client use