### PR TITLE
fix bazel feature propagation and update test rules

### DIFF
--- a/bd-api/BUILD.bazel
+++ b/bd-api/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-api",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-artifact-upload/BUILD.bazel
+++ b/bd-artifact-upload/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-artifact-upload",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-backoff/BUILD.bazel
+++ b/bd-backoff/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-backoff",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-bonjson-ffi/BUILD.bazel
+++ b/bd-bonjson-ffi/BUILD.bazel
@@ -1,7 +1,14 @@
 load("@crates//:defs.bzl", "all_crate_deps")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//tools/lint:linters.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "headers",
+    hdrs = glob(["include/**/*.h"]),
+    includes = ["include"],
+)
 
 rust_library(
     name = "bd-bonjson-ffi",

--- a/bd-bonjson-tests/BUILD.bazel
+++ b/bd-bonjson-tests/BUILD.bazel
@@ -1,9 +1,17 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+cc_library(
+    name = "ffi-test-helpers",
+    testonly = True,
+    srcs = ["src/ffi_tests.c"],
+    deps = ["//shared-core/bd-bonjson-ffi:headers"],
+)
+
+rust_library_with_test(
     name = "bd-bonjson-tests",
     srcs = glob(
         ["src/**/*.rs"],
@@ -13,5 +21,6 @@ rust_library(
     crate_name = "bd_bonjson_tests",
     crate_root = "src/lib.rs",
     edition = "2024",
+    test_deps = [":ffi-test-helpers"],
     deps = all_crate_deps(normal = True),
 )

--- a/bd-bonjson/BUILD.bazel
+++ b/bd-bonjson/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-bonjson",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-bounded-buffer/BUILD.bazel
+++ b/bd-bounded-buffer/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-bounded-buffer",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-buffer/BUILD.bazel
+++ b/bd-buffer/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//tools/rust:feature_variants.bzl", "rust_library_with_feature_variants")
+load("//tools/rust:tests.bzl", "rust_library_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -22,3 +23,5 @@ rust_library_with_feature_variants(
         },
     },
 )
+
+rust_library_test(crate = ":bd-buffer")

--- a/bd-buffer/BUILD.bazel
+++ b/bd-buffer/BUILD.bazel
@@ -1,9 +1,8 @@
-load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:feature_variants.bzl", "rust_library_with_feature_variants")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_feature_variants(
     name = "bd-buffer",
     srcs = glob(
         ["src/**/*.rs"],
@@ -13,5 +12,13 @@ rust_library(
     crate_name = "bd_buffer",
     crate_root = "src/lib.rs",
     edition = "2024",
-    deps = all_crate_deps(normal = True),
+    feature_variants = {
+        "fuzz": {
+            "dependency_overrides": {
+                "//shared-core/bd-client-stats-store": "//shared-core/bd-client-stats-store:bd-client-stats-store-fuzz",
+                "//shared-core/bd-resilient-kv": "//shared-core/bd-resilient-kv:bd-resilient-kv-fuzz",
+                "//shared-core/bd-stats-common": "//shared-core/bd-stats-common:bd-stats-common-fuzz",
+            },
+        },
+    },
 )

--- a/bd-client-common/BUILD.bazel
+++ b/bd-client-common/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-client-common",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-client-stats-store/BUILD.bazel
+++ b/bd-client-stats-store/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@crates//:defs.bzl", "aliases")
 load("//tools/rust:feature_variants.bzl", "rust_library_with_feature_variants")
+load("//tools/rust:tests.bzl", "rust_library_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -21,3 +22,5 @@ rust_library_with_feature_variants(
         },
     },
 )
+
+rust_library_test(crate = ":bd-client-stats-store")

--- a/bd-client-stats-store/BUILD.bazel
+++ b/bd-client-stats-store/BUILD.bazel
@@ -1,9 +1,9 @@
-load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("@crates//:defs.bzl", "aliases")
+load("//tools/rust:feature_variants.bzl", "rust_library_with_feature_variants")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_feature_variants(
     name = "bd-client-stats-store",
     srcs = glob(
         ["src/**/*.rs"],
@@ -13,5 +13,11 @@ rust_library(
     crate_name = "bd_client_stats_store",
     crate_root = "src/lib.rs",
     edition = "2024",
-    deps = all_crate_deps(normal = True),
+    feature_variants = {
+        "fuzz": {
+            "dependency_overrides": {
+                "//shared-core/bd-stats-common": "//shared-core/bd-stats-common:bd-stats-common-fuzz",
+            },
+        },
+    },
 )

--- a/bd-client-stats/BUILD.bazel
+++ b/bd-client-stats/BUILD.bazel
@@ -1,23 +1,25 @@
-load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("@crates//:defs.bzl", "aliases")
+load("//tools/rust:feature_variants.bzl", "rust_library_with_feature_variants")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_feature_variants(
     name = "bd-client-stats",
     srcs = glob(
         ["src/**/*.rs"],
         exclude = ["src/bin/**/*.rs"],
     ),
-    # logger-cli is a workspace consumer of the optional observation API. Bazel
-    # models each first-party crate as one shared target, so mirror Cargo's
-    # feature unification here rather than creating a feature-specific copy.
-    crate_features = [
-        "default",
-        "logger-cli-observer",
-    ],
+    crate_features = ["default"],
     crate_name = "bd_client_stats",
     crate_root = "src/lib.rs",
     edition = "2024",
-    deps = all_crate_deps(normal = True),
+    feature_variants = {
+        "fuzz": {
+            "dependency_overrides": {
+                "//shared-core/bd-client-stats-store": "//shared-core/bd-client-stats-store:bd-client-stats-store-fuzz",
+                "//shared-core/bd-stats-common": "//shared-core/bd-stats-common:bd-stats-common-fuzz",
+            },
+        },
+        "logger-cli": {"crate_features": ["logger-cli-observer"]},
+    },
 )

--- a/bd-completion/BUILD.bazel
+++ b/bd-completion/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-completion",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-crash-handler/BUILD.bazel
+++ b/bd-crash-handler/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-crash-handler",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-device/BUILD.bazel
+++ b/bd-device/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-device",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-error-reporter/BUILD.bazel
+++ b/bd-error-reporter/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-error-reporter",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-events/BUILD.bazel
+++ b/bd-events/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-events",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-grpc-codec/BUILD.bazel
+++ b/bd-grpc-codec/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-grpc-codec",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-grpc/BUILD.bazel
+++ b/bd-grpc/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-grpc",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-hyper-network/BUILD.bazel
+++ b/bd-hyper-network/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-hyper-network",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-key-value/BUILD.bazel
+++ b/bd-key-value/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-key-value",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-log-filter/BUILD.bazel
+++ b/bd-log-filter/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-log-filter",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-log-matcher/BUILD.bazel
+++ b/bd-log-matcher/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-log-matcher",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-log-primitives/BUILD.bazel
+++ b/bd-log-primitives/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-log-primitives",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-log/BUILD.bazel
+++ b/bd-log/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-log",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-logger/BUILD.bazel
+++ b/bd-logger/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-logger",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-macros/BUILD.bazel
+++ b/bd-macros/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_proc_macro")
+load("//tools/rust:tests.bzl", "rust_proc_macro_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_proc_macro(
+rust_proc_macro_with_test(
     name = "bd-macros",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-panic/BUILD.bazel
+++ b/bd-panic/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-panic",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-pgv/BUILD.bazel
+++ b/bd-pgv/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-pgv",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-proto-util/BUILD.bazel
+++ b/bd-proto-util/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -29,7 +29,7 @@ cc_library(
     deps = ["@@+http_archive+shared_core_flatbuffers//:flatbuffers"],
 )
 
-rust_library(
+rust_library_with_test(
     name = "bd-proto-util",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-proto/BUILD.bazel
+++ b/bd-proto/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,7 +8,7 @@ exports_files([
     "src/flatbuffers/common_generated.h",
 ])
 
-rust_library(
+rust_library_with_test(
     name = "bd-proto",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-report-parsers/BUILD.bazel
+++ b/bd-report-parsers/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-report-parsers",
     srcs = glob(
         ["src/**/*.rs"],
@@ -13,5 +13,9 @@ rust_library(
     crate_name = "bd_report_parsers",
     crate_root = "src/lib.rs",
     edition = "2024",
+    test_data = glob([
+        "fixtures/**",
+        "src/snapshots/**",
+    ]),
     deps = all_crate_deps(normal = True),
 )

--- a/bd-report-writer-tests/BUILD.bazel
+++ b/bd-report-writer-tests/BUILD.bazel
@@ -1,9 +1,17 @@
 load("@crates//:defs.bzl", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+cc_library(
+    name = "ffi-test-helpers",
+    testonly = True,
+    srcs = ["src/ffi_tests.c"],
+    deps = ["//shared-core/bd-report-writer:headers"],
+)
+
+rust_library_with_test(
     name = "bd-report-writer-tests",
     srcs = glob(
         ["src/**/*.rs"],
@@ -13,5 +21,6 @@ rust_library(
     crate_name = "bd_report_writer_tests",
     crate_root = "src/lib.rs",
     edition = "2024",
+    test_deps = [":ffi-test-helpers"],
     deps = all_crate_deps(normal = True),
 )

--- a/bd-report-writer/BUILD.bazel
+++ b/bd-report-writer/BUILD.bazel
@@ -1,7 +1,14 @@
 load("@crates//:defs.bzl", "all_crate_deps")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//tools/lint:linters.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "headers",
+    hdrs = glob(["include/**/*.h"]),
+    includes = ["include"],
+)
 
 rust_library(
     name = "bd-report-writer",

--- a/bd-resilient-kv/BUILD.bazel
+++ b/bd-resilient-kv/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@crates//:defs.bzl", "aliases")
 load("//tools/rust:feature_variants.bzl", "rust_library_with_feature_variants")
+load("//tools/rust:tests.bzl", "rust_library_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -22,3 +23,5 @@ rust_library_with_feature_variants(
         },
     },
 )
+
+rust_library_test(crate = ":bd-resilient-kv")

--- a/bd-resilient-kv/BUILD.bazel
+++ b/bd-resilient-kv/BUILD.bazel
@@ -1,9 +1,9 @@
-load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("@crates//:defs.bzl", "aliases")
+load("//tools/rust:feature_variants.bzl", "rust_library_with_feature_variants")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_feature_variants(
     name = "bd-resilient-kv",
     srcs = glob(
         ["src/**/*.rs"],
@@ -13,5 +13,12 @@ rust_library(
     crate_name = "bd_resilient_kv",
     crate_root = "src/lib.rs",
     edition = "2024",
-    deps = all_crate_deps(normal = True),
+    feature_variants = {
+        "fuzz": {
+            "dependency_overrides": {
+                "//shared-core/bd-client-stats-store": "//shared-core/bd-client-stats-store:bd-client-stats-store-fuzz",
+                "//shared-core/bd-stats-common": "//shared-core/bd-stats-common:bd-stats-common-fuzz",
+            },
+        },
+    },
 )

--- a/bd-resource-utilization/BUILD.bazel
+++ b/bd-resource-utilization/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-resource-utilization",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-runtime-config/BUILD.bazel
+++ b/bd-runtime-config/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-runtime-config",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-runtime/BUILD.bazel
+++ b/bd-runtime/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-runtime",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-script/BUILD.bazel
+++ b/bd-script/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-script",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-server-stats/BUILD.bazel
+++ b/bd-server-stats/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-server-stats",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-session-replay/BUILD.bazel
+++ b/bd-session-replay/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-session-replay",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-session/BUILD.bazel
+++ b/bd-session/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-session",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-state/BUILD.bazel
+++ b/bd-state/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-state",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-stats-common/BUILD.bazel
+++ b/bd-stats-common/BUILD.bazel
@@ -1,9 +1,9 @@
-load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("@crates//:defs.bzl", "aliases")
+load("//tools/rust:feature_variants.bzl", "rust_library_with_feature_variants")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_feature_variants(
     name = "bd-stats-common",
     srcs = glob(
         ["src/**/*.rs"],
@@ -13,5 +13,7 @@ rust_library(
     crate_name = "bd_stats_common",
     crate_root = "src/lib.rs",
     edition = "2024",
-    deps = all_crate_deps(normal = True),
+    feature_variants = {
+        "fuzz": {"crate_features": ["fuzzing"]},
+    },
 )

--- a/bd-test-helpers/BUILD.bazel
+++ b/bd-test-helpers/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_test(
     name = "bd-test-helpers",
     srcs = glob(
         ["src/**/*.rs"],

--- a/bd-workflows/BUILD.bazel
+++ b/bd-workflows/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@crates//:defs.bzl", "aliases")
 load("//tools/rust:feature_variants.bzl", "rust_library_with_feature_variants")
+load("//tools/rust:tests.bzl", "rust_library_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,3 +25,5 @@ rust_library_with_feature_variants(
         },
     },
 )
+
+rust_library_test(crate = ":bd-workflows")

--- a/bd-workflows/BUILD.bazel
+++ b/bd-workflows/BUILD.bazel
@@ -1,9 +1,9 @@
-load("@crates//:defs.bzl", "aliases", "all_crate_deps")
-load("//tools/lint:linters.bzl", "rust_library")
+load("@crates//:defs.bzl", "aliases")
+load("//tools/rust:feature_variants.bzl", "rust_library_with_feature_variants")
 
 package(default_visibility = ["//visibility:public"])
 
-rust_library(
+rust_library_with_feature_variants(
     name = "bd-workflows",
     srcs = glob(
         ["src/**/*.rs"],
@@ -13,5 +13,14 @@ rust_library(
     crate_name = "bd_workflows",
     crate_root = "src/lib.rs",
     edition = "2024",
-    deps = all_crate_deps(normal = True),
+    feature_variants = {
+        "fuzz": {
+            "crate_features": ["fuzzing"],
+            "dependency_overrides": {
+                "//shared-core/bd-client-stats": "//shared-core/bd-client-stats:bd-client-stats-fuzz",
+                "//shared-core/bd-client-stats-store": "//shared-core/bd-client-stats-store:bd-client-stats-store-fuzz",
+                "//shared-core/bd-stats-common": "//shared-core/bd-stats-common:bd-stats-common-fuzz",
+            },
+        },
+    },
 )

--- a/fuzz/BUILD.bazel
+++ b/fuzz/BUILD.bazel
@@ -1,36 +1,42 @@
-load("//tools/lint:linters.bzl", "rust_binary", "rust_library")
+load("//tools/lint:linters.bzl", "rust_binary")
 load("//tools/rust:feature_variants.bzl", "all_crate_deps_with_overrides")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
 FUZZ_DEPS = all_crate_deps_with_overrides(
-    normal = True,
     dependency_overrides = {
         "//shared-core/bd-buffer": "//shared-core/bd-buffer:bd-buffer-fuzz",
         "//shared-core/bd-client-stats-store": "//shared-core/bd-client-stats-store:bd-client-stats-store-fuzz",
         "//shared-core/bd-resilient-kv": "//shared-core/bd-resilient-kv:bd-resilient-kv-fuzz",
         "//shared-core/bd-workflows": "//shared-core/bd-workflows:bd-workflows-fuzz",
     },
+    normal = True,
 )
 
-rust_library(
+rust_library_with_test(
     name = "fuzz",
-    srcs = glob(["src/**/*.rs"], exclude = ["src/bin/**/*.rs"]),
-    crate_root = "src/lib.rs",
-    crate_name = "fuzz",
-    edition = "2024",
+    srcs = glob(
+        ["src/**/*.rs"],
+        exclude = ["src/bin/**/*.rs"],
+    ),
     crate_features = ["default"],
+    crate_name = "fuzz",
+    crate_root = "src/lib.rs",
+    edition = "2024",
     tags = ["manual"],
+    test_data = glob(["corpus/**"]),
+    test_tags = ["manual"],
     deps = FUZZ_DEPS,
 )
 
 rust_binary(
     name = "bonjson",
     srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/bonjson.rs"],
-    crate_root = "fuzz_targets/bonjson.rs",
-    crate_name = "bonjson",
-    edition = "2024",
     crate_features = ["default"],
+    crate_name = "bonjson",
+    crate_root = "fuzz_targets/bonjson.rs",
+    edition = "2024",
     tags = ["manual"],
     deps = FUZZ_DEPS + [":fuzz"],
 )
@@ -38,10 +44,10 @@ rust_binary(
 rust_binary(
     name = "buffer_corruption_fuzz_test",
     srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/buffer_corruption_fuzz_test.rs"],
-    crate_root = "fuzz_targets/buffer_corruption_fuzz_test.rs",
-    crate_name = "buffer_corruption_fuzz_test",
-    edition = "2024",
     crate_features = ["default"],
+    crate_name = "buffer_corruption_fuzz_test",
+    crate_root = "fuzz_targets/buffer_corruption_fuzz_test.rs",
+    edition = "2024",
     tags = ["manual"],
     deps = FUZZ_DEPS + [":fuzz"],
 )
@@ -49,10 +55,10 @@ rust_binary(
 rust_binary(
     name = "mpsc_buffer_fuzz_test",
     srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/mpsc_buffer_fuzz_test.rs"],
-    crate_root = "fuzz_targets/mpsc_buffer_fuzz_test.rs",
-    crate_name = "mpsc_buffer_fuzz_test",
-    edition = "2024",
     crate_features = ["default"],
+    crate_name = "mpsc_buffer_fuzz_test",
+    crate_root = "fuzz_targets/mpsc_buffer_fuzz_test.rs",
+    edition = "2024",
     tags = ["manual"],
     deps = FUZZ_DEPS + [":fuzz"],
 )
@@ -60,10 +66,10 @@ rust_binary(
 rust_binary(
     name = "spsc_buffer_fuzz_test",
     srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/spsc_buffer_fuzz_test.rs"],
-    crate_root = "fuzz_targets/spsc_buffer_fuzz_test.rs",
-    crate_name = "spsc_buffer_fuzz_test",
-    edition = "2024",
     crate_features = ["default"],
+    crate_name = "spsc_buffer_fuzz_test",
+    crate_root = "fuzz_targets/spsc_buffer_fuzz_test.rs",
+    edition = "2024",
     tags = ["manual"],
     deps = FUZZ_DEPS + [":fuzz"],
 )
@@ -71,10 +77,10 @@ rust_binary(
 rust_binary(
     name = "versioned_kv_journal",
     srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/versioned_kv_journal.rs"],
-    crate_root = "fuzz_targets/versioned_kv_journal.rs",
-    crate_name = "versioned_kv_journal",
-    edition = "2024",
     crate_features = ["default"],
+    crate_name = "versioned_kv_journal",
+    crate_root = "fuzz_targets/versioned_kv_journal.rs",
+    edition = "2024",
     tags = ["manual"],
     deps = FUZZ_DEPS + [":fuzz"],
 )
@@ -82,10 +88,10 @@ rust_binary(
 rust_binary(
     name = "workflow_state",
     srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/workflow_state.rs"],
-    crate_root = "fuzz_targets/workflow_state.rs",
-    crate_name = "workflow_state",
-    edition = "2024",
     crate_features = ["default"],
+    crate_name = "workflow_state",
+    crate_root = "fuzz_targets/workflow_state.rs",
+    edition = "2024",
     tags = ["manual"],
     deps = FUZZ_DEPS + [":fuzz"],
 )

--- a/fuzz/BUILD.bazel
+++ b/fuzz/BUILD.bazel
@@ -1,7 +1,17 @@
-load("@crates//:defs.bzl", "all_crate_deps")
 load("//tools/lint:linters.bzl", "rust_binary", "rust_library")
+load("//tools/rust:feature_variants.bzl", "all_crate_deps_with_overrides")
 
 package(default_visibility = ["//visibility:public"])
+
+FUZZ_DEPS = all_crate_deps_with_overrides(
+    normal = True,
+    dependency_overrides = {
+        "//shared-core/bd-buffer": "//shared-core/bd-buffer:bd-buffer-fuzz",
+        "//shared-core/bd-client-stats-store": "//shared-core/bd-client-stats-store:bd-client-stats-store-fuzz",
+        "//shared-core/bd-resilient-kv": "//shared-core/bd-resilient-kv:bd-resilient-kv-fuzz",
+        "//shared-core/bd-workflows": "//shared-core/bd-workflows:bd-workflows-fuzz",
+    },
+)
 
 rust_library(
     name = "fuzz",
@@ -11,71 +21,71 @@ rust_library(
     edition = "2024",
     crate_features = ["default"],
     tags = ["manual"],
-    deps = all_crate_deps(normal = True),
+    deps = FUZZ_DEPS,
 )
 
 rust_binary(
     name = "bonjson",
-    srcs = glob(["src/**/*.rs"]),
+    srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/bonjson.rs"],
     crate_root = "fuzz_targets/bonjson.rs",
     crate_name = "bonjson",
     edition = "2024",
     crate_features = ["default"],
     tags = ["manual"],
-    deps = all_crate_deps(normal = True) + [":fuzz"],
+    deps = FUZZ_DEPS + [":fuzz"],
 )
 
 rust_binary(
     name = "buffer_corruption_fuzz_test",
-    srcs = glob(["src/**/*.rs"]),
+    srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/buffer_corruption_fuzz_test.rs"],
     crate_root = "fuzz_targets/buffer_corruption_fuzz_test.rs",
     crate_name = "buffer_corruption_fuzz_test",
     edition = "2024",
     crate_features = ["default"],
     tags = ["manual"],
-    deps = all_crate_deps(normal = True) + [":fuzz"],
+    deps = FUZZ_DEPS + [":fuzz"],
 )
 
 rust_binary(
     name = "mpsc_buffer_fuzz_test",
-    srcs = glob(["src/**/*.rs"]),
+    srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/mpsc_buffer_fuzz_test.rs"],
     crate_root = "fuzz_targets/mpsc_buffer_fuzz_test.rs",
     crate_name = "mpsc_buffer_fuzz_test",
     edition = "2024",
     crate_features = ["default"],
     tags = ["manual"],
-    deps = all_crate_deps(normal = True) + [":fuzz"],
+    deps = FUZZ_DEPS + [":fuzz"],
 )
 
 rust_binary(
     name = "spsc_buffer_fuzz_test",
-    srcs = glob(["src/**/*.rs"]),
+    srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/spsc_buffer_fuzz_test.rs"],
     crate_root = "fuzz_targets/spsc_buffer_fuzz_test.rs",
     crate_name = "spsc_buffer_fuzz_test",
     edition = "2024",
     crate_features = ["default"],
     tags = ["manual"],
-    deps = all_crate_deps(normal = True) + [":fuzz"],
+    deps = FUZZ_DEPS + [":fuzz"],
 )
 
 rust_binary(
     name = "versioned_kv_journal",
-    srcs = glob(["src/**/*.rs"]),
+    srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/versioned_kv_journal.rs"],
     crate_root = "fuzz_targets/versioned_kv_journal.rs",
     crate_name = "versioned_kv_journal",
     edition = "2024",
     crate_features = ["default"],
     tags = ["manual"],
-    deps = all_crate_deps(normal = True) + [":fuzz"],
+    deps = FUZZ_DEPS + [":fuzz"],
 )
 
 rust_binary(
     name = "workflow_state",
-    srcs = glob(["src/**/*.rs"]),
+    srcs = glob(["src/**/*.rs"]) + ["fuzz_targets/workflow_state.rs"],
     crate_root = "fuzz_targets/workflow_state.rs",
     crate_name = "workflow_state",
     edition = "2024",
     crate_features = ["default"],
     tags = ["manual"],
-    deps = all_crate_deps(normal = True) + [":fuzz"],
+    deps = FUZZ_DEPS + [":fuzz"],
 )

--- a/logger-cli/BUILD.bazel
+++ b/logger-cli/BUILD.bazel
@@ -1,7 +1,14 @@
-load("@crates//:defs.bzl", "all_crate_deps")
 load("//tools/lint:linters.bzl", "rust_binary", "rust_library")
+load("//tools/rust:feature_variants.bzl", "all_crate_deps_with_overrides")
 
 package(default_visibility = ["//visibility:public"])
+
+LOGGER_CLI_DEPS = all_crate_deps_with_overrides(
+    normal = True,
+    dependency_overrides = {
+        "//shared-core/bd-client-stats": "//shared-core/bd-client-stats:bd-client-stats-logger-cli",
+    },
+)
 
 rust_library(
     name = "logger-cli",
@@ -13,7 +20,7 @@ rust_library(
     crate_name = "logger_cli",
     crate_root = "src/lib.rs",
     edition = "2024",
-    deps = all_crate_deps(normal = True),
+    deps = LOGGER_CLI_DEPS,
 )
 
 rust_binary(
@@ -23,7 +30,7 @@ rust_binary(
     crate_name = "logger_cli",
     crate_root = "src/main.rs",
     edition = "2024",
-    deps = all_crate_deps(normal = True) + [":logger-cli"],
+    deps = LOGGER_CLI_DEPS + [":logger-cli"],
 )
 
 rust_binary(
@@ -33,5 +40,5 @@ rust_binary(
     crate_name = "logger_mcp",
     crate_root = "src/bin/mcp.rs",
     edition = "2024",
-    deps = all_crate_deps(normal = True) + [":logger-cli"],
+    deps = LOGGER_CLI_DEPS + [":logger-cli"],
 )

--- a/logger-cli/BUILD.bazel
+++ b/logger-cli/BUILD.bazel
@@ -1,16 +1,17 @@
-load("//tools/lint:linters.bzl", "rust_binary", "rust_library")
+load("//tools/lint:linters.bzl", "rust_binary")
 load("//tools/rust:feature_variants.bzl", "all_crate_deps_with_overrides")
+load("//tools/rust:tests.bzl", "rust_library_with_test")
 
 package(default_visibility = ["//visibility:public"])
 
 LOGGER_CLI_DEPS = all_crate_deps_with_overrides(
-    normal = True,
     dependency_overrides = {
         "//shared-core/bd-client-stats": "//shared-core/bd-client-stats:bd-client-stats-logger-cli",
     },
+    normal = True,
 )
 
-rust_library(
+rust_library_with_test(
     name = "logger-cli",
     srcs = glob(
         ["src/**/*.rs"],


### PR DESCRIPTION
Updates the shared macros to support specifying feature variants that adjust the dependencies. This is less elegant than how Cargo does it but should be functionally very flexible