### PR TITLE
workflows: reserve on-crash configuration version

### DIFF
--- a/bd-metadata/src/lib.rs
+++ b/bd-metadata/src/lib.rs
@@ -39,7 +39,8 @@ use std::collections::HashMap;
 // Version 42: Added support for server driven state updates.
 // Version 43: Added support for sending trigger UUIDs in log uploads to allow the server to
 //             associate logs with the flush that generated them.
-const CONFIGURATION_VERSION: &str = "43";
+// Version 44: Added support for propagating client workflow state with crash reports.
+const CONFIGURATION_VERSION: &str = "44";
 
 /// The platform we're currently running as.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]

--- a/bd-workflows/src/config.rs
+++ b/bd-workflows/src/config.rs
@@ -609,6 +609,9 @@ impl Transition {
         extra_matcher: rule.log_matcher.as_ref().map(Tree::new).transpose()?,
       },
       Rule_type::OnNewSession(_) => Predicate::OnNewSession,
+      // Crash dispatch is introduced separately from config conversion. Until then, this remains
+      // parked during normal log and state processing.
+      Rule_type::OnCrash(_) => Predicate::OnCrash,
     };
 
     let actions = transition
@@ -684,6 +687,7 @@ pub(crate) enum Predicate {
     matcher: Tree,
     required_matches: u32,
   },
+  OnCrash,
   OnNewSession,
   StateChangeMatch {
     state_change_match: StateChangeMatch,


### PR DESCRIPTION
Reserves client configuration version 44 for crash-handoff support and parses the dormant `OnCrash` workflow predicate.\n\nDepends on #556.