### PR TITLE
server stats: add contribution guage

### DIFF
--- a/bd-server-stats/src/stats.rs
+++ b/bd-server-stats/src/stats.rs
@@ -890,8 +890,13 @@ impl ContributionGauge {
   pub fn inc_by(&self, value: u64) {
     let mut contribution = self.inner.contribution.lock();
     // A contribution is signed, but increments are not. An increment outside the signed range
-    // exhausts this owner's representable positive contribution.
-    let next = i64::try_from(value).map_or(i64::MAX, |value| contribution.saturating_add(value));
+    // can still be offset by an existing negative contribution before it saturates.
+    let next = match i64::try_from(value) {
+      Ok(value) => contribution.saturating_add(value),
+      Err(_) if contribution.is_negative() => i64::try_from(value - contribution.unsigned_abs())
+        .unwrap_or(i64::MAX),
+      Err(_) => i64::MAX,
+    };
     Self::update_gauge(&self.inner.gauge, *contribution, next);
     *contribution = next;
   }
@@ -899,8 +904,16 @@ impl ContributionGauge {
   /// Decrease this owner's contribution and the shared gauge.
   pub fn dec_by(&self, value: u64) {
     let mut contribution = self.inner.contribution.lock();
-    // Mirror `inc_by`: an unrepresentable decrement exhausts the negative signed range.
-    let next = i64::try_from(value).map_or(i64::MIN, |value| contribution.saturating_sub(value));
+    // Mirror `inc_by`: an unrepresentable decrement can still be offset by an existing positive
+    // contribution before it saturates.
+    let next = match i64::try_from(value) {
+      Ok(value) => contribution.saturating_sub(value),
+      Err(_) if contribution.is_positive() => {
+        let magnitude = value - contribution.unsigned_abs();
+        i64::try_from(magnitude).map_or(i64::MIN, |magnitude| -magnitude)
+      },
+      Err(_) => i64::MIN,
+    };
     Self::update_gauge(&self.inner.gauge, *contribution, next);
     *contribution = next;
   }

--- a/bd-server-stats/src/stats.rs
+++ b/bd-server-stats/src/stats.rs
@@ -855,3 +855,101 @@ impl Drop for AutoGauge {
     self.gauge.sub(1);
   }
 }
+
+//
+// ContributionGauge
+//
+
+/// Tracks one owner's signed contribution to a shared gauge.
+///
+/// Clones share the same contribution, while separate instances can safely contribute to the
+/// same underlying gauge. The outstanding contribution is removed when the final handle drops.
+#[derive(Clone)]
+pub struct ContributionGauge {
+  inner: Arc<ContributionGaugeInner>,
+}
+
+struct ContributionGaugeInner {
+  gauge: IntGauge,
+  contribution: Mutex<i64>,
+}
+
+impl ContributionGauge {
+  /// Create a zero-valued contribution to `gauge`.
+  #[must_use]
+  pub fn new(gauge: IntGauge) -> Self {
+    Self {
+      inner: Arc::new(ContributionGaugeInner {
+        gauge,
+        contribution: Mutex::new(0),
+      }),
+    }
+  }
+
+  /// Increase this owner's contribution and the shared gauge.
+  pub fn inc_by(&self, value: u64) {
+    let mut contribution = self.inner.contribution.lock();
+    // A contribution is signed, but increments are not. An increment outside the signed range
+    // exhausts this owner's representable positive contribution.
+    let next = i64::try_from(value).map_or(i64::MAX, |value| contribution.saturating_add(value));
+    Self::update_gauge(&self.inner.gauge, *contribution, next);
+    *contribution = next;
+  }
+
+  /// Decrease this owner's contribution and the shared gauge.
+  pub fn dec_by(&self, value: u64) {
+    let mut contribution = self.inner.contribution.lock();
+    // Mirror `inc_by`: an unrepresentable decrement exhausts the negative signed range.
+    let next = i64::try_from(value).map_or(i64::MIN, |value| contribution.saturating_sub(value));
+    Self::update_gauge(&self.inner.gauge, *contribution, next);
+    *contribution = next;
+  }
+
+  /// Set this owner's contribution while preserving all other owners' values.
+  pub fn set(&self, value: i64) {
+    let mut contribution = self.inner.contribution.lock();
+    Self::update_gauge(&self.inner.gauge, *contribution, value);
+    *contribution = value;
+  }
+
+  /// Remove this owner's outstanding contribution from the shared gauge.
+  pub fn clear(&self) {
+    let mut contribution = self.inner.contribution.lock();
+    Self::update_gauge(&self.inner.gauge, *contribution, 0);
+    *contribution = 0;
+  }
+
+  /// Reconcile one owner's old and new contributions without changing other owners' values.
+  ///
+  /// For example, changing this owner from `-4` to `3` adds `7` to the shared gauge. It does not
+  /// set the shared gauge to `3`, because other owners may have outstanding contributions.
+  ///
+  /// The distance from `i64::MIN` to `i64::MAX` cannot fit in one signed `IntGauge` adjustment.
+  /// That rare transition is applied as `i64::MAX`, `i64::MAX`, and `1` sized chunks.
+  fn update_gauge(gauge: &IntGauge, current: i64, next: i64) {
+    // `abs_diff` preserves the full unsigned magnitude of the owner's required adjustment.
+    let mut remaining = next.abs_diff(current);
+    let maximum_adjustment = u64::try_from(i64::MAX).unwrap_or(u64::MAX);
+    while remaining > 0 {
+      // Limit every Prometheus call to the signed range accepted by `IntGauge::add` and `sub`.
+      let adjustment = remaining.min(maximum_adjustment);
+      let adjustment = i64::try_from(adjustment).unwrap_or(i64::MAX);
+      if next > current {
+        // The owner's value increased, so its delta increases the shared gauge.
+        gauge.add(adjustment);
+      } else {
+        // The owner's value decreased, so its delta decreases the shared gauge.
+        gauge.sub(adjustment);
+      }
+      // Ordinary transitions finish here. A range-spanning transition loops for its next chunk.
+      remaining = remaining.saturating_sub(u64::try_from(adjustment).unwrap_or(u64::MAX));
+    }
+  }
+}
+
+impl Drop for ContributionGaugeInner {
+  fn drop(&mut self) {
+    let contribution = *self.contribution.get_mut();
+    ContributionGauge::update_gauge(&self.gauge, contribution, 0);
+  }
+}

--- a/bd-server-stats/src/stats.rs
+++ b/bd-server-stats/src/stats.rs
@@ -893,8 +893,9 @@ impl ContributionGauge {
     // can still be offset by an existing negative contribution before it saturates.
     let next = match i64::try_from(value) {
       Ok(value) => contribution.saturating_add(value),
-      Err(_) if contribution.is_negative() => i64::try_from(value - contribution.unsigned_abs())
-        .unwrap_or(i64::MAX),
+      Err(_) if contribution.is_negative() => {
+        i64::try_from(value - contribution.unsigned_abs()).unwrap_or(i64::MAX)
+      },
       Err(_) => i64::MAX,
     };
     Self::update_gauge(&self.inner.gauge, *contribution, next);

--- a/bd-server-stats/src/stats_test.rs
+++ b/bd-server-stats/src/stats_test.rs
@@ -47,6 +47,64 @@ fn labeled_float_counter_records_fractional_values() {
   );
 }
 
+#[test]
+fn contribution_gauges_aggregate_and_remove_only_their_own_values() {
+  let helper = Helper::new();
+  let gauge = helper.collector().scope("contribution").gauge("value");
+  let first = ContributionGauge::new(gauge.clone());
+  let first_clone = first.clone();
+  let second = ContributionGauge::new(gauge);
+
+  first.inc_by(3);
+  second.inc_by(5);
+  helper.assert_gauge_eq(8, "contribution:value", &labels!());
+
+  first_clone.dec_by(2);
+  helper.assert_gauge_eq(6, "contribution:value", &labels!());
+
+  first.set(-4);
+  helper.assert_gauge_eq(1, "contribution:value", &labels!());
+
+  second.set(-2);
+  helper.assert_gauge_eq(-6, "contribution:value", &labels!());
+
+  first_clone.inc_by(5);
+  helper.assert_gauge_eq(-1, "contribution:value", &labels!());
+
+  second.dec_by(4);
+  helper.assert_gauge_eq(-5, "contribution:value", &labels!());
+
+  first.clear();
+  helper.assert_gauge_eq(-6, "contribution:value", &labels!());
+
+  first_clone.set(2);
+  helper.assert_gauge_eq(-4, "contribution:value", &labels!());
+
+  drop(first);
+  helper.assert_gauge_eq(-4, "contribution:value", &labels!());
+
+  drop(first_clone);
+  helper.assert_gauge_eq(-6, "contribution:value", &labels!());
+
+  drop(second);
+  helper.assert_gauge_eq(0, "contribution:value", &labels!());
+}
+
+#[test]
+fn contribution_gauge_saturates_large_signed_adjustments() {
+  let helper = Helper::new();
+  let gauge = ContributionGauge::new(helper.collector().scope("contribution").gauge("value"));
+
+  gauge.inc_by(u64::MAX);
+  helper.assert_gauge_eq(i64::MAX, "contribution:value", &labels!());
+
+  gauge.dec_by(u64::MAX);
+  helper.assert_gauge_eq(i64::MIN, "contribution:value", &labels!());
+
+  gauge.clear();
+  helper.assert_gauge_eq(0, "contribution:value", &labels!());
+}
+
 // Verify basic label tracking functionality.
 #[test]
 fn label_tracker() {

--- a/bd-server-stats/src/stats_test.rs
+++ b/bd-server-stats/src/stats_test.rs
@@ -95,6 +95,16 @@ fn contribution_gauge_saturates_large_signed_adjustments() {
   let helper = Helper::new();
   let gauge = ContributionGauge::new(helper.collector().scope("contribution").gauge("value"));
 
+  // Prometheus serializes gauges as f64, so use an offset representable near 2^63.
+  gauge.set(-4_096);
+  gauge.inc_by(i64::MAX as u64 + 1);
+  helper.assert_gauge_eq(i64::MAX - 4_095, "contribution:value", &labels!());
+
+  gauge.set(4_096);
+  gauge.dec_by(i64::MAX as u64 + 1);
+  helper.assert_gauge_eq(i64::MIN + 4_096, "contribution:value", &labels!());
+
+  gauge.clear();
   gauge.inc_by(u64::MAX);
   helper.assert_gauge_eq(i64::MAX, "contribution:value", &labels!());
 


### PR DESCRIPTION
Allow multiple in-process entities to safely contribute to a single gauge.