### PR TITLE
[Android] [ANR] Send basic reports without ANR traces

### DIFF
--- a/bd-report-parsers/src/android.rs
+++ b/bd-report-parsers/src/android.rs
@@ -54,11 +54,35 @@ type FrameOffsetSequence = Vec<u32>;
 
 const MAIN_THREAD: &str = "main";
 
-pub fn build_anr<'a, 'fbb>(
+pub fn build_anr_from_app_exit<'fbb>(
   builder: &mut FlatBufferBuilder<'fbb>,
   app_info: &mut v_1::AppMetricsArgs<'fbb>,
   device_info: &mut v_1::DeviceMetricsArgs<'fbb>,
-  input: MemmapView<'a>,
+  anr_trace: Option<MemmapView<'_>>,
+  app_exit_description: Option<&str>,
+  is_file_size_optimization_enabled: bool,
+) -> WIPOffset<v_1::Report<'fbb>> {
+  if let Some(anr_trace) = anr_trace
+    && let Ok((_, report)) = build_anr_from_trace(
+      builder,
+      app_info,
+      device_info,
+      anr_trace,
+      app_exit_description,
+      is_file_size_optimization_enabled,
+    )
+  {
+    return report;
+  }
+
+  build_anr_without_trace(builder, app_info, device_info, app_exit_description)
+}
+
+fn build_anr_from_trace<'a, 'fbb>(
+  builder: &mut FlatBufferBuilder<'fbb>,
+  app_info: &mut v_1::AppMetricsArgs<'fbb>,
+  device_info: &mut v_1::DeviceMetricsArgs<'fbb>,
+  anr_trace: MemmapView<'a>,
   app_exit_description: Option<&str>,
   is_file_size_optimization_enabled: bool,
 ) -> IResult<MemmapView<'a>, WIPOffset<v_1::Report<'fbb>>, nom::error::Error<MemmapView<'a>>> {
@@ -69,7 +93,7 @@ pub fn build_anr<'a, 'fbb>(
     thread_counter,
     |text| build_threads(builder, text, is_file_size_optimization_enabled),
   )
-    .parse(input)?;
+    .parse(anr_trace)?;
 
   if let Ok(pid) = u32::try_from(pid) {
     app_info.process_id = pid;
@@ -80,6 +104,19 @@ pub fn build_anr<'a, 'fbb>(
     builder.create_vector(&[abi])
   });
   let description = app_exit_description.or(subject.as_deref());
+  Ok((
+    remainder,
+    create_anr_report(builder, app_info, device_info, description, &stacks),
+  ))
+}
+
+fn create_anr_report<'fbb>(
+  builder: &mut FlatBufferBuilder<'fbb>,
+  app_info: &v_1::AppMetricsArgs<'fbb>,
+  device_info: &v_1::DeviceMetricsArgs<'fbb>,
+  description: Option<&str>,
+  stacks: &Stacks<'fbb>,
+) -> WIPOffset<v_1::Report<'fbb>> {
   let error_args = v_1::ErrorArgs {
     name: Some(builder.create_string(anr_name(description))),
     reason: description.map(|d| builder.create_string(d)),
@@ -97,7 +134,30 @@ pub fn build_anr<'a, 'fbb>(
     binary_images: stacks.binary_images,
     ..Default::default()
   };
-  Ok((remainder, v_1::Report::create(builder, &args)))
+  v_1::Report::create(builder, &args)
+}
+
+fn build_anr_without_trace<'fbb>(
+  builder: &mut FlatBufferBuilder<'fbb>,
+  app_info: &v_1::AppMetricsArgs<'fbb>,
+  device_info: &mut v_1::DeviceMetricsArgs<'fbb>,
+  app_exit_description: Option<&str>,
+) -> WIPOffset<v_1::Report<'fbb>> {
+  device_info.platform = v_1::Platform::Android;
+  create_anr_report(
+    builder,
+    app_info,
+    device_info,
+    app_exit_description,
+    &Stacks {
+      args: v_1::ThreadDetailsArgs {
+        count: 0,
+        threads: None,
+      },
+      binary_images: None,
+      main_stack: None,
+    },
+  )
 }
 
 fn build_threads<'a, 'fbb, E: ParseError<MemmapView<'a>>>(

--- a/bd-report-parsers/src/android.rs
+++ b/bd-report-parsers/src/android.rs
@@ -62,6 +62,7 @@ pub fn build_anr_from_app_exit<'fbb>(
   app_exit_description: Option<&str>,
   is_file_size_optimization_enabled: bool,
 ) -> WIPOffset<v_1::Report<'fbb>> {
+  device_info.platform = v_1::Platform::Android;
   if let Some(anr_trace) = anr_trace
     && let Ok((_, report)) = build_anr_from_trace(
       builder,
@@ -98,7 +99,6 @@ fn build_anr_from_trace<'a, 'fbb>(
   if let Ok(pid) = u32::try_from(pid) {
     app_info.process_id = pid;
   }
-  device_info.platform = v_1::Platform::Android;
   device_info.cpu_abis = metrics.get("ABI").map(|abi| {
     let abi = builder.create_string(abi);
     builder.create_vector(&[abi])
@@ -140,10 +140,9 @@ fn create_anr_report<'fbb>(
 fn build_anr_without_trace<'fbb>(
   builder: &mut FlatBufferBuilder<'fbb>,
   app_info: &v_1::AppMetricsArgs<'fbb>,
-  device_info: &mut v_1::DeviceMetricsArgs<'fbb>,
+  device_info: &v_1::DeviceMetricsArgs<'fbb>,
   app_exit_description: Option<&str>,
 ) -> WIPOffset<v_1::Report<'fbb>> {
-  device_info.platform = v_1::Platform::Android;
   create_anr_report(
     builder,
     app_info,

--- a/bd-report-parsers/src/android_tests.rs
+++ b/bd-report-parsers/src/android_tests.rs
@@ -495,6 +495,7 @@ fn build_anr_without_trace_uses_app_exit_description() {
   builder.finish(offset, None);
 
   let report = flatbuffers::root::<Report<'_>>(builder.finished_data()).unwrap();
+  insta::assert_debug_snapshot!(report);
   let error = report.errors().unwrap().get(0);
   assert_eq!(error.name(), Some("User Perceived ANR"));
   assert_eq!(error.reason(), Some(description));
@@ -520,6 +521,7 @@ fn build_anr_with_unparsable_trace_uses_app_exit_description() -> anyhow::Result
   builder.finish(offset, None);
 
   let report = flatbuffers::root::<Report<'_>>(builder.finished_data()).unwrap();
+  insta::assert_debug_snapshot!(report);
   let error = report.errors().unwrap().get(0);
   assert_eq!(error.name(), Some("Broadcast Receiver ANR"));
   assert_eq!(error.reason(), Some(description));

--- a/bd-report-parsers/src/android_tests.rs
+++ b/bd-report-parsers/src/android_tests.rs
@@ -309,7 +309,7 @@ macro_rules! assert_parsed_anr_eq {
     let mut builder = FlatBufferBuilder::new();
     let file = open_fixture($filename);
     let mmap = unsafe { memmap2::Mmap::map(&file).unwrap() };
-    let input = MemmapView::new(&mmap);
+    let anr_trace = MemmapView::new(&mmap);
     let mut app_info = AppMetricsArgs {
       app_id: Some(builder.create_string("com.example.MyApp")),
       ..Default::default()
@@ -319,25 +319,16 @@ macro_rules! assert_parsed_anr_eq {
       time: Some(&Timestamp::new(1_756_987_272, 357_156_958)),
       ..Default::default()
     };
-    match build_anr(
+    let offset = build_anr_from_app_exit(
       &mut builder,
       &mut app_info,
       &mut device_info,
-      input,
+      Some(anr_trace),
       None,
       true,
-    ) {
-      Ok((_, offset)) => {
-        let report = get_table!(Report, builder, offset);
-        insta::assert_debug_snapshot!(report);
-      },
-      Err(nom::Err::Error(e) | nom::Err::Failure(e)) => {
-        let mut contents = format!("{e:?}");
-        contents.truncate(300);
-        panic!("failed to parse: {contents:?}")
-      },
-      Err(e) => panic!("failed to parse: {e:#?}"),
-    }
+    );
+    let report = get_table!(Report, builder, offset);
+    insta::assert_debug_snapshot!(report);
   };
 }
 
@@ -430,7 +421,7 @@ fn build_anr_to_bytes(filename: &str, description: Option<&str>) -> Vec<u8> {
   let mut builder = FlatBufferBuilder::new();
   let file = open_fixture(filename);
   let mmap = unsafe { memmap2::Mmap::map(&file).unwrap() };
-  let input = MemmapView::new(&mmap);
+  let anr_trace = MemmapView::new(&mmap);
   let mut app_info = AppMetricsArgs {
     app_id: Some(builder.create_string("com.example.MyApp")),
     ..Default::default()
@@ -440,15 +431,14 @@ fn build_anr_to_bytes(filename: &str, description: Option<&str>) -> Vec<u8> {
     time: Some(&Timestamp::new(1_756_987_272, 357_156_958)),
     ..Default::default()
   };
-  let (_, offset) = build_anr(
+  let offset = build_anr_from_app_exit(
     &mut builder,
     &mut app_info,
     &mut device_info,
-    input,
+    Some(anr_trace),
     description,
     true,
-  )
-  .unwrap();
+  );
   builder.finish(offset, None);
   builder.finished_data().to_vec()
 }
@@ -486,4 +476,53 @@ fn build_anr_without_description_or_subject() {
   let error = report.errors().unwrap().get(0);
   assert_eq!(error.name(), Some("Undetermined ANR"));
   assert_eq!(error.reason(), None);
+}
+
+#[test]
+fn build_anr_without_trace_uses_app_exit_description() {
+  let mut builder = FlatBufferBuilder::new();
+  let mut app_info = AppMetricsArgs::default();
+  let mut device_info = DeviceMetricsArgs::default();
+  let description = "Input dispatching timed out";
+  let offset = build_anr_from_app_exit(
+    &mut builder,
+    &mut app_info,
+    &mut device_info,
+    None,
+    Some(description),
+    true,
+  );
+  builder.finish(offset, None);
+
+  let report = flatbuffers::root::<Report<'_>>(builder.finished_data()).unwrap();
+  let error = report.errors().unwrap().get(0);
+  assert_eq!(error.name(), Some("User Perceived ANR"));
+  assert_eq!(error.reason(), Some(description));
+  assert_eq!(report.thread_details().unwrap().count(), 0);
+}
+
+#[test]
+fn build_anr_with_unparsable_trace_uses_app_exit_description() -> anyhow::Result<()> {
+  let file = make_tempfile(b"not an ANR trace")?;
+  let mmap = unsafe { memmap2::Mmap::map(&file)? };
+  let mut builder = FlatBufferBuilder::new();
+  let mut app_info = AppMetricsArgs::default();
+  let mut device_info = DeviceMetricsArgs::default();
+  let description = "Broadcast of Intent { act=android.intent.action.MAIN }";
+  let offset = build_anr_from_app_exit(
+    &mut builder,
+    &mut app_info,
+    &mut device_info,
+    Some(MemmapView::new(&mmap)),
+    Some(description),
+    true,
+  );
+  builder.finish(offset, None);
+
+  let report = flatbuffers::root::<Report<'_>>(builder.finished_data()).unwrap();
+  let error = report.errors().unwrap().get(0);
+  assert_eq!(error.name(), Some("Broadcast Receiver ANR"));
+  assert_eq!(error.reason(), Some(description));
+  assert_eq!(report.thread_details().unwrap().count(), 0);
+  Ok(())
 }

--- a/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__build_anr_with_unparsable_trace_uses_app_exit_description.snap
+++ b/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__build_anr_with_unparsable_trace_uses_app_exit_description.snap
@@ -1,0 +1,67 @@
+---
+source: bd-report-parsers/src/./android_tests.rs
+expression: report
+---
+Report {
+    sdk: None,
+    type_: AppNotResponding,
+    app_metrics: Some(
+        AppMetrics {
+            app_id: None,
+            memory: None,
+            version: None,
+            build_number: None,
+            running_state: None,
+            process_id: 0,
+            region_format: None,
+            cpu_usage: None,
+            lifecycle_event: None,
+            javascript_engine: UnknownJsEngine,
+            memory_pressure_level: Unknown,
+        },
+    ),
+    device_metrics: Some(
+        DeviceMetrics {
+            time: None,
+            timezone: None,
+            power_metrics: None,
+            network_state: Unknown,
+            rotation: Unknown,
+            arch: Unknown,
+            display: None,
+            manufacturer: None,
+            model: None,
+            os_build: None,
+            platform: Android,
+            cpu_abis: None,
+            low_power_mode_enabled: false,
+            cpu_usage: None,
+            thermal_state: 0,
+        },
+    ),
+    errors: Some(
+        [
+            Error {
+                name: Some(
+                    "Broadcast Receiver ANR",
+                ),
+                reason: Some(
+                    "Broadcast of Intent { act=android.intent.action.MAIN }",
+                ),
+                stack_trace: None,
+                relation_to_next: CausedBy,
+            },
+        ],
+    ),
+    thread_details: Some(
+        ThreadDetails {
+            count: 0,
+            threads: None,
+        },
+    ),
+    binary_images: None,
+    fields: None,
+    feature_flags: None,
+    processing_result: None,
+    crash_info: None,
+}

--- a/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__build_anr_without_trace_uses_app_exit_description.snap
+++ b/bd-report-parsers/src/snapshots/bd_report_parsers__android__tests__build_anr_without_trace_uses_app_exit_description.snap
@@ -1,0 +1,67 @@
+---
+source: bd-report-parsers/src/./android_tests.rs
+expression: report
+---
+Report {
+    sdk: None,
+    type_: AppNotResponding,
+    app_metrics: Some(
+        AppMetrics {
+            app_id: None,
+            memory: None,
+            version: None,
+            build_number: None,
+            running_state: None,
+            process_id: 0,
+            region_format: None,
+            cpu_usage: None,
+            lifecycle_event: None,
+            javascript_engine: UnknownJsEngine,
+            memory_pressure_level: Unknown,
+        },
+    ),
+    device_metrics: Some(
+        DeviceMetrics {
+            time: None,
+            timezone: None,
+            power_metrics: None,
+            network_state: Unknown,
+            rotation: Unknown,
+            arch: Unknown,
+            display: None,
+            manufacturer: None,
+            model: None,
+            os_build: None,
+            platform: Android,
+            cpu_abis: None,
+            low_power_mode_enabled: false,
+            cpu_usage: None,
+            thermal_state: 0,
+        },
+    ),
+    errors: Some(
+        [
+            Error {
+                name: Some(
+                    "User Perceived ANR",
+                ),
+                reason: Some(
+                    "Input dispatching timed out",
+                ),
+                stack_trace: None,
+                relation_to_next: CausedBy,
+            },
+        ],
+    ),
+    thread_details: Some(
+        ThreadDetails {
+            count: 0,
+            threads: None,
+        },
+    ),
+    binary_images: None,
+    fields: None,
+    feature_flags: None,
+    processing_result: None,
+    crash_info: None,
+}


### PR DESCRIPTION
## Problem

[ApplicationExitInfo](https://developer.android.com/reference/android/app/ApplicationExitInfo) can return a null stacktrace sometimes via [getTraceInputStream](https://developer.android.com/reference/android/app/ApplicationExitInfo#getTraceInputStream()) parameter given this definition on their docs

_“Note that because these traces are kept in a separate global circular buffer, crashes may be overwritten by newer crashes (including from other applications), so this may still return null.”_

If that’s the case, getPreviousRunInfo will return ANR as termination reason, but given no report is stored due to the lack of stactrace the count won’t increment in Issue pages/Callback/ANR workflows

For more context please refer to this [doc](https://docs.google.com/document/d/1PHxyRpKdAkza3LC_e0mxkXiDDbO_hJBxIbxo_Lhfy-8/edit?tab=t.0)

## Solution

Resolves BIT-9198

If we fail to parse a trace (either because being nullable or invalid contents) instead of dropping the report will create a basic one empty stacks/threads using appExitDescription for classification (e.g. User Perceived ANR, BroadcastReceiver, Background ANR, etc).

## Verification

Verified in capture-sdk shared-core bump pr https://github.com/bitdriftlabs/capture-sdk/pull/1083

<img width="1352" height="734" alt="Screenshot 2026-08-06 at 15 48 44" src="https://github.com/user-attachments/assets/5b2b8044-70fa-4487-a44b-d95bce1893f1" />
