### PR TITLE
api: redefine connection count

### DIFF
--- a/bd-api/src/api.rs
+++ b/bd-api/src/api.rs
@@ -502,7 +502,7 @@ impl Api {
       last_disconnect_reason: None,
       sdk_status_tracker,
       stats_handshake_extension,
-      connection_count_since_process_start: 0,
+      connection_count_since_process_start: 1,
       #[cfg(test)]
       data_idle_timeout_test_hook: None,
     }
@@ -916,6 +916,8 @@ impl Api {
         client_state_updates,
         remaining_responses,
       } => {
+        // Advance the logical connection number only after its handshake succeeded.
+        self.connection_count_since_process_start += 1;
         self
           .session_strategy
           .acknowledge_state_update(&handshake_state_update)
@@ -1301,7 +1303,7 @@ impl Api {
 
   // Creates a handshake request containing the current version nonces and static metadata.
   async fn handshake_request(
-    &mut self,
+    &self,
     metadata: &HashMap<String, ProtoData>,
     previous_disconnect_reason: Option<String>,
   ) -> (
@@ -1309,7 +1311,6 @@ impl Api {
     bd_session::PendingStateUpdate,
     Option<TrackedStatsUploadRequest>,
   ) {
-    self.connection_count_since_process_start += 1;
     let opaque_client_state = tokio::fs::read(&self.opaque_client_state_path()).await.ok();
     let session_update = self.session_strategy.handshake_state_update().await;
     let mut handshake = HandshakeRequest {

--- a/bd-api/src/api_test.rs
+++ b/bd-api/src/api_test.rs
@@ -753,6 +753,46 @@ async fn handshake_connection_count_starts_at_one() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn handshake_connection_count_only_increments_after_handshake_response() {
+  let mut setup = Setup::new().await;
+
+  let first_handshake = setup.next_stream(1.seconds()).await.unwrap();
+  assert_eq!(
+    first_handshake
+      .analytics
+      .as_ref()
+      .unwrap()
+      .connection_count_since_process_start,
+    1
+  );
+  setup
+    .error_shutdown(Code::Internal, "some message", None)
+    .await;
+
+  let retry_handshake = setup.next_stream(1.seconds()).await.unwrap();
+  assert_eq!(
+    retry_handshake
+      .analytics
+      .as_ref()
+      .unwrap()
+      .connection_count_since_process_start,
+    1
+  );
+  setup.handshake_response(0, None, None).await;
+  setup.close_stream().await;
+
+  let post_success_handshake = setup.next_stream(5.seconds()).await.unwrap();
+  assert_eq!(
+    post_success_handshake
+      .analytics
+      .as_ref()
+      .unwrap()
+      .connection_count_since_process_start,
+    2
+  );
+}
+
+#[tokio::test(start_paused = true)]
 async fn handshake_metadata_omits_manufacturer_for_non_android() {
   let mut setup = Setup::new_with_metadata(Arc::new(TestMetadata {
     platform: Platform::Apple,

--- a/bd-workflows/src/engine.rs
+++ b/bd-workflows/src/engine.rs
@@ -653,19 +653,8 @@ impl<C: CounterTrait, H: HistogramTrait> WorkflowsEngine<C, H> {
       flush_buffers
     );
 
-    if flush_buffers {
-      let buffer_flush = BuffersToFlush::new(action);
-
-      if let Err(e) = self.buffers_to_flush_tx.try_send(buffer_flush) {
-        self.stats.buffers_to_flush_channel_send_failures.inc();
-        log::debug!("failed to send information about buffers to flush: {e}");
-      } else {
-        self
-          .process_local_pending_flush_state
-          .mark_pending(action.id.clone());
-      }
-    }
-
+    // A remote command can arrive as soon as the trigger upload is published. Register local
+    // streaming first so its equivalent-reroute check cannot miss this workflow action.
     if let Some(streaming_action) = self
       .flush_buffers_actions_resolver
       .make_streaming_action(action.clone())
@@ -678,6 +667,19 @@ impl<C: CounterTrait, H: HistogramTrait> WorkflowsEngine<C, H> {
           self.state.active_streaming_tracing_count.saturating_sub(1);
       }
       log::debug!("no streaming configuration defined for action: \"{action:?}\"");
+    }
+
+    if flush_buffers {
+      let buffer_flush = BuffersToFlush::new(action);
+
+      if let Err(e) = self.buffers_to_flush_tx.try_send(buffer_flush) {
+        self.stats.buffers_to_flush_channel_send_failures.inc();
+        log::debug!("failed to send information about buffers to flush: {e}");
+      } else {
+        self
+          .process_local_pending_flush_state
+          .mark_pending(action.id.clone());
+      }
     }
 
     self.needs_state_persistence = true;


### PR DESCRIPTION
Define as logical successful connections since process start.