### PR TITLE
implement platfrom mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ dependencies = [
  "mockall",
  "parking_lot",
  "protobuf 4.0.0-alpha.0",
+ "static_assertions",
  "tempfile",
  "thiserror 2.0.20",
  "time",

--- a/bd-client-common/Cargo.toml
+++ b/bd-client-common/Cargo.toml
@@ -33,8 +33,9 @@ tokio.workspace             = true
 walkdir.workspace           = true
 
 [dev-dependencies]
-bd-test-helpers.path      = "../bd-test-helpers"
-bd-test-helpers-core.path = "../bd-test-helpers-core"
-ctor.workspace            = true
-tempfile.workspace        = true
-uuid.workspace            = true
+bd-test-helpers.path        = "../bd-test-helpers"
+bd-test-helpers-core.path   = "../bd-test-helpers-core"
+ctor.workspace              = true
+static_assertions.workspace = true
+tempfile.workspace          = true
+uuid.workspace              = true

--- a/bd-client-common/src/lib.rs
+++ b/bd-client-common/src/lib.rs
@@ -23,9 +23,12 @@ pub mod file;
 pub mod file_system;
 pub mod init_lifecycle;
 pub mod payload_conversion;
+pub mod platform_mutex;
 pub mod safe_file_cache;
 pub mod sdk_status;
 pub mod test;
+
+pub use platform_mutex::{PlatformMutex, PlatformMutexGuard};
 
 #[cfg(test)]
 #[ctor::ctor(unsafe)]

--- a/bd-client-common/src/platform_mutex.rs
+++ b/bd-client-common/src/platform_mutex.rs
@@ -1,0 +1,196 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE.polyform file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+//! A synchronous mutex for state that can be accessed by caller-owned threads.
+//!
+//! SDK-owned Tokio tasks should use `parking_lot` directly. Use [`PlatformMutex`] only when a
+//! caller-owned thread can contend with SDK work. On iOS it uses `os_unfair_lock`, which supports
+//! priority inheritance and avoids priority inversion when contending threads have different `QoS`.
+//!
+//! Its guard is intentionally `!Send`. This keeps an iOS unfair lock on its acquiring thread and,
+//! in the SDK's `Send` async APIs, makes holding the guard across an await a compile error.
+
+#[cfg(test)]
+#[path = "./platform_mutex_test.rs"]
+mod tests;
+
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
+
+#[cfg(not(target_os = "ios"))]
+mod implementation {
+  use std::ops::{Deref, DerefMut};
+
+  // TODO(snowp): If ever in the future we decide that we need a mutex that supports priority
+  // inheritance on non-iOS platforms we can consider using a feature to switch this to using
+  // std::sync::Mutex. For now we're defaulting to parking_lot::Mutex as it should be faster in
+  // the common case.
+  pub(super) struct Mutex<T>(parking_lot::Mutex<T>);
+
+  impl<T> Mutex<T> {
+    pub(super) const fn new(value: T) -> Self {
+      Self(parking_lot::Mutex::new(value))
+    }
+
+    pub(super) fn lock(&self) -> MutexGuard<'_, T> {
+      MutexGuard(self.0.lock())
+    }
+  }
+
+  pub(super) struct MutexGuard<'a, T>(parking_lot::MutexGuard<'a, T>);
+
+  impl<T> Deref for MutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+      &self.0
+    }
+  }
+
+  impl<T> DerefMut for MutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+      &mut self.0
+    }
+  }
+}
+
+#[cfg(target_os = "ios")]
+mod implementation {
+  use std::cell::UnsafeCell;
+  use std::ops::{Deref, DerefMut};
+
+  // `os_unfair_lock_s` is intentionally opaque. Apple defines its initialized representation as
+  // all zeroes, which lets it live directly alongside the protected value.
+  #[repr(C)]
+  struct OsUnfairLock {
+    _os_unfair_lock_opaque: u32,
+  }
+
+  unsafe extern "C" {
+    fn os_unfair_lock_lock(lock: *mut OsUnfairLock);
+    fn os_unfair_lock_unlock(lock: *mut OsUnfairLock);
+  }
+
+  pub(super) struct Mutex<T> {
+    lock: UnsafeCell<OsUnfairLock>,
+    value: UnsafeCell<T>,
+  }
+
+  // The lock serializes access to `value`; moving the mutex itself is safe when its value can be
+  // moved between threads.
+  unsafe impl<T: Send> Send for Mutex<T> {}
+  unsafe impl<T: Send> Sync for Mutex<T> {}
+
+  impl<T> Mutex<T> {
+    pub(super) const fn new(value: T) -> Self {
+      Self {
+        lock: UnsafeCell::new(OsUnfairLock {
+          _os_unfair_lock_opaque: 0,
+        }),
+        value: UnsafeCell::new(value),
+      }
+    }
+
+    pub(super) fn lock(&self) -> MutexGuard<'_, T> {
+      // Apple requires the same thread that acquires an unfair lock to release it. The public
+      // guard is non-Send, so it cannot be moved to a different thread before `Drop` unlocks it.
+      unsafe {
+        os_unfair_lock_lock(self.lock.get());
+      }
+      MutexGuard { mutex: self }
+    }
+  }
+
+  pub(super) struct MutexGuard<'a, T> {
+    mutex: &'a Mutex<T>,
+  }
+
+  impl<T> Deref for MutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+      // The guard proves this thread holds the lock for the duration of the reference.
+      unsafe { &*self.mutex.value.get() }
+    }
+  }
+
+  impl<T> DerefMut for MutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+      // The guard provides exclusive access until it is dropped.
+      unsafe { &mut *self.mutex.value.get() }
+    }
+  }
+
+  impl<T> Drop for MutexGuard<'_, T> {
+    fn drop(&mut self) {
+      unsafe {
+        os_unfair_lock_unlock(self.mutex.lock.get());
+      }
+    }
+  }
+}
+
+//
+// PlatformMutex
+//
+
+/// A mutex for state that can be contended by caller-owned threads.
+///
+/// SDK-owned Tokio tasks should use `parking_lot` directly. On iOS this uses `os_unfair_lock` so
+/// a higher-QoS caller thread does not experience priority inversion while waiting on SDK work.
+/// The returned guard is `!Send`, enforcing same-thread unlock and preventing it from crossing an
+/// await in the SDK's `Send` async APIs.
+pub struct PlatformMutex<T> {
+  inner: implementation::Mutex<T>,
+}
+
+impl<T> PlatformMutex<T> {
+  #[must_use]
+  pub const fn new(value: T) -> Self {
+    Self {
+      inner: implementation::Mutex::new(value),
+    }
+  }
+
+  /// Acquires the mutex on the calling thread.
+  pub fn lock(&self) -> PlatformMutexGuard<'_, T> {
+    PlatformMutexGuard {
+      inner: self.inner.lock(),
+      // Keep guards on the acquiring thread so an iOS unfair lock is always released by its
+      // owner.
+      _not_send: PhantomData,
+    }
+  }
+}
+
+//
+// PlatformMutexGuard
+//
+
+/// An RAII guard returned by [`PlatformMutex::lock`].
+///
+/// This guard is intentionally non-`Send`. On iOS, that ensures the acquiring thread unlocks the
+/// unfair lock. It also cannot be retained across an await in the SDK's `Send` async APIs.
+pub struct PlatformMutexGuard<'a, T> {
+  inner: implementation::MutexGuard<'a, T>,
+  _not_send: PhantomData<Rc<()>>,
+}
+
+impl<T> Deref for PlatformMutexGuard<'_, T> {
+  type Target = T;
+
+  fn deref(&self) -> &Self::Target {
+    &self.inner
+  }
+}
+
+impl<T> DerefMut for PlatformMutexGuard<'_, T> {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.inner
+  }
+}

--- a/bd-client-common/src/platform_mutex_test.rs
+++ b/bd-client-common/src/platform_mutex_test.rs
@@ -1,0 +1,12 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE.polyform file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use super::PlatformMutexGuard;
+use static_assertions::assert_not_impl_any;
+
+// The iOS implementation must unlock on the thread that acquired the unfair lock.
+assert_not_impl_any!(PlatformMutexGuard<'static, ()>: Send);

--- a/bd-session/Cargo.toml
+++ b/bd-session/Cargo.toml
@@ -17,7 +17,6 @@ bd-proto-util.path          = "../bd-proto-util"
 bd-time.path                = "../bd-time"
 bd-workspace-hack.workspace = true
 log.workspace               = true
-parking_lot.workspace       = true
 protobuf.workspace          = true
 thread_local.workspace      = true
 time.workspace              = true
@@ -28,5 +27,6 @@ uuid.workspace              = true
 bd-test-helpers             = { path = "../bd-test-helpers", default-features = false }
 bd-test-helpers-core.path   = "../bd-test-helpers-core"
 ctor.workspace              = true
+parking_lot.workspace       = true
 pretty_assertions.workspace = true
 tempfile.workspace          = true

--- a/bd-session/src/lib.rs
+++ b/bd-session/src/lib.rs
@@ -40,6 +40,7 @@ fn test_global_init() {
   bd_test_helpers_core::test_global_init();
 }
 
+use bd_client_common::{PlatformMutex, PlatformMutexGuard};
 use bd_proto::protos::client::api::StateUpdateRequest;
 use bd_proto::protos::client::api::state_update_request::StartedSession;
 use bd_time::{OffsetDateTimeExt as _, TimeProvider};
@@ -263,7 +264,7 @@ impl BackendState {
 pub struct Strategy {
   backend: Backend,
   store: Store,
-  state: parking_lot::Mutex<Option<LoadedState>>,
+  state: PlatformMutex<Option<LoadedState>>,
   update_tx: watch::Sender<u64>,
   callback_in_progress: Box<ThreadLocal<Cell<bool>>>,
 }
@@ -275,7 +276,7 @@ impl Strategy {
     Self {
       backend: Backend::Fixed(fixed::Strategy::new(callbacks)),
       store: Store::new(sdk_directory),
-      state: parking_lot::Mutex::new(None),
+      state: PlatformMutex::new(None),
       update_tx,
       callback_in_progress: Box::new(ThreadLocal::new()),
     }
@@ -296,7 +297,7 @@ impl Strategy {
         time_provider,
       )),
       store: Store::new(sdk_directory),
-      state: parking_lot::Mutex::new(None),
+      state: PlatformMutex::new(None),
       update_tx,
       callback_in_progress: Box::new(ThreadLocal::new()),
     }
@@ -672,7 +673,7 @@ impl Strategy {
 
   fn start_new_session_locked(
     &self,
-    guard: &mut parking_lot::MutexGuard<'_, Option<LoadedState>>,
+    guard: &mut PlatformMutexGuard<'_, Option<LoadedState>>,
   ) -> (LoadedState, Mutation) {
     // Explicit session rotation re-reads persisted state so the durable queue remains the source
     // of truth even if this process has not initialized the in-memory cache yet.


### PR DESCRIPTION
This implements a mutex abstraction that should be preferred when called directly via platform APIs.
It allows us to use os_unfair_lock on iOS which is the preferred mutex type that will provide priority inheritance.

Fixes BIT-9594