### PR TITLE
bd-session: move towards best effort persistence

### DIFF
--- a/bd-api/src/api.rs
+++ b/bd-api/src/api.rs
@@ -920,8 +920,7 @@ impl Api {
         self.connection_count_since_process_start += 1;
         self
           .session_strategy
-          .acknowledge_state_update(&handshake_state_update)
-          .await;
+          .acknowledge_state_update(&handshake_state_update);
         self.apply_client_state_updates(&client_state_updates).await;
         stream_state.initialize_stream_settings(stream_settings);
 
@@ -1036,7 +1035,7 @@ impl Api {
         }
         _ = self.session_updates.changed(), if in_flight_state_update.is_none() => {
           let _ = self.session_updates.borrow_and_update();
-          let Some(session_update) = self.session_strategy.pending_state_update().await else {
+          let Some(session_update) = self.session_strategy.pending_state_update() else {
             continue;
           };
           stream_state.send_request(session_update.request().clone()).await?;
@@ -1201,7 +1200,6 @@ impl Api {
           let session_id = self
             .session_strategy
             .session_id()
-            .await
             .map_err(|_| anyhow!("remote trigger upload session id"))?;
 
           self
@@ -1288,8 +1286,7 @@ impl Api {
           {
             self
               .session_strategy
-              .acknowledge_state_update(&session_update)
-              .await;
+              .acknowledge_state_update(&session_update);
           }
         },
         None => {
@@ -1312,7 +1309,7 @@ impl Api {
     Option<TrackedStatsUploadRequest>,
   ) {
     let opaque_client_state = tokio::fs::read(&self.opaque_client_state_path()).await.ok();
-    let session_update = self.session_strategy.handshake_state_update().await;
+    let session_update = self.session_strategy.handshake_state_update();
     let mut handshake = HandshakeRequest {
       static_device_metadata: metadata.clone(),
       previous_disconnect_reason: previous_disconnect_reason.unwrap_or_default(),

--- a/bd-api/src/api_test.rs
+++ b/bd-api/src/api_test.rs
@@ -55,7 +55,6 @@ use bd_proto::protos::logging::payload::LogType;
 use bd_proto::protos::logging::payload::data::Data_type;
 use bd_proto::protos::workflow::workflow::workflow::action::action_flush_buffers;
 use bd_runtime::runtime::{ConfigLoader, FeatureFlag};
-use bd_session::test::start_new_session;
 use bd_state::StateReader;
 use bd_stats_common::labels;
 use bd_test_helpers::make_mut;
@@ -317,10 +316,11 @@ impl Setup {
       &runtime_loader,
       &collector.scope("state"),
     );
-    let session_strategy = Arc::new(bd_session::Strategy::fixed(
+    let session_parts = bd_session::Strategy::fixed(
       sdk_directory.path(),
       Arc::new(bd_session::fixed::UUIDCallbacks),
-    ));
+    );
+    let session_strategy = session_parts.strategy;
     let mut api = Api::new(
       sdk_directory.path().to_path_buf(),
       api_key.clone(),
@@ -2051,7 +2051,7 @@ async fn session_state_update_is_resent_until_acked() {
     .await;
   setup.wait_for_cleared_pending_session_update().await;
 
-  start_new_session(&setup.session_strategy).await;
+  setup.session_strategy.start_new_session().unwrap();
   let next_session_id = setup.session_strategy.session_id().await.unwrap();
 
   let request = setup.next_request(1.seconds()).await.unwrap();

--- a/bd-api/src/api_test.rs
+++ b/bd-api/src/api_test.rs
@@ -320,7 +320,7 @@ impl Setup {
       sdk_directory.path(),
       Arc::new(bd_session::fixed::UUIDCallbacks),
     );
-    let session_strategy = session_parts.strategy;
+    let session_strategy = session_parts.strategy();
     let mut api = Api::new(
       sdk_directory.path().to_path_buf(),
       api_key.clone(),
@@ -562,7 +562,7 @@ impl Setup {
     // Response injection only guarantees the frame is enqueued to the API task. Tests that depend
     // on session-state side effects need to wait until the strategy queue reflects the ack.
     for _ in 0 .. 100 {
-      if self.session_strategy.pending_state_update().await.is_none() {
+      if self.session_strategy.pending_state_update().is_none() {
         return;
       }
 
@@ -1945,7 +1945,7 @@ async fn handshake_includes_opaque_entity_and_current_session() {
   );
   assert_eq!(1, state_update.started_sessions.len());
   assert_eq!(
-    setup.session_strategy.session_id().await.unwrap(),
+    setup.session_strategy.session_id().unwrap(),
     state_update.started_sessions[0].session_id
   );
 }
@@ -2052,7 +2052,7 @@ async fn session_state_update_is_resent_until_acked() {
   setup.wait_for_cleared_pending_session_update().await;
 
   setup.session_strategy.start_new_session().unwrap();
-  let next_session_id = setup.session_strategy.session_id().await.unwrap();
+  let next_session_id = setup.session_strategy.session_id().unwrap();
 
   let request = setup.next_request(1.seconds()).await.unwrap();
   let Some(Request_type::StateUpdate(state_update)) = request.request_type else {

--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -501,7 +501,7 @@ impl Monitor {
 
   async fn get_session_id(&self, origin: ReportOrigin) -> anyhow::Result<String> {
     match origin {
-      ReportOrigin::Current => self.session.session_id().await,
+      ReportOrigin::Current => self.session.session_id(),
       ReportOrigin::Previous => Ok(
         self
           .session

--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -499,7 +499,7 @@ impl Monitor {
     }
   }
 
-  async fn get_session_id(&self, origin: ReportOrigin) -> anyhow::Result<String> {
+  fn get_session_id(&self, origin: ReportOrigin) -> anyhow::Result<String> {
     match origin {
       ReportOrigin::Current => self.session.session_id(),
       ReportOrigin::Previous => Ok(
@@ -588,7 +588,6 @@ impl Monitor {
     let global_state_fields = self.get_global_state_fields(origin);
     let session_id = self
       .get_session_id(origin)
-      .await
       .unwrap_or_else(|_| "unknown".to_string());
     let (timestamp, mut state_fields) = Self::read_log_fields(bin_report, &global_state_fields);
     state_fields.extend(self.get_memory_pressure_fields(origin));

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -257,13 +257,17 @@ impl Setup {
 
     // Set up the session to return a fixed previous session ID, making it obvious that we are
     // using the previous session ID for uploads.
-    let mut session = bd_session::Strategy::fixed(
+    let bd_session::StrategyParts {
+      strategy: session,
+      persistence_worker: worker,
+    } = bd_session::Strategy::fixed(
       directory.path(),
       Arc::new(StaticSession("previous_session_id".into())),
     );
     assert_eq!(session.session_id().await.unwrap(), "previous_session_id");
+    bd_session::test::flush(session.clone(), worker).await;
 
-    session = bd_session::Strategy::fixed(directory.path(), Arc::new(UUIDCallbacks));
+    let session = bd_session::Strategy::fixed(directory.path(), Arc::new(UUIDCallbacks)).strategy;
 
     let (tx, rx) = tokio::sync::mpsc::channel(10);
     let emit_log =
@@ -319,7 +323,7 @@ impl Setup {
       directory.path(),
       store,
       upload_client.clone(),
-      Arc::new(session),
+      session,
       &InitLifecycleState::new(),
       (*state).clone(),
       previous_run_state,

--- a/bd-crash-handler/src/monitor_test.rs
+++ b/bd-crash-handler/src/monitor_test.rs
@@ -257,17 +257,15 @@ impl Setup {
 
     // Set up the session to return a fixed previous session ID, making it obvious that we are
     // using the previous session ID for uploads.
-    let bd_session::StrategyParts {
-      strategy: session,
-      persistence_worker: worker,
-    } = bd_session::Strategy::fixed(
+    let (session, worker) = bd_session::Strategy::fixed(
       directory.path(),
       Arc::new(StaticSession("previous_session_id".into())),
-    );
-    assert_eq!(session.session_id().await.unwrap(), "previous_session_id");
+    )
+    .into_parts();
+    assert_eq!(session.session_id().unwrap(), "previous_session_id");
     bd_session::test::flush(session.clone(), worker).await;
 
-    let session = bd_session::Strategy::fixed(directory.path(), Arc::new(UUIDCallbacks)).strategy;
+    let session = bd_session::Strategy::fixed(directory.path(), Arc::new(UUIDCallbacks)).strategy();
 
     let (tx, rx) = tokio::sync::mpsc::channel(10);
     let emit_log =
@@ -700,7 +698,7 @@ async fn file_watcher_detects_current_session_report() {
     ]
     .into(),
     crash_timestamp.into(),
-    setup.monitor.session.session_id().await.unwrap().as_str(),
+    setup.monitor.session.session_id().unwrap().as_str(),
     Some(vec![
       ("initial_flag".to_string(), "true".to_string()),
       ("previous_only_flag".to_string(), "enabled".to_string()),
@@ -1099,7 +1097,7 @@ async fn current_session_crash_uses_current_feature_flags() {
     ]
     .into(),
     crash_timestamp.into(),
-    setup.monitor.session.session_id().await.unwrap().as_str(),
+    setup.monitor.session.session_id().unwrap().as_str(),
     Some(vec![
       ("initial_flag".to_string(), "updated".to_string()),
       ("current_only_flag".to_string(), "new".to_string()),

--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -25,7 +25,6 @@ use bd_buffer::BuffersWithAck;
 use bd_client_common::init_lifecycle::{InitLifecycle, InitLifecycleState};
 use bd_client_common::{maybe_await, maybe_await_map};
 use bd_client_stats::FlushTriggerRequest;
-use bd_client_stats_store::Counter;
 use bd_crash_handler::global_state;
 use bd_device::Store;
 use bd_log_metadata::MetadataProvider;
@@ -59,7 +58,6 @@ use bd_state::{
   Scope,
   string_value,
 };
-use bd_stats_common::Counter as _;
 use bd_time::{OffsetDateTimeExt, TimeDurationExt, TimeProvider};
 use bd_workflow_stats::workflow::{WorkflowDebugStateKey, WorkflowDebugTransitionType};
 use bd_workflows::workflow::WorkflowDebugStateMap;
@@ -338,8 +336,6 @@ pub struct AsyncLogBuffer<R: LogReplay> {
   time_provider: Arc<dyn TimeProvider>,
   lifecycle_state: InitLifecycleState,
   sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
-  session_persistence_failures: Counter,
-
   pending_workflow_debug_state: HashMap<String, WorkflowDebugStateMap>,
   send_workflow_debug_state_delay: Option<Pin<Box<Sleep>>>,
   last_session_id: Option<String>,
@@ -367,10 +363,6 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
     sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
     data_upload_tx: mpsc::Sender<DataUpload>,
   ) -> (Self, Sender) {
-    let session_persistence_failures = uninitialized_logging_context
-      .stats
-      .scope
-      .counter("session_persistence_failures");
     let (log_tx, log_rx) = channel(
       uninitialized_logging_context
         .pre_config_log_buffer
@@ -452,8 +444,6 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
         time_provider,
         lifecycle_state,
         sdk_status_tracker,
-        session_persistence_failures,
-
         pending_workflow_debug_state: HashMap::new(),
         send_workflow_debug_state_delay: None,
         last_session_id: None,
@@ -889,24 +879,6 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
     // stored in pre-config log buffer are guaranteed to be replayed before
     // the async log buffer goes back to processing incoming logs.
 
-    let session_strategy = self.session_strategy.clone();
-    let session_persistence_failures = self.session_persistence_failures.clone();
-    let mut session_flusher_local_shutdown = shutdown.clone();
-    let mut session_flusher_self_shutdown = self.shutdown_trigger_handle.make_shutdown();
-    let session_flusher = tokio::spawn(async move {
-      session_strategy
-        .run_persistence_flusher(
-          async move {
-            tokio::select! {
-              () = session_flusher_local_shutdown.cancelled() => {},
-              () = session_flusher_self_shutdown.cancelled() => {},
-            }
-          },
-          move || session_persistence_failures.inc(),
-        )
-        .await;
-    });
-
     let local_shutdown = shutdown.cancelled();
     tokio::pin!(local_shutdown);
     let mut self_shutdown = self.shutdown_trigger_handle.make_shutdown();
@@ -1156,12 +1128,6 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
         () = &mut local_shutdown => break,
         () = &mut self_shutdown => break,
       }
-    }
-
-    // The session flusher observes both run-loop shutdown paths. Await it here so a blocking
-    // logger shutdown includes the final coalesced session write.
-    if let Err(e) = session_flusher.await {
-      log::warn!("session persistence flusher terminated unexpectedly: {e}");
     }
 
     self

--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -25,6 +25,7 @@ use bd_buffer::BuffersWithAck;
 use bd_client_common::init_lifecycle::{InitLifecycle, InitLifecycleState};
 use bd_client_common::{maybe_await, maybe_await_map};
 use bd_client_stats::FlushTriggerRequest;
+use bd_client_stats_store::Counter;
 use bd_crash_handler::global_state;
 use bd_device::Store;
 use bd_log_metadata::MetadataProvider;
@@ -49,7 +50,6 @@ use bd_proto::protos::client::api::debug_data_request::{
 use bd_proto::protos::client::api::{DebugDataRequest, debug_data_request};
 use bd_proto::protos::logging::payload::LogType;
 use bd_runtime::runtime::ConfigLoader;
-use bd_session::{PreparedSessionCallback, PreparedSessionOperation};
 use bd_session_replay::CaptureScreenshotHandler;
 use bd_shutdown::{ComponentShutdown, ComponentShutdownTrigger, ComponentShutdownTriggerHandle};
 use bd_state::{
@@ -59,6 +59,7 @@ use bd_state::{
   Scope,
   string_value,
 };
+use bd_stats_common::Counter as _;
 use bd_time::{OffsetDateTimeExt, TimeDurationExt, TimeProvider};
 use bd_workflow_stats::workflow::{WorkflowDebugStateKey, WorkflowDebugTransitionType};
 use bd_workflows::workflow::WorkflowDebugStateMap;
@@ -68,15 +69,10 @@ use std::mem::size_of_val;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration as StdDuration;
 use time::OffsetDateTime;
 use time::ext::NumericalDuration;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Sleep;
-
-// Synchronous callers may invoke these bridges from latency-sensitive threads, so keep the
-// timeout well below ANR territory if the async logger task stalls.
-pub const SESSION_BRIDGE_TIMEOUT: StdDuration = StdDuration::from_secs(1);
 
 //
 // ReportProcessor
@@ -104,14 +100,8 @@ pub enum StateUpdateMessage {
   AddLogField(String, DataValue),
   RemoveLogField(String),
   SetFeatureFlagExposure(String, Option<String>),
-  SetMemoryPressureLevel {
-    level: MemoryPressureLevel,
-  },
+  SetMemoryPressureLevel { level: MemoryPressureLevel },
   SetEntityId(Option<String>),
-  PersistPreparedSession(
-    PreparedSessionOperation,
-    bd_completion::Sender<PreparedSessionCallback>,
-  ),
   FlushState(Option<bd_completion::Sender<()>>),
 }
 
@@ -126,9 +116,6 @@ impl MemorySized for StateUpdateMessage {
         },
         Self::SetMemoryPressureLevel { .. } => 0,
         Self::SetEntityId(entity_id) => entity_id.as_ref().map_or(0, String::len),
-        Self::PersistPreparedSession(operation, response_tx) => {
-          operation.estimated_size() + size_of_val(response_tx)
-        },
         Self::FlushState(sender) => size_of_val(sender),
       }
   }
@@ -316,22 +303,6 @@ impl Sender {
     }
     Ok(())
   }
-
-  pub fn persist_prepared_session(
-    &self,
-    prepared: PreparedSessionOperation,
-    timeout: StdDuration,
-  ) -> anyhow::Result<PreparedSessionCallback> {
-    let (response_tx, response_rx) = bd_completion::Sender::new();
-    self.try_send_state_update(StateUpdateMessage::PersistPreparedSession(
-      prepared,
-      response_tx,
-    ))?;
-
-    response_rx
-      .blocking_recv_with_timeout(timeout)
-      .map_err(|e| anyhow!("failed to receive prepared session ack from async logger: {e}"))
-  }
 }
 
 pub type AsyncLogBufferOrderedReceiver = OrderedReceiver<EmitLogMessage, StateUpdateMessage>;
@@ -367,6 +338,7 @@ pub struct AsyncLogBuffer<R: LogReplay> {
   time_provider: Arc<dyn TimeProvider>,
   lifecycle_state: InitLifecycleState,
   sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
+  session_persistence_failures: Counter,
 
   pending_workflow_debug_state: HashMap<String, WorkflowDebugStateMap>,
   send_workflow_debug_state_delay: Option<Pin<Box<Sleep>>>,
@@ -395,6 +367,10 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
     sdk_status_tracker: bd_client_common::sdk_status::SdkStatusTracker,
     data_upload_tx: mpsc::Sender<DataUpload>,
   ) -> (Self, Sender) {
+    let session_persistence_failures = uninitialized_logging_context
+      .stats
+      .scope
+      .counter("session_persistence_failures");
     let (log_tx, log_rx) = channel(
       uninitialized_logging_context
         .pre_config_log_buffer
@@ -476,6 +452,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
         time_provider,
         lifecycle_state,
         sdk_status_tracker,
+        session_persistence_failures,
 
         pending_workflow_debug_state: HashMap::new(),
         send_workflow_debug_state_delay: None,
@@ -912,6 +889,24 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
     // stored in pre-config log buffer are guaranteed to be replayed before
     // the async log buffer goes back to processing incoming logs.
 
+    let session_strategy = self.session_strategy.clone();
+    let session_persistence_failures = self.session_persistence_failures.clone();
+    let mut session_flusher_local_shutdown = shutdown.clone();
+    let mut session_flusher_self_shutdown = self.shutdown_trigger_handle.make_shutdown();
+    let session_flusher = tokio::spawn(async move {
+      session_strategy
+        .run_persistence_flusher(
+          async move {
+            tokio::select! {
+              () = session_flusher_local_shutdown.cancelled() => {},
+              () = session_flusher_self_shutdown.cancelled() => {},
+            }
+          },
+          move || session_persistence_failures.inc(),
+        )
+        .await;
+    });
+
     let local_shutdown = shutdown.cancelled();
     tokio::pin!(local_shutdown);
     let mut self_shutdown = self.shutdown_trigger_handle.make_shutdown();
@@ -1096,14 +1091,6 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
                     log::debug!("failed to persist entity ID state: {e}");
                   }
                 },
-                StateUpdateMessage::PersistPreparedSession(prepared, response_tx) => {
-                  let callback = self.session_strategy.persist_prepared(prepared).await;
-                  // TODO: If the synchronous caller has already timed out or dropped its receiver,
-                  // this callback token is lost. Fixing that requires a recoverable completion
-                  // path or a deliberate fallback that does not reintroduce cross-thread callback
-                  // execution and the deadlock risk this change set is avoiding.
-                  response_tx.send(callback);
-                },
                 StateUpdateMessage::FlushState(completion_tx) => {
                   let flush_stats_trigger = self.logging_state.flush_stats_trigger().clone();
                   let flush_stats = async move {
@@ -1137,8 +1124,13 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
                   };
 
                   let session_strategy = self.session_strategy.clone();
+                  let session_persistence_failures = self.session_persistence_failures.clone();
                   let flush_session = async {
-                    session_strategy.flush().await;
+                    session_strategy
+                      .flush_with_persistence_failure_callback(move || {
+                        session_persistence_failures.inc();
+                      })
+                      .await;
                   };
 
                   let persist_workflows = async {
@@ -1169,14 +1161,18 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
         () = self.resource_utilization_reporter.run() => {},
         () = self.session_replay_recorder.run() => {},
         () = self.events_listener.run() => {},
-        () = &mut local_shutdown => {
-          return self;
-        },
-        () = &mut self_shutdown => {
-          return self;
-        },
+        () = &mut local_shutdown => break,
+        () = &mut self_shutdown => break,
       }
     }
+
+    // The session flusher observes both run-loop shutdown paths. Await it here so a blocking
+    // logger shutdown includes the final coalesced session write.
+    if let Err(e) = session_flusher.await {
+      log::warn!("session persistence flusher terminated unexpectedly: {e}");
+    }
+
+    self
   }
 
   async fn send_debug_data(&mut self) {

--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -635,7 +635,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
             // Use the previous session ID if available and the provided timestamp.
             let session_id = match self.session_strategy.previous_process_session_id() {
               Some(session_id) => session_id,
-              None => self.session_strategy.session_id().await?,
+              None => self.session_strategy.session_id()?,
             };
             (
               session_id,
@@ -649,7 +649,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
           Some(LogAttributesOverrides::OccurredAt(overridden_timestamp)) => {
             // Occurred at override provided. Emit log with overrides applied.
             (
-              self.session_strategy.session_id().await?,
+              self.session_strategy.session_id()?,
               overridden_timestamp,
               Some(LogFields::from([(
                 "_logged_at".into(),
@@ -660,7 +660,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
           None => {
             // No overrides provided. Emit log without any overrides.
             (
-              self.session_strategy.session_id().await?,
+              self.session_strategy.session_id()?,
               metadata.timestamp,
               None,
             )
@@ -983,7 +983,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
                   self.metadata_collector.remove_field(&field_name);
                 },
                 StateUpdateMessage::SetFeatureFlagExposure(flag, variant) => {
-                  let session_id = match self.session_strategy.session_id().await {
+                  let session_id = match self.session_strategy.session_id() {
                     Ok(session_id) => session_id,
                     Err(e) => {
                       log::debug!(

--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -1123,15 +1123,7 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
                     }
                   };
 
-                  let session_strategy = self.session_strategy.clone();
-                  let session_persistence_failures = self.session_persistence_failures.clone();
-                  let flush_session = async {
-                    session_strategy
-                      .flush_with_persistence_failure_callback(move || {
-                        session_persistence_failures.inc();
-                      })
-                      .await;
-                  };
+                  let flush_session = self.session_strategy.flush();
 
                   let persist_workflows = async {
                     if let Some(workflows_engine) = self.logging_state.workflows_engine() {

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -87,7 +87,7 @@ impl Setup {
     let collector = Collector::default();
     let stats = Stats::new(collector.clone());
     let (data_upload_tx, data_upload_rx) = mpsc::channel(1);
-    let session_strategy = Strategy::fixed(tmp_dir.path(), Arc::new(UUIDCallbacks)).strategy;
+    let session_strategy = Strategy::fixed(tmp_dir.path(), Arc::new(UUIDCallbacks)).strategy();
 
     Self {
       buffer_manager: bd_buffer::Manager::new(
@@ -743,7 +743,7 @@ async fn updates_system_session_id_for_new_sessions() {
   let handle =
     tokio::task::spawn(buffer.run_with_shutdown(state_store, (), shutdown_trigger.make_shutdown()));
 
-  let first_session_id = setup.session_strategy.session_id().await.unwrap();
+  let first_session_id = setup.session_strategy.session_id().unwrap();
   assert_ok!(AsyncLogBuffer::<TestReplay>::enqueue_log(
     &sender,
     0,
@@ -757,7 +757,7 @@ async fn updates_system_session_id_for_new_sessions() {
   ));
 
   setup.session_strategy.start_new_session().unwrap();
-  let second_session_id = setup.session_strategy.session_id().await.unwrap();
+  let second_session_id = setup.session_strategy.session_id().unwrap();
   assert_ne!(first_session_id, second_session_id);
 
   assert_ok!(AsyncLogBuffer::<TestReplay>::enqueue_log(
@@ -855,7 +855,7 @@ async fn previous_run_log_does_not_override_system_session_id() {
   let handle =
     tokio::task::spawn(buffer.run_with_shutdown(state_store, (), shutdown_trigger.make_shutdown()));
 
-  let current_session_id = setup.session_strategy.session_id().await.unwrap();
+  let current_session_id = setup.session_strategy.session_id().unwrap();
   assert_ok!(AsyncLogBuffer::<TestReplay>::enqueue_log(
     &sender,
     0,
@@ -869,7 +869,7 @@ async fn previous_run_log_does_not_override_system_session_id() {
   ));
 
   setup.session_strategy.start_new_session().unwrap();
-  let next_session_id = setup.session_strategy.session_id().await.unwrap();
+  let next_session_id = setup.session_strategy.session_id().unwrap();
   assert_ne!(current_session_id, next_session_id);
 
   let log = LogLine {
@@ -914,7 +914,7 @@ async fn pre_config_logs_trigger_session_id_update() {
   let state_store = (*test_store).clone();
   let shutdown_trigger = ComponentShutdownTrigger::default();
 
-  let first_session_id = setup.session_strategy.session_id().await.unwrap();
+  let first_session_id = setup.session_strategy.session_id().unwrap();
   assert_ok!(AsyncLogBuffer::<TestReplay>::enqueue_log(
     &sender,
     0,
@@ -928,7 +928,7 @@ async fn pre_config_logs_trigger_session_id_update() {
   ));
 
   setup.session_strategy.start_new_session().unwrap();
-  let second_session_id = setup.session_strategy.session_id().await.unwrap();
+  let second_session_id = setup.session_strategy.session_id().unwrap();
   assert_ne!(first_session_id, second_session_id);
 
   assert_ok!(AsyncLogBuffer::<TestReplay>::enqueue_log(

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -59,7 +59,6 @@ use bd_workflows::engine::ProcessLocalPendingFlushState;
 use bd_workflows::test::MakeConfig;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration as StdDuration;
 use time::OffsetDateTime;
 use time::ext::{NumericalDuration, NumericalStdDuration};
 use tokio::sync::mpsc;
@@ -226,25 +225,6 @@ impl Setup {
   fn make_runtime(tmp_dir: &Arc<tempfile::TempDir>) -> std::sync::Arc<ConfigLoader> {
     ConfigLoader::new(tmp_dir.path())
   }
-}
-
-#[test]
-fn persist_prepared_session_times_out_when_async_logger_is_stalled() {
-  let (log_tx, _log_rx) = bd_bounded_buffer::channel(1024 * 1024);
-  let (state_tx, _state_rx) = bd_bounded_buffer::channel(1024 * 1024);
-  let sender = Sender::from_parts(log_tx, state_tx);
-  let sdk_directory = tempfile::TempDir::new().unwrap();
-  let strategy = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
-  let prepared = strategy.prepare_session_id().unwrap();
-
-  let error = sender
-    .persist_prepared_session(prepared, StdDuration::from_millis(20))
-    .unwrap_err();
-
-  assert_eq!(
-    "failed to receive prepared session ack from async logger: timeout duration reached",
-    error.to_string()
-  );
 }
 
 struct TestReplay {
@@ -595,6 +575,34 @@ async fn creates_workflows_engine_in_response_to_config_update() {
   drop(test_store);
 
   assert!(buffer.logging_state.workflows_engine().is_some());
+}
+
+#[tokio::test]
+async fn self_shutdown_awaits_session_persistence_flusher() {
+  let mut setup = Setup::new();
+  let strategy = setup.session_strategy.clone();
+  let (_config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
+  let (buffer, _sender) = setup.make_test_async_log_buffer(config_update_rx);
+  let state_store = TestStore::new().await;
+  let run_shutdown = ComponentShutdownTrigger::default();
+  let buffer_task = tokio::spawn(buffer.run_with_shutdown(
+    state_store.take_inner(),
+    (),
+    run_shutdown.make_shutdown(),
+  ));
+
+  // Let the run loop create its flusher before scheduling the session mutation.
+  tokio::task::yield_now().await;
+  strategy.session_id().await.unwrap();
+
+  // Keep `run_shutdown` alive: the buffer's own shutdown path must independently stop and await
+  // the flusher rather than leaving it attached to this unrelated shutdown receiver.
+  setup.shutdown.take().unwrap().shutdown().await;
+  drop(buffer_task.await.unwrap());
+
+  // `setup` and this local clone are the only remaining strategy owners. A detached flusher would
+  // retain a third reference after the buffer's run loop returned.
+  assert_eq!(2, Arc::strong_count(&strategy));
 }
 
 #[tokio::test]

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -41,7 +41,6 @@ use bd_proto::protos::logging::payload::LogType;
 use bd_runtime::runtime::{ConfigLoader, FeatureFlag};
 use bd_session::Strategy;
 use bd_session::fixed::UUIDCallbacks;
-use bd_session::test::start_new_session;
 use bd_shutdown::ComponentShutdownTrigger;
 use bd_state::test::TestStore;
 use bd_state::{MEMORY_PRESSURE_LEVEL_KEY, SYSTEM_SESSION_ID_KEY, Scope, StateReader};
@@ -88,7 +87,7 @@ impl Setup {
     let collector = Collector::default();
     let stats = Stats::new(collector.clone());
     let (data_upload_tx, data_upload_rx) = mpsc::channel(1);
-    let session_strategy = Arc::new(Strategy::fixed(tmp_dir.path(), Arc::new(UUIDCallbacks)));
+    let session_strategy = Strategy::fixed(tmp_dir.path(), Arc::new(UUIDCallbacks)).strategy;
 
     Self {
       buffer_manager: bd_buffer::Manager::new(
@@ -578,34 +577,6 @@ async fn creates_workflows_engine_in_response_to_config_update() {
 }
 
 #[tokio::test]
-async fn self_shutdown_awaits_session_persistence_flusher() {
-  let mut setup = Setup::new();
-  let strategy = setup.session_strategy.clone();
-  let (_config_update_tx, config_update_rx) = tokio::sync::mpsc::channel(1);
-  let (buffer, _sender) = setup.make_test_async_log_buffer(config_update_rx);
-  let state_store = TestStore::new().await;
-  let run_shutdown = ComponentShutdownTrigger::default();
-  let buffer_task = tokio::spawn(buffer.run_with_shutdown(
-    state_store.take_inner(),
-    (),
-    run_shutdown.make_shutdown(),
-  ));
-
-  // Let the run loop create its flusher before scheduling the session mutation.
-  tokio::task::yield_now().await;
-  strategy.session_id().await.unwrap();
-
-  // Keep `run_shutdown` alive: the buffer's own shutdown path must independently stop and await
-  // the flusher rather than leaving it attached to this unrelated shutdown receiver.
-  setup.shutdown.take().unwrap().shutdown().await;
-  drop(buffer_task.await.unwrap());
-
-  // `setup` and this local clone are the only remaining strategy owners. A detached flusher would
-  // retain a third reference after the buffer's run loop returned.
-  assert_eq!(2, Arc::strong_count(&strategy));
-}
-
-#[tokio::test]
 async fn updates_workflow_engine_in_response_to_config_update() {
   let setup = Setup::new();
 
@@ -785,7 +756,7 @@ async fn updates_system_session_id_for_new_sessions() {
     None,
   ));
 
-  start_new_session(&setup.session_strategy).await;
+  setup.session_strategy.start_new_session().unwrap();
   let second_session_id = setup.session_strategy.session_id().await.unwrap();
   assert_ne!(first_session_id, second_session_id);
 
@@ -897,7 +868,7 @@ async fn previous_run_log_does_not_override_system_session_id() {
     None,
   ));
 
-  start_new_session(&setup.session_strategy).await;
+  setup.session_strategy.start_new_session().unwrap();
   let next_session_id = setup.session_strategy.session_id().await.unwrap();
   assert_ne!(current_session_id, next_session_id);
 
@@ -956,7 +927,7 @@ async fn pre_config_logs_trigger_session_id_update() {
     None,
   ));
 
-  start_new_session(&setup.session_strategy).await;
+  setup.session_strategy.start_new_session().unwrap();
   let second_session_id = setup.session_strategy.session_id().await.unwrap();
   assert_ne!(first_session_id, second_session_id);
 

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -54,6 +54,7 @@ use bd_state::{
   Value_type,
   string_value,
 };
+use bd_stats_common::Counter as _;
 use bd_time::{SystemTimeProvider, Ticker, TimeProvider};
 use bd_workflows::engine::ProcessLocalPendingFlushState;
 use futures_util::{Future, try_join};
@@ -270,6 +271,10 @@ impl LoggerBuilder {
       "bitdrift Capture SDK: {:?}",
       self.params.static_metadata.sdk_version()
     );
+    let bd_session::StrategyParts {
+      strategy: session_strategy,
+      persistence_worker: session_persistence_worker,
+    } = self.params.session;
 
     let init_lifecycle = InitLifecycleState::new();
 
@@ -295,6 +300,7 @@ impl LoggerBuilder {
     let collector = Collector::new(Some(max_dynamic_stats));
 
     let scope = collector.scope("");
+    let session_persistence_failures = scope.counter("session_persistence_failures");
     let stats = bd_client_stats::Stats::new(collector.clone());
     let (sleep_mode_active_tx, sleep_mode_active_rx) =
       watch::channel(self.params.start_in_sleep_mode);
@@ -362,7 +368,7 @@ impl LoggerBuilder {
         process_local_pending_flush_state.clone(),
       ),
       LoggerReplay,
-      self.params.session_strategy.clone(),
+      session_strategy.clone(),
       self.params.metadata_provider.clone(),
       self.params.resource_utilization_target,
       self.params.session_replay_target,
@@ -394,7 +400,7 @@ impl LoggerBuilder {
       scope.clone(),
       async_log_buffer_communication_tx.clone(),
       report_proc_tx,
-      self.params.session_strategy.clone(),
+      session_strategy.clone(),
       self.params.device,
       self.params.static_metadata.sdk_version(),
       self.params.store.clone(),
@@ -416,6 +422,7 @@ impl LoggerBuilder {
 
     UnexpectedErrorHandler::register_stats(&scope);
 
+    let session_persistence_shutdown_handle = shutdown_handle.clone();
     let logger_future = async move {
       // Acquire exclusive lock on the SDK directory to prevent multiple processes from
       // accessing it simultaneously. The lock is acquired asynchronously using spawn_blocking
@@ -521,7 +528,7 @@ impl LoggerBuilder {
         &self.params.sdk_directory,
         self.params.store.clone(),
         artifact_client.clone(),
-        self.params.session_strategy.clone(),
+        session_strategy.clone(),
         &init_lifecycle,
         state_store.clone(),
         previous_run_state,
@@ -591,7 +598,7 @@ impl LoggerBuilder {
         sleep_mode_active_rx,
         self.params.store.clone(),
         state_store.clone(),
-        self.params.session_strategy.clone(),
+        session_strategy.clone(),
         opaque_entity_updates_rx,
         sdk_status_tracker,
         Some(Arc::new(handshake_stats)),
@@ -638,6 +645,15 @@ impl LoggerBuilder {
           if let Some(worker) = state_upload_worker {
             worker.run().await;
           }
+          Ok(())
+        },
+        async move {
+          let mut shutdown = session_persistence_shutdown_handle.make_shutdown();
+          session_persistence_worker
+            .run(shutdown.cancelled(), move || {
+              session_persistence_failures.inc();
+            })
+            .await;
           Ok(())
         }
       )

--- a/bd-logger/src/builder.rs
+++ b/bd-logger/src/builder.rs
@@ -271,10 +271,7 @@ impl LoggerBuilder {
       "bitdrift Capture SDK: {:?}",
       self.params.static_metadata.sdk_version()
     );
-    let bd_session::StrategyParts {
-      strategy: session_strategy,
-      persistence_worker: session_persistence_worker,
-    } = self.params.session;
+    let (session_strategy, session_persistence_worker) = self.params.session.into_parts();
 
     let init_lifecycle = InitLifecycleState::new();
 

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -542,7 +542,7 @@ impl LoggerHandle {
     let is_allowed = LOGGER_GUARD.with(|cell| cell.try_borrow().is_ok());
 
     if is_allowed {
-      self.session_strategy.start_new_session_sync()
+      self.session_strategy.start_new_session()
     } else {
       Err(anyhow::anyhow!(
         "operation not allowed from within a field provider"
@@ -560,7 +560,8 @@ impl LoggerHandle {
 pub struct InitParams {
   pub sdk_directory: PathBuf,
   pub api_key: String,
-  pub session_strategy: Arc<bd_session::Strategy>,
+  /// The session state and its single persistence worker.
+  pub session: bd_session::StrategyParts,
 
   pub store: Arc<bd_key_value::Store>,
 

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -530,7 +530,7 @@ impl LoggerHandle {
     let is_allowed = LOGGER_GUARD.with(|cell| cell.try_borrow().is_ok());
 
     if is_allowed {
-      self.session_strategy.session_id_sync()
+      self.session_strategy.session_id()
     } else {
       Err(anyhow::anyhow!(
         "operation not allowed from within a field provider"
@@ -561,7 +561,7 @@ pub struct InitParams {
   pub sdk_directory: PathBuf,
   pub api_key: String,
   /// The session state and its single persistence worker.
-  pub session: bd_session::StrategyParts,
+  pub session: bd_session::StrategyWithWorker,
 
   pub store: Arc<bd_key_value::Store>,
 

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -530,18 +530,7 @@ impl LoggerHandle {
     let is_allowed = LOGGER_GUARD.with(|cell| cell.try_borrow().is_ok());
 
     if is_allowed {
-      let prepared = self.session_strategy.prepare_session_id()?;
-
-      if !prepared.has_follow_up_work() {
-        return Ok(prepared.into_current_session_id());
-      }
-
-      let session_id = prepared.current_session_id().to_string();
-      let callback = self
-        .tx
-        .persist_prepared_session(prepared, async_log_buffer::SESSION_BRIDGE_TIMEOUT)?;
-      self.session_strategy.run_prepared_callback(callback);
-      Ok(session_id)
+      self.session_strategy.session_id_sync()
     } else {
       Err(anyhow::anyhow!(
         "operation not allowed from within a field provider"
@@ -553,12 +542,7 @@ impl LoggerHandle {
     let is_allowed = LOGGER_GUARD.with(|cell| cell.try_borrow().is_ok());
 
     if is_allowed {
-      let prepared = self.session_strategy.prepare_start_new_session()?;
-      let callback = self
-        .tx
-        .persist_prepared_session(prepared, async_log_buffer::SESSION_BRIDGE_TIMEOUT)?;
-      self.session_strategy.run_prepared_callback(callback);
-      Ok(())
+      self.session_strategy.start_new_session_sync()
     } else {
       Err(anyhow::anyhow!(
         "operation not allowed from within a field provider"

--- a/bd-logger/src/logger_test.rs
+++ b/bd-logger/src/logger_test.rs
@@ -34,10 +34,7 @@ async fn thread_local_logger_guard() {
   let handle = LoggerHandle {
     tx: sender,
     stats: Stats::new(&Collector::default().scope("")),
-    session_strategy: Arc::new(Strategy::fixed(
-      sdk_directory.path(),
-      Arc::new(UUIDCallbacks),
-    )),
+    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy,
     device: Arc::new(bd_device::Device::new(store.clone())),
     sdk_version: "1.0.0".into(),
     app_version_repo: Repository::new(store.clone()),
@@ -76,10 +73,7 @@ async fn session_id_is_rejected_while_reentrancy_guard_is_held() {
   let handle = LoggerHandle {
     tx: sender,
     stats: Stats::new(&Collector::default().scope("")),
-    session_strategy: Arc::new(Strategy::fixed(
-      sdk_directory.path(),
-      Arc::new(UUIDCallbacks),
-    )),
+    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy,
     device: Arc::new(bd_device::Device::new(store.clone())),
     sdk_version: "1.0.0".into(),
     app_version_repo: Repository::new(store),
@@ -109,10 +103,7 @@ async fn register_opaque_entity_id_updates_queue_and_watch() {
   let handle = LoggerHandle {
     tx: sender,
     stats: Stats::new(&Collector::default().scope("")),
-    session_strategy: Arc::new(Strategy::fixed(
-      sdk_directory.path(),
-      Arc::new(UUIDCallbacks),
-    )),
+    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy,
     device: Arc::new(bd_device::Device::new(store.clone())),
     sdk_version: "1.0.0".into(),
     app_version_repo: Repository::new(store.clone()),
@@ -173,10 +164,7 @@ async fn register_opaque_entity_id_does_not_update_watch_when_queueing_fails() {
   let handle = LoggerHandle {
     tx: sender,
     stats: Stats::new(&Collector::default().scope("")),
-    session_strategy: Arc::new(Strategy::fixed(
-      sdk_directory.path(),
-      Arc::new(UUIDCallbacks),
-    )),
+    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy,
     device: Arc::new(bd_device::Device::new(store.clone())),
     sdk_version: "1.0.0".into(),
     app_version_repo: Repository::new(store.clone()),

--- a/bd-logger/src/logger_test.rs
+++ b/bd-logger/src/logger_test.rs
@@ -34,7 +34,7 @@ async fn thread_local_logger_guard() {
   let handle = LoggerHandle {
     tx: sender,
     stats: Stats::new(&Collector::default().scope("")),
-    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy,
+    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy(),
     device: Arc::new(bd_device::Device::new(store.clone())),
     sdk_version: "1.0.0".into(),
     app_version_repo: Repository::new(store.clone()),
@@ -73,7 +73,7 @@ async fn session_id_is_rejected_while_reentrancy_guard_is_held() {
   let handle = LoggerHandle {
     tx: sender,
     stats: Stats::new(&Collector::default().scope("")),
-    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy,
+    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy(),
     device: Arc::new(bd_device::Device::new(store.clone())),
     sdk_version: "1.0.0".into(),
     app_version_repo: Repository::new(store),
@@ -103,7 +103,7 @@ async fn register_opaque_entity_id_updates_queue_and_watch() {
   let handle = LoggerHandle {
     tx: sender,
     stats: Stats::new(&Collector::default().scope("")),
-    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy,
+    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy(),
     device: Arc::new(bd_device::Device::new(store.clone())),
     sdk_version: "1.0.0".into(),
     app_version_repo: Repository::new(store.clone()),
@@ -164,7 +164,7 @@ async fn register_opaque_entity_id_does_not_update_watch_when_queueing_fails() {
   let handle = LoggerHandle {
     tx: sender,
     stats: Stats::new(&Collector::default().scope("")),
-    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy,
+    session_strategy: Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy(),
     device: Arc::new(bd_device::Device::new(store.clone())),
     sdk_version: "1.0.0".into(),
     app_version_repo: Repository::new(store.clone()),

--- a/bd-logger/src/test/embedded_logger_integration.rs
+++ b/bd-logger/src/test/embedded_logger_integration.rs
@@ -67,13 +67,11 @@ impl Setup {
     let store = in_memory_store();
     let device = Arc::new(bd_device::Device::new(store.clone()));
 
+    let session = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
     let (logger, _, future, _) = crate::LoggerBuilder::new(InitParams {
       sdk_directory: sdk_directory.path().to_owned(),
       network: Box::new(handle),
-      session_strategy: Arc::new(Strategy::fixed(
-        sdk_directory.path(),
-        Arc::new(UUIDCallbacks),
-      )),
+      session,
       metadata_provider: Arc::new(TestMetadataProvider),
       store,
       resource_utilization_target: Box::new(EmptyTarget),

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -191,7 +191,7 @@ fn session_id_runs_fixed_strategy_callback_on_calling_thread() {
   let sdk_directory = Arc::new(tempfile::TempDir::with_prefix("sdk").unwrap());
   let app_lock = Arc::new(ReentrantMutex::new(()));
   let callbacks = Arc::new(LockingFixedCallbacks::new(app_lock.clone()));
-  let session_strategy = Arc::new(Strategy::fixed(sdk_directory.path(), callbacks.clone()));
+  let session_strategy = Strategy::fixed(sdk_directory.path(), callbacks.clone());
 
   let setup = Setup::new_with_options(SetupOptions {
     sdk_directory,
@@ -207,14 +207,32 @@ fn session_id_runs_fixed_strategy_callback_on_calling_thread() {
 }
 
 #[test]
+fn logger_shutdown_flushes_session_persistence() {
+  let sdk_directory = Arc::new(tempfile::TempDir::with_prefix("sdk").unwrap());
+  let session = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
+  let session_strategy = session.strategy.clone();
+  let setup = Setup::new_with_options(SetupOptions {
+    sdk_directory: sdk_directory.clone(),
+    session_strategy: Some(session),
+    ..Default::default()
+  });
+
+  let session_id = session_strategy.session_id_sync().unwrap();
+  setup.logger.shutdown(true);
+
+  let restarted = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy;
+  assert_eq!(Some(session_id), restarted.previous_process_session_id());
+}
+
+#[test]
 fn start_new_session_runs_fixed_strategy_callback_on_calling_thread() {
   let sdk_directory = tempfile::TempDir::with_prefix("sdk").unwrap();
   let app_lock = Arc::new(ReentrantMutex::new(()));
   let callbacks = Arc::new(LockingFixedCallbacks::new(app_lock.clone()));
-  let session_strategy = Arc::new(Strategy::fixed(sdk_directory.path(), callbacks.clone()));
+  let session = Strategy::fixed(sdk_directory.path(), callbacks.clone());
 
   let mut init_params = crate::test::setup::create_minimal_init_params(sdk_directory.path());
-  init_params.session_strategy = session_strategy;
+  init_params.session = session;
 
   let logger = crate::LoggerBuilder::new(init_params)
     .build_dedicated_thread()
@@ -244,12 +262,12 @@ fn session_id_runs_activity_callback_on_calling_thread() {
   let time_provider = Arc::new(TestTimeProvider::new(OffsetDateTime::now_utc()));
   let app_lock = Arc::new(ReentrantMutex::new(()));
   let callbacks = Arc::new(LockingActivityCallbacks::new(app_lock.clone()));
-  let session_strategy = Arc::new(Strategy::activity_based(
+  let session_strategy = Strategy::activity_based(
     sdk_directory.path(),
     30.seconds(),
     callbacks.clone(),
     time_provider.clone(),
-  ));
+  );
 
   let setup = Setup::new_with_options(SetupOptions {
     sdk_directory,
@@ -550,15 +568,21 @@ fn log_upload_attributes_override() {
 
   let time_first = datetime!(2024-06-01 12:00:00 UTC);
   let sdk_directory = Arc::new(tempfile::TempDir::with_prefix("sdk").unwrap());
-  let previous_session = Arc::new(bd_session::Strategy::fixed(
+  let bd_session::StrategyParts {
+    strategy: previous_session,
+    persistence_worker: previous_session_worker,
+  } = bd_session::Strategy::fixed(
     sdk_directory.path(),
     Arc::new(StaticSessionId("foo_overridden".to_string())),
-  ));
+  );
   assert_eq!(
     tokio_test::block_on(previous_session.session_id()).unwrap(),
     "foo_overridden"
   );
-  tokio_test::block_on(bd_session::test::flush(previous_session));
+  tokio_test::block_on(bd_session::test::flush(
+    previous_session,
+    previous_session_worker,
+  ));
 
   let mut setup = Setup::new_with_options(SetupOptions {
     sdk_directory,
@@ -3729,13 +3753,11 @@ fn runtime_caching() {
     let store = in_memory_store();
     let device = Arc::new(bd_device::Device::new(store.clone()));
 
+    let session = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
     let logger = crate::LoggerBuilder::new(InitParams {
       api_key: "foo-api-key".to_string(),
       network,
-      session_strategy: Arc::new(Strategy::fixed(
-        sdk_directory.path(),
-        Arc::new(UUIDCallbacks),
-      )),
+      session,
       static_metadata: Arc::new(EmptyMetadata),
       store,
       resource_utilization_target: Box::new(EmptyTarget),

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -558,6 +558,7 @@ fn log_upload_attributes_override() {
     tokio_test::block_on(previous_session.session_id()).unwrap(),
     "foo_overridden"
   );
+  tokio_test::block_on(previous_session.flush());
 
   let mut setup = Setup::new_with_options(SetupOptions {
     sdk_directory,

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -210,17 +210,17 @@ fn session_id_runs_fixed_strategy_callback_on_calling_thread() {
 fn logger_shutdown_flushes_session_persistence() {
   let sdk_directory = Arc::new(tempfile::TempDir::with_prefix("sdk").unwrap());
   let session = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
-  let session_strategy = session.strategy.clone();
+  let session_strategy = session.strategy();
   let setup = Setup::new_with_options(SetupOptions {
     sdk_directory: sdk_directory.clone(),
     session_strategy: Some(session),
     ..Default::default()
   });
 
-  let session_id = session_strategy.session_id_sync().unwrap();
+  let session_id = session_strategy.session_id().unwrap();
   setup.logger.shutdown(true);
 
-  let restarted = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy;
+  let restarted = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks)).strategy();
   assert_eq!(Some(session_id), restarted.previous_process_session_id());
 }
 
@@ -568,17 +568,12 @@ fn log_upload_attributes_override() {
 
   let time_first = datetime!(2024-06-01 12:00:00 UTC);
   let sdk_directory = Arc::new(tempfile::TempDir::with_prefix("sdk").unwrap());
-  let bd_session::StrategyParts {
-    strategy: previous_session,
-    persistence_worker: previous_session_worker,
-  } = bd_session::Strategy::fixed(
+  let (previous_session, previous_session_worker) = bd_session::Strategy::fixed(
     sdk_directory.path(),
     Arc::new(StaticSessionId("foo_overridden".to_string())),
-  );
-  assert_eq!(
-    tokio_test::block_on(previous_session.session_id()).unwrap(),
-    "foo_overridden"
-  );
+  )
+  .into_parts();
+  assert_eq!(previous_session.session_id().unwrap(), "foo_overridden");
   tokio_test::block_on(bd_session::test::flush(
     previous_session,
     previous_session_worker,

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -550,15 +550,15 @@ fn log_upload_attributes_override() {
 
   let time_first = datetime!(2024-06-01 12:00:00 UTC);
   let sdk_directory = Arc::new(tempfile::TempDir::with_prefix("sdk").unwrap());
-  let previous_session = bd_session::Strategy::fixed(
+  let previous_session = Arc::new(bd_session::Strategy::fixed(
     sdk_directory.path(),
     Arc::new(StaticSessionId("foo_overridden".to_string())),
-  );
+  ));
   assert_eq!(
     tokio_test::block_on(previous_session.session_id()).unwrap(),
     "foo_overridden"
   );
-  tokio_test::block_on(previous_session.flush());
+  tokio_test::block_on(bd_session::test::flush(previous_session));
 
   let mut setup = Setup::new_with_options(SetupOptions {
     sdk_directory,

--- a/bd-logger/src/test/setup.rs
+++ b/bd-logger/src/test/setup.rs
@@ -24,8 +24,8 @@ use bd_proto::protos::client::api::configuration_update_ack::Nack;
 use bd_proto::protos::config::v1::config::{BufferConfigList, buffer_config};
 use bd_proto::protos::logging::payload::LogType;
 use bd_runtime::runtime::FeatureFlag as _;
-use bd_session::Strategy;
 use bd_session::fixed::UUIDCallbacks;
+use bd_session::{Strategy, StrategyParts};
 use bd_shutdown::{ComponentShutdown, ComponentShutdownTrigger};
 use bd_test_helpers::config_helper::{
   configuration_update,
@@ -106,7 +106,7 @@ pub struct SetupOptions {
   pub disk_storage: bool,
   pub start_in_sleep_mode: bool,
   pub time_provider: Option<Arc<dyn TimeProvider>>,
-  pub session_strategy: Option<Arc<Strategy>>,
+  pub session_strategy: Option<StrategyParts>,
   pub extra_runtime_values: Vec<(&'static str, ValueKind)>,
   pub handshake_response_plans: Vec<HandshakeResponsePlan>,
   pub stats_upload_response_plans: Vec<StatsUploadResponsePlan>,
@@ -212,17 +212,14 @@ impl Setup {
 
     let (flush_tick_tx, flush_ticker) = TestTicker::new();
     let (upload_tick_tx, upload_ticker) = TestTicker::new();
-    let session_strategy = options.session_strategy.unwrap_or_else(|| {
-      Arc::new(Strategy::fixed(
-        options.sdk_directory.path(),
-        Arc::new(UUIDCallbacks),
-      ))
-    });
+    let session = options
+      .session_strategy
+      .unwrap_or_else(|| Strategy::fixed(options.sdk_directory.path(), Arc::new(UUIDCallbacks)));
 
     let (logger, _, flush_trigger) = crate::LoggerBuilder::new(InitParams {
       sdk_directory: options.sdk_directory.path().into(),
       api_key: "foo-api-key".to_string(),
-      session_strategy,
+      session,
       metadata_provider: options.metadata_provider,
       resource_utilization_target: Box::new(EmptyTarget),
       session_replay_target,
@@ -527,11 +524,12 @@ pub fn create_minimal_init_params(sdk_directory: &std::path::Path) -> InitParams
   let device_store = Arc::new(Store::new(Box::new(
     bd_test_helpers::session::InMemoryStorage::default(),
   )));
+  let session = Strategy::fixed(sdk_directory, Arc::new(UUIDCallbacks));
 
   InitParams {
     sdk_directory: sdk_directory.into(),
     api_key: "test-api-key".to_string(),
-    session_strategy: Arc::new(Strategy::fixed(sdk_directory, Arc::new(UUIDCallbacks))),
+    session,
     metadata_provider: Arc::new(LogMetadata::default()),
     resource_utilization_target: Box::new(EmptyTarget),
     session_replay_target: Box::new(bd_test_helpers::session_replay::NoOpTarget),

--- a/bd-logger/src/test/setup.rs
+++ b/bd-logger/src/test/setup.rs
@@ -25,7 +25,7 @@ use bd_proto::protos::config::v1::config::{BufferConfigList, buffer_config};
 use bd_proto::protos::logging::payload::LogType;
 use bd_runtime::runtime::FeatureFlag as _;
 use bd_session::fixed::UUIDCallbacks;
-use bd_session::{Strategy, StrategyParts};
+use bd_session::{Strategy, StrategyWithWorker};
 use bd_shutdown::{ComponentShutdown, ComponentShutdownTrigger};
 use bd_test_helpers::config_helper::{
   configuration_update,
@@ -106,7 +106,7 @@ pub struct SetupOptions {
   pub disk_storage: bool,
   pub start_in_sleep_mode: bool,
   pub time_provider: Option<Arc<dyn TimeProvider>>,
-  pub session_strategy: Option<StrategyParts>,
+  pub session_strategy: Option<StrategyWithWorker>,
   pub extra_runtime_values: Vec<(&'static str, ValueKind)>,
   pub handshake_response_plans: Vec<HandshakeResponsePlan>,
   pub stats_upload_response_plans: Vec<StatsUploadResponsePlan>,

--- a/bd-session/src/activity_based.rs
+++ b/bd-session/src/activity_based.rs
@@ -105,16 +105,17 @@ impl Strategy {
             OffsetDateTime::from(state.persisted.current_session_start),
           ));
         state.persistence_pending = true;
+        effects.persist = true;
         effects.notify_update = true;
       }
 
       log::debug!(
         "initialized activity-based session from persisted state: current_session_id={}, \
-         previous_process_session_id={:?}, persistence_pending={}, notify_update={}, \
+         previous_process_session_id={:?}, persist={}, notify_update={}, \
          pending_started_sessions={}",
         state.persisted.current_session_id,
         state.persisted.previous_process_session_id,
-        state.persistence_pending,
+        effects.persist,
         effects.notify_update,
         state.pending_started_sessions.len()
       );
@@ -146,6 +147,7 @@ impl Strategy {
           persistence_pending: true,
         },
         effects: TransitionEffects {
+          persist: true,
           notify_update: true,
           callback: Some(DeferredCallback::ActivitySessionChanged(session_id)),
         },
@@ -218,6 +220,7 @@ impl Strategy {
       );
 
       TransitionEffects {
+        persist: true,
         notify_update: true,
         callback: Some(DeferredCallback::ActivitySessionChanged(session_id)),
       }
@@ -232,7 +235,10 @@ impl Strategy {
          current_session_id={previous_session_id}, last_activity={now:?}"
       );
 
-      TransitionEffects::default()
+      TransitionEffects {
+        persist: true,
+        ..Default::default()
+      }
     } else {
       log::debug!(
         "leaving activity-based session unchanged: current_session_id={previous_session_id}, no \
@@ -282,6 +288,7 @@ impl Strategy {
         persistence_pending: true,
       },
       effects: TransitionEffects {
+        persist: true,
         notify_update: true,
         callback: None,
       },

--- a/bd-session/src/activity_based.rs
+++ b/bd-session/src/activity_based.rs
@@ -83,6 +83,8 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: None,
+        persistence_generation: 0,
+        completed_persistence_generation: 0,
       };
       let mut mutation = self.on_session_id(&mut state);
       // Handshake uploads must be able to announce the current session after a restart even if the
@@ -141,6 +143,8 @@ impl Strategy {
           },
           pending_started_sessions,
           last_activity_write: Some(now),
+          persistence_generation: 0,
+          completed_persistence_generation: 0,
         },
         mutation: Mutation {
           persist_state: true,
@@ -279,6 +283,8 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: Some(now),
+        persistence_generation: 0,
+        completed_persistence_generation: 0,
       },
       mutation: Mutation {
         persist_state: true,
@@ -295,5 +301,7 @@ impl Strategy {
 }
 
 pub trait Callbacks: Send + Sync {
+  /// Invoked synchronously on the thread that created or rotated the session. Durable persistence
+  /// continues asynchronously and is intentionally not a precondition for this notification.
   fn session_id_changed(&self, session_id: &str);
 }

--- a/bd-session/src/activity_based.rs
+++ b/bd-session/src/activity_based.rs
@@ -83,8 +83,7 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: None,
-        persistence_generation: 0,
-        completed_persistence_generation: 0,
+        persistence_pending: false,
       };
       let mut mutation = self.on_session_id(&mut state);
       // Handshake uploads must be able to announce the current session after a restart even if the
@@ -143,8 +142,7 @@ impl Strategy {
           },
           pending_started_sessions,
           last_activity_write: Some(now),
-          persistence_generation: 0,
-          completed_persistence_generation: 0,
+          persistence_pending: false,
         },
         mutation: Mutation {
           persist_state: true,
@@ -283,8 +281,7 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: Some(now),
-        persistence_generation: 0,
-        completed_persistence_generation: 0,
+        persistence_pending: false,
       },
       mutation: Mutation {
         persist_state: true,

--- a/bd-session/src/activity_based.rs
+++ b/bd-session/src/activity_based.rs
@@ -10,7 +10,7 @@
 mod activity_based_test;
 
 use crate::persistence::{BackendState, PersistedSessionState, StartedSessionRecord};
-use crate::{DeferredCallback, Initialization, LoadedState, Mutation};
+use crate::{DeferredCallback, LoadedState, Transition, TransitionEffects};
 use bd_time::TimeProvider;
 use std::sync::Arc;
 use time::{Duration, OffsetDateTime};
@@ -62,7 +62,7 @@ impl Strategy {
     &self,
     persisted: Option<PersistedSessionState>,
     mut pending_started_sessions: Vec<StartedSessionRecord>,
-  ) -> Initialization {
+  ) -> Transition {
     let now = self.time_provider.now();
     if let Some(persisted) = persisted {
       log::debug!(
@@ -85,7 +85,7 @@ impl Strategy {
         last_activity_write: None,
         persistence_pending: false,
       };
-      let mut mutation = self.on_session_id(&mut state);
+      let mut effects = self.on_session_id(&mut state);
       // Handshake uploads must be able to announce the current session after a restart even if the
       // process died before flushing a pending-started-sessions queue entry.
       if !state
@@ -104,21 +104,22 @@ impl Strategy {
             state.persisted.current_session_id.clone(),
             OffsetDateTime::from(state.persisted.current_session_start),
           ));
-        mutation.persist_pending = true;
+        state.persistence_pending = true;
+        effects.notify_update = true;
       }
 
       log::debug!(
         "initialized activity-based session from persisted state: current_session_id={}, \
-         previous_process_session_id={:?}, persist_state={}, persist_pending={}, \
+         previous_process_session_id={:?}, persistence_pending={}, notify_update={}, \
          pending_started_sessions={}",
         state.persisted.current_session_id,
         state.persisted.previous_process_session_id,
-        mutation.persist_state,
-        mutation.persist_pending,
+        state.persistence_pending,
+        effects.notify_update,
         state.pending_started_sessions.len()
       );
 
-      Initialization { state, mutation }
+      Transition { state, effects }
     } else {
       let session_id = Self::generate_session_id();
       let session_start = now;
@@ -130,7 +131,7 @@ impl Strategy {
         pending_started_sessions.len()
       );
 
-      Initialization {
+      Transition {
         state: LoadedState {
           persisted: PersistedSessionState {
             current_session_id: session_id.clone(),
@@ -142,18 +143,17 @@ impl Strategy {
           },
           pending_started_sessions,
           last_activity_write: Some(now),
-          persistence_pending: false,
+          persistence_pending: true,
         },
-        mutation: Mutation {
-          persist_state: true,
-          persist_pending: true,
+        effects: TransitionEffects {
+          notify_update: true,
           callback: Some(DeferredCallback::ActivitySessionChanged(session_id)),
         },
       }
     }
   }
 
-  pub(crate) fn on_session_id(&self, state: &mut LoadedState) -> Mutation {
+  pub(crate) fn on_session_id(&self, state: &mut LoadedState) -> TransitionEffects {
     let now = self.time_provider.now();
     let BackendState::ActivityBased { last_activity } = &mut state.persisted.backend else {
       // `initialize_state()` should already resync any persisted backend mismatch before an
@@ -167,7 +167,7 @@ impl Strategy {
         "activity-based session observed incompatible backend state after initialization; leaving \
          state unchanged"
       );
-      return Mutation::default();
+      return TransitionEffects::default();
     };
 
     let previous_session_id = state.persisted.current_session_id.clone();
@@ -202,6 +202,7 @@ impl Strategy {
         .pending_started_sessions
         .push(StartedSessionRecord::new(session_id.clone(), now));
       state.last_activity_write = Some(now);
+      state.persistence_pending = true;
 
       log::debug!(
         "rotating activity-based session: previous_session_id={}, new_session_id={}, reason={}, \
@@ -216,32 +217,29 @@ impl Strategy {
         state.pending_started_sessions.len()
       );
 
-      Mutation {
-        persist_state: true,
-        persist_pending: true,
+      TransitionEffects {
+        notify_update: true,
         callback: Some(DeferredCallback::ActivitySessionChanged(session_id)),
       }
     } else if last_activity_storage_needs_write {
       // The session itself is unchanged, but we periodically persist the last-activity timestamp so
       // a restart can continue the inactivity window from roughly the right point in time.
       state.last_activity_write = Some(now);
+      state.persistence_pending = true;
 
       log::debug!(
         "persisting activity-based last-activity without session rotation: \
          current_session_id={previous_session_id}, last_activity={now:?}"
       );
 
-      Mutation {
-        persist_state: true,
-        ..Default::default()
-      }
+      TransitionEffects::default()
     } else {
       log::debug!(
         "leaving activity-based session unchanged: current_session_id={previous_session_id}, no \
          durable write required"
       );
 
-      Mutation::default()
+      TransitionEffects::default()
     }
   }
 
@@ -250,7 +248,7 @@ impl Strategy {
     state: Option<&LoadedState>,
     persisted: Option<PersistedSessionState>,
     mut pending_started_sessions: Vec<StartedSessionRecord>,
-  ) -> Initialization {
+  ) -> Transition {
     // An explicit rotation behaves like a brand-new activity session, but it preserves the last
     // previous-process session marker for post-restart reporting.
     let session_id = Self::generate_session_id();
@@ -269,7 +267,7 @@ impl Strategy {
       pending_started_sessions.len()
     );
 
-    Initialization {
+    Transition {
       state: LoadedState {
         persisted: PersistedSessionState {
           current_session_id: session_id,
@@ -281,11 +279,10 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: Some(now),
-        persistence_pending: false,
+        persistence_pending: true,
       },
-      mutation: Mutation {
-        persist_state: true,
-        persist_pending: true,
+      effects: TransitionEffects {
+        notify_update: true,
         callback: None,
       },
     }

--- a/bd-session/src/activity_based_test.rs
+++ b/bd-session/src/activity_based_test.rs
@@ -5,9 +5,9 @@
 // LICENSE.polyform file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::Strategy;
 use crate::activity_based::Callbacks;
-use crate::test::{flush, start_new_session};
+use crate::test::flush;
+use crate::{Strategy, StrategyParts};
 use bd_time::TestTimeProvider;
 use pretty_assertions::assert_eq;
 use std::sync::Arc;
@@ -61,7 +61,7 @@ async fn generates_new_session_and_stores_it_if_none_exists() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -83,7 +83,7 @@ async fn try_current_session_id_fails_before_initialization() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -100,7 +100,7 @@ async fn try_current_session_id_fails_before_initialization() {
 async fn try_current_session_id_returns_loaded_session() {
   let now = OffsetDateTime::now_utc();
   let sdk_directory = TempDir::new().unwrap();
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     Arc::new(MockCallbacks::default()),
@@ -117,12 +117,12 @@ async fn try_current_session_id_rejects_callback_reentry() {
   let now = OffsetDateTime::now_utc();
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(ReEntryCallbacks::default());
-  let strategy = Arc::new(Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
     Arc::new(TestTimeProvider::new(now)),
-  ));
+  );
 
   callbacks.session_strategy.lock().replace(strategy.clone());
 
@@ -141,7 +141,7 @@ async fn session_id_runs_callback_without_waiting_for_persistence() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -163,7 +163,7 @@ async fn generates_new_session_and_stores_it_if_old_exceeded_inactivity_threshol
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -184,7 +184,7 @@ async fn does_not_update_neither_session_nor_last_activity_if_within_max_write_i
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -210,7 +210,7 @@ async fn updates_only_last_activity_date_if_after_max_write_interval() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -237,7 +237,7 @@ async fn updates_session_and_last_activity_after_inactivity_threshold_is_exceede
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -265,7 +265,7 @@ async fn refreshes_session_and_last_activity_after_reboot() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -288,7 +288,7 @@ async fn starts_new_session() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -301,7 +301,7 @@ async fn starts_new_session() {
   let advanced_time = now + 1.seconds();
   time_provider.set_time(advanced_time);
 
-  start_new_session(&strategy).await;
+  strategy.start_new_session().unwrap();
 
   let next_session_id = strategy.session_id().await.unwrap();
 
@@ -317,14 +317,14 @@ async fn previous_session_id() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let StrategyParts { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks,
     time_provider,
   );
 
-  start_new_session(&strategy).await;
+  strategy.start_new_session().unwrap();
 
   assert!(strategy.previous_process_session_id().is_none());
 
@@ -340,12 +340,15 @@ async fn flushes_state() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Arc::new(Strategy::activity_based(
+  let StrategyParts {
+    strategy,
+    persistence_worker: worker,
+  } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks,
     time_provider.clone(),
-  ));
+  );
 
   let session_id = strategy.session_id().await.unwrap();
 
@@ -354,7 +357,7 @@ async fn flushes_state() {
 
   let next_session_id = strategy.session_id().await.unwrap();
 
-  flush(strategy.clone()).await;
+  flush(strategy.clone(), worker).await;
 
   assert_eq!(session_id, next_session_id);
 }

--- a/bd-session/src/activity_based_test.rs
+++ b/bd-session/src/activity_based_test.rs
@@ -136,7 +136,7 @@ async fn try_current_session_id_rejects_callback_reentry() {
 }
 
 #[tokio::test]
-async fn prepared_session_id_runs_callback_only_after_apply() {
+async fn session_id_runs_callback_without_waiting_for_persistence() {
   let now = OffsetDateTime::now_utc();
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
@@ -148,16 +148,9 @@ async fn prepared_session_id_runs_callback_only_after_apply() {
     Arc::new(TestTimeProvider::new(now)),
   );
 
-  let prepared = strategy.prepare_session_id().unwrap();
-  let session_id = prepared.current_session_id().to_string();
+  let session_id = strategy.session_id().await.unwrap();
 
   assert_eq!(session_id, strategy.try_current_session_id().unwrap());
-  assert!(callbacks.session_id_changes.lock().is_empty());
-
-  let callback = strategy.persist_prepared(prepared).await;
-  assert!(callbacks.session_id_changes.lock().is_empty());
-
-  strategy.run_prepared_callback(callback);
   assert_eq!(
     vec![session_id],
     callbacks.session_id_changes.lock().clone()

--- a/bd-session/src/activity_based_test.rs
+++ b/bd-session/src/activity_based_test.rs
@@ -7,7 +7,7 @@
 
 use crate::activity_based::Callbacks;
 use crate::test::flush;
-use crate::{Strategy, StrategyParts};
+use crate::{Strategy, StrategyWithWorker};
 use bd_time::TestTimeProvider;
 use pretty_assertions::assert_eq;
 use std::sync::Arc;
@@ -61,7 +61,7 @@ async fn generates_new_session_and_stores_it_if_none_exists() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -70,7 +70,7 @@ async fn generates_new_session_and_stores_it_if_none_exists() {
 
   assert!(strategy.previous_process_session_id().is_none());
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   assert_eq!(1, callbacks.session_id_changes.lock().len());
   assert_eq!(session_id, callbacks.session_id_changes.lock()[0]);
@@ -83,7 +83,7 @@ async fn try_current_session_id_fails_before_initialization() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -100,14 +100,14 @@ async fn try_current_session_id_fails_before_initialization() {
 async fn try_current_session_id_returns_loaded_session() {
   let now = OffsetDateTime::now_utc();
   let sdk_directory = TempDir::new().unwrap();
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     Arc::new(MockCallbacks::default()),
     Arc::new(TestTimeProvider::new(now)),
   );
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   assert_eq!(session_id, strategy.try_current_session_id().unwrap());
 }
@@ -117,7 +117,7 @@ async fn try_current_session_id_rejects_callback_reentry() {
   let now = OffsetDateTime::now_utc();
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(ReEntryCallbacks::default());
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -126,7 +126,7 @@ async fn try_current_session_id_rejects_callback_reentry() {
 
   callbacks.session_strategy.lock().replace(strategy.clone());
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   assert_eq!(36, session_id.len());
   assert_eq!(
@@ -141,14 +141,14 @@ async fn session_id_runs_callback_without_waiting_for_persistence() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
     Arc::new(TestTimeProvider::new(now)),
   );
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   assert_eq!(session_id, strategy.try_current_session_id().unwrap());
   assert_eq!(
@@ -163,14 +163,14 @@ async fn generates_new_session_and_stores_it_if_old_exceeded_inactivity_threshol
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
     Arc::new(TestTimeProvider::new(now)),
   );
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   assert_eq!(1, callbacks.session_id_changes.lock().len());
   assert_eq!(session_id, callbacks.session_id_changes.lock()[0]);
@@ -184,20 +184,20 @@ async fn does_not_update_neither_session_nor_last_activity_if_within_max_write_i
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
     time_provider.clone(),
   );
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   callbacks.clear();
 
   time_provider.advance(time::Duration::seconds(3));
 
-  let second_session_id = strategy.session_id().await.unwrap();
+  let second_session_id = strategy.session_id().unwrap();
 
   assert_eq!(session_id, second_session_id);
   assert!(callbacks.session_id_changes.lock().is_empty());
@@ -210,21 +210,21 @@ async fn updates_only_last_activity_date_if_after_max_write_interval() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
     time_provider.clone(),
   );
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   callbacks.clear();
 
   let advanced_time = now + std::time::Duration::from_secs(20);
   time_provider.set_time(advanced_time);
 
-  let second_session_id = strategy.session_id().await.unwrap();
+  let second_session_id = strategy.session_id().unwrap();
 
   assert_eq!(session_id, second_session_id);
   assert!(callbacks.session_id_changes.lock().is_empty());
@@ -237,21 +237,21 @@ async fn updates_session_and_last_activity_after_inactivity_threshold_is_exceede
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
     time_provider.clone(),
   );
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   callbacks.clear();
 
   let advanced_time = now + std::time::Duration::from_secs(31);
   time_provider.set_time(advanced_time);
 
-  let second_session_id = strategy.session_id().await.unwrap();
+  let second_session_id = strategy.session_id().unwrap();
 
   assert_eq!(1, callbacks.session_id_changes.lock().len());
   assert_ne!(session_id, second_session_id);
@@ -265,7 +265,7 @@ async fn refreshes_session_and_last_activity_after_reboot() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
@@ -275,7 +275,7 @@ async fn refreshes_session_and_last_activity_after_reboot() {
   let past_time = now - 5.seconds();
   time_provider.set_time(past_time);
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   assert_eq!(1, callbacks.session_id_changes.lock().len());
   assert_eq!(session_id, callbacks.session_id_changes.lock()[0]);
@@ -288,14 +288,14 @@ async fn starts_new_session() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks.clone(),
     time_provider.clone(),
   );
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
   callbacks.clear();
 
   let advanced_time = now + 1.seconds();
@@ -303,7 +303,7 @@ async fn starts_new_session() {
 
   strategy.start_new_session().unwrap();
 
-  let next_session_id = strategy.session_id().await.unwrap();
+  let next_session_id = strategy.session_id().unwrap();
 
   assert_ne!(session_id, next_session_id);
   assert!(callbacks.session_id_changes.lock().is_empty());
@@ -317,7 +317,7 @@ async fn previous_session_id() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts { strategy, .. } = Strategy::activity_based(
+  let StrategyWithWorker { strategy, .. } = Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks,
@@ -328,7 +328,7 @@ async fn previous_session_id() {
 
   assert!(strategy.previous_process_session_id().is_none());
 
-  strategy.session_id().await.unwrap();
+  strategy.session_id().unwrap();
 
   assert!(strategy.previous_process_session_id().is_none());
 }
@@ -340,7 +340,7 @@ async fn flushes_state() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy,
     persistence_worker: worker,
   } = Strategy::activity_based(
@@ -350,12 +350,12 @@ async fn flushes_state() {
     time_provider.clone(),
   );
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   let advanced_time = now + 1.seconds();
   time_provider.set_time(advanced_time);
 
-  let next_session_id = strategy.session_id().await.unwrap();
+  let next_session_id = strategy.session_id().unwrap();
 
   flush(strategy.clone(), worker).await;
 

--- a/bd-session/src/activity_based_test.rs
+++ b/bd-session/src/activity_based_test.rs
@@ -7,7 +7,7 @@
 
 use crate::Strategy;
 use crate::activity_based::Callbacks;
-use crate::test::start_new_session;
+use crate::test::{flush, start_new_session};
 use bd_time::TestTimeProvider;
 use pretty_assertions::assert_eq;
 use std::sync::Arc;
@@ -340,12 +340,12 @@ async fn flushes_state() {
   let time_provider = Arc::new(TestTimeProvider::new(now));
   let callbacks = Arc::new(MockCallbacks::default());
 
-  let strategy = Strategy::activity_based(
+  let strategy = Arc::new(Strategy::activity_based(
     sdk_directory.path(),
     Duration::seconds(30),
     callbacks,
     time_provider.clone(),
-  );
+  ));
 
   let session_id = strategy.session_id().await.unwrap();
 
@@ -354,7 +354,7 @@ async fn flushes_state() {
 
   let next_session_id = strategy.session_id().await.unwrap();
 
-  strategy.flush().await;
+  flush(strategy.clone()).await;
 
   assert_eq!(session_id, next_session_id);
 }

--- a/bd-session/src/fixed.rs
+++ b/bd-session/src/fixed.rs
@@ -10,7 +10,7 @@
 mod fixed_test;
 
 use crate::persistence::{BackendState, PersistedSessionState, StartedSessionRecord};
-use crate::{Initialization, LoadedState, Mutation};
+use crate::{LoadedState, Transition, TransitionEffects};
 use std::sync::Arc;
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -51,7 +51,7 @@ impl Strategy {
     &self,
     persisted: Option<PersistedSessionState>,
     mut pending_started_sessions: Vec<StartedSessionRecord>,
-  ) -> Initialization {
+  ) -> Transition {
     // Fixed sessions always create a fresh session on startup. The persisted current session is
     // only used to seed `previous_process_session_id` for crash/error attribution.
     let session_id = self.generate_session_id();
@@ -68,7 +68,7 @@ impl Strategy {
       pending_started_sessions.len()
     );
 
-    Initialization {
+    Transition {
       state: LoadedState {
         persisted: PersistedSessionState {
           current_session_id: session_id,
@@ -78,18 +78,17 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: None,
-        persistence_pending: false,
+        persistence_pending: true,
       },
-      mutation: Mutation {
-        persist_state: true,
-        persist_pending: true,
+      effects: TransitionEffects {
+        notify_update: true,
         callback: None,
       },
     }
   }
 
-  pub(crate) fn on_session_id(_state: &mut LoadedState) -> Mutation {
-    Mutation::default()
+  pub(crate) fn on_session_id(_state: &mut LoadedState) -> TransitionEffects {
+    TransitionEffects::default()
   }
 
   pub(crate) fn start_new_session(
@@ -97,7 +96,7 @@ impl Strategy {
     state: Option<&LoadedState>,
     persisted: Option<PersistedSessionState>,
     mut pending_started_sessions: Vec<StartedSessionRecord>,
-  ) -> Initialization {
+  ) -> Transition {
     // Explicit session starts should preserve whatever we already consider the previous-process
     // session rather than replacing it with the session we are rotating away from in this run.
     let session_id = self.generate_session_id();
@@ -116,7 +115,7 @@ impl Strategy {
       pending_started_sessions.len()
     );
 
-    Initialization {
+    Transition {
       state: LoadedState {
         persisted: PersistedSessionState {
           current_session_id: session_id,
@@ -126,11 +125,10 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: None,
-        persistence_pending: false,
+        persistence_pending: true,
       },
-      mutation: Mutation {
-        persist_state: true,
-        persist_pending: true,
+      effects: TransitionEffects {
+        notify_update: true,
         callback: None,
       },
     }

--- a/bd-session/src/fixed.rs
+++ b/bd-session/src/fixed.rs
@@ -81,6 +81,7 @@ impl Strategy {
         persistence_pending: true,
       },
       effects: TransitionEffects {
+        persist: true,
         notify_update: true,
         callback: None,
       },
@@ -128,6 +129,7 @@ impl Strategy {
         persistence_pending: true,
       },
       effects: TransitionEffects {
+        persist: true,
         notify_update: true,
         callback: None,
       },

--- a/bd-session/src/fixed.rs
+++ b/bd-session/src/fixed.rs
@@ -78,6 +78,8 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: None,
+        persistence_generation: 0,
+        completed_persistence_generation: 0,
       },
       mutation: Mutation {
         persist_state: true,
@@ -125,6 +127,8 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: None,
+        persistence_generation: 0,
+        completed_persistence_generation: 0,
       },
       mutation: Mutation {
         persist_state: true,

--- a/bd-session/src/fixed.rs
+++ b/bd-session/src/fixed.rs
@@ -78,8 +78,7 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: None,
-        persistence_generation: 0,
-        completed_persistence_generation: 0,
+        persistence_pending: false,
       },
       mutation: Mutation {
         persist_state: true,
@@ -127,8 +126,7 @@ impl Strategy {
         },
         pending_started_sessions,
         last_activity_write: None,
-        persistence_generation: 0,
-        completed_persistence_generation: 0,
+        persistence_pending: false,
       },
       mutation: Mutation {
         persist_state: true,

--- a/bd-session/src/fixed_test.rs
+++ b/bd-session/src/fixed_test.rs
@@ -104,27 +104,26 @@ async fn test_previous_process_session_id() {
   let session_id = strategy.session_id().await.unwrap();
 
   assert!(strategy.previous_process_session_id().is_none());
+  strategy.flush().await;
 
   let strategy = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   assert_eq!(Some(session_id), strategy.previous_process_session_id());
 }
 
 #[tokio::test]
-async fn prepared_session_id_persists_only_after_apply() {
+async fn session_id_persists_only_after_flush() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
   let strategy = Strategy::fixed(sdk_directory.path(), callbacks);
 
-  let prepared = strategy.prepare_session_id().unwrap();
-  let session_id = prepared.current_session_id().to_string();
+  let session_id = strategy.session_id().await.unwrap();
 
   assert_eq!(session_id, strategy.try_current_session_id().unwrap());
 
   let restarted = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   assert_eq!(None, restarted.previous_process_session_id());
 
-  let callback = strategy.persist_prepared(prepared).await;
-  strategy.run_prepared_callback(callback);
+  strategy.flush().await;
 
   let restarted = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   assert_eq!(Some(session_id), restarted.previous_process_session_id());

--- a/bd-session/src/fixed_test.rs
+++ b/bd-session/src/fixed_test.rs
@@ -7,7 +7,7 @@
 
 use super::{Callbacks, UUIDCallbacks};
 use crate::Strategy;
-use crate::test::start_new_session;
+use crate::test::{flush, start_new_session};
 use pretty_assertions::assert_eq;
 use std::future::Future;
 use std::pin::pin;
@@ -98,13 +98,16 @@ async fn test_start_new_session() {
 #[tokio::test]
 async fn test_previous_process_session_id() {
   let sdk_directory = TempDir::new().unwrap();
-  let strategy = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
+  let strategy = Arc::new(Strategy::fixed(
+    sdk_directory.path(),
+    Arc::new(UUIDCallbacks),
+  ));
   strategy.session_id().await.unwrap();
   start_new_session(&strategy).await;
   let session_id = strategy.session_id().await.unwrap();
 
   assert!(strategy.previous_process_session_id().is_none());
-  strategy.flush().await;
+  flush(strategy.clone()).await;
 
   let strategy = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   assert_eq!(Some(session_id), strategy.previous_process_session_id());
@@ -114,7 +117,7 @@ async fn test_previous_process_session_id() {
 async fn session_id_persists_only_after_flush() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
-  let strategy = Strategy::fixed(sdk_directory.path(), callbacks);
+  let strategy = Arc::new(Strategy::fixed(sdk_directory.path(), callbacks));
 
   let session_id = strategy.session_id().await.unwrap();
 
@@ -123,7 +126,7 @@ async fn session_id_persists_only_after_flush() {
   let restarted = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   assert_eq!(None, restarted.previous_process_session_id());
 
-  strategy.flush().await;
+  flush(strategy.clone()).await;
 
   let restarted = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   assert_eq!(Some(session_id), restarted.previous_process_session_id());

--- a/bd-session/src/fixed_test.rs
+++ b/bd-session/src/fixed_test.rs
@@ -6,8 +6,8 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use super::{Callbacks, UUIDCallbacks};
-use crate::Strategy;
-use crate::test::{flush, start_new_session};
+use crate::test::flush;
+use crate::{Strategy, StrategyParts};
 use pretty_assertions::assert_eq;
 use std::future::Future;
 use std::pin::pin;
@@ -43,7 +43,7 @@ impl Callbacks for MockCallbacks {
 async fn test_session_id() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
-  let strategy = Strategy::fixed(sdk_directory.path(), callbacks.clone());
+  let StrategyParts { strategy, .. } = Strategy::fixed(sdk_directory.path(), callbacks.clone());
 
   let session_id = strategy.session_id().await.unwrap();
   let previous_session_id = strategy.previous_process_session_id();
@@ -57,7 +57,7 @@ async fn test_session_id() {
 async fn try_current_session_id_fails_before_initialization() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
-  let strategy = Strategy::fixed(sdk_directory.path(), callbacks.clone());
+  let StrategyParts { strategy, .. } = Strategy::fixed(sdk_directory.path(), callbacks.clone());
 
   let error = strategy.try_current_session_id().unwrap_err();
 
@@ -68,7 +68,8 @@ async fn try_current_session_id_fails_before_initialization() {
 #[tokio::test]
 async fn try_current_session_id_returns_loaded_session() {
   let sdk_directory = TempDir::new().unwrap();
-  let strategy = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
+  let StrategyParts { strategy, .. } =
+    Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
 
   let session_id = strategy.session_id().await.unwrap();
 
@@ -79,14 +80,14 @@ async fn try_current_session_id_returns_loaded_session() {
 async fn test_start_new_session() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
-  let strategy = Strategy::fixed(sdk_directory.path(), callbacks.clone());
+  let StrategyParts { strategy, .. } = Strategy::fixed(sdk_directory.path(), callbacks.clone());
 
   let session_id = strategy.session_id().await.unwrap();
 
   assert_eq!(1, callbacks.generated_session_ids.lock().len());
   assert_eq!(callbacks.generated_session_ids.lock()[0], session_id);
 
-  start_new_session(&strategy).await;
+  strategy.start_new_session().unwrap();
   let next_session_id = strategy.session_id().await.unwrap();
 
   assert_eq!(next_session_id, strategy.session_id().await.unwrap());
@@ -98,18 +99,19 @@ async fn test_start_new_session() {
 #[tokio::test]
 async fn test_previous_process_session_id() {
   let sdk_directory = TempDir::new().unwrap();
-  let strategy = Arc::new(Strategy::fixed(
-    sdk_directory.path(),
-    Arc::new(UUIDCallbacks),
-  ));
+  let StrategyParts {
+    strategy,
+    persistence_worker: worker,
+  } = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   strategy.session_id().await.unwrap();
-  start_new_session(&strategy).await;
+  strategy.start_new_session().unwrap();
   let session_id = strategy.session_id().await.unwrap();
 
   assert!(strategy.previous_process_session_id().is_none());
-  flush(strategy.clone()).await;
+  flush(strategy.clone(), worker).await;
 
-  let strategy = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
+  let StrategyParts { strategy, .. } =
+    Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   assert_eq!(Some(session_id), strategy.previous_process_session_id());
 }
 
@@ -117,18 +119,27 @@ async fn test_previous_process_session_id() {
 async fn session_id_persists_only_after_flush() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
-  let strategy = Arc::new(Strategy::fixed(sdk_directory.path(), callbacks));
+  let StrategyParts {
+    strategy,
+    persistence_worker: worker,
+  } = Strategy::fixed(sdk_directory.path(), callbacks);
 
   let session_id = strategy.session_id().await.unwrap();
 
   assert_eq!(session_id, strategy.try_current_session_id().unwrap());
 
-  let restarted = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
+  let StrategyParts {
+    strategy: restarted,
+    ..
+  } = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   assert_eq!(None, restarted.previous_process_session_id());
 
-  flush(strategy.clone()).await;
+  flush(strategy.clone(), worker).await;
 
-  let restarted = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
+  let StrategyParts {
+    strategy: restarted,
+    ..
+  } = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   assert_eq!(Some(session_id), restarted.previous_process_session_id());
 }
 
@@ -142,7 +153,7 @@ struct ReEntryCallbacks {
 impl Callbacks for ReEntryCallbacks {
   fn generate_session_id(&self) -> anyhow::Result<String> {
     if let Some(strategy) = &*self.session_strategy.lock() {
-      expect_ready(start_new_session(strategy));
+      let _ignored = strategy.start_new_session();
       let error = expect_ready(strategy.session_id()).unwrap_err();
       *self.inner_session_id_error.lock() = Some(error.to_string());
       let error = strategy.try_current_session_id().unwrap_err();
@@ -159,7 +170,7 @@ async fn handles_re_entry() {
   let sdk_directory = TempDir::new().unwrap();
 
   let callbacks = Arc::new(ReEntryCallbacks::default());
-  let strategy = Arc::new(Strategy::fixed(sdk_directory.path(), callbacks.clone()));
+  let StrategyParts { strategy, .. } = Strategy::fixed(sdk_directory.path(), callbacks.clone());
 
   callbacks.session_strategy.lock().replace(strategy.clone());
 
@@ -176,7 +187,7 @@ async fn handles_re_entry() {
   );
 
   // Confirm that it doesn't deadlock and returns a reasonable ID.
-  start_new_session(&strategy).await;
+  strategy.start_new_session().unwrap();
   let new_session_id = strategy.session_id().await.unwrap();
   assert_eq!(36, new_session_id.len());
 

--- a/bd-session/src/fixed_test.rs
+++ b/bd-session/src/fixed_test.rs
@@ -7,24 +7,11 @@
 
 use super::{Callbacks, UUIDCallbacks};
 use crate::test::flush;
-use crate::{Strategy, StrategyParts};
+use crate::{Strategy, StrategyWithWorker};
 use pretty_assertions::assert_eq;
-use std::future::Future;
-use std::pin::pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 use tempfile::TempDir;
 use uuid::Uuid;
-
-fn expect_ready<T>(future: impl Future<Output = T>) -> T {
-  let waker = Arc::new(std::task::Waker::noop());
-  let mut context = Context::from_waker(&waker);
-  let mut future = pin!(future);
-  match future.as_mut().poll(&mut context) {
-    Poll::Ready(value) => value,
-    Poll::Pending => panic!("future unexpectedly pending"),
-  }
-}
 
 #[derive(Default)]
 struct MockCallbacks {
@@ -43,9 +30,10 @@ impl Callbacks for MockCallbacks {
 async fn test_session_id() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
-  let StrategyParts { strategy, .. } = Strategy::fixed(sdk_directory.path(), callbacks.clone());
+  let StrategyWithWorker { strategy, .. } =
+    Strategy::fixed(sdk_directory.path(), callbacks.clone());
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
   let previous_session_id = strategy.previous_process_session_id();
 
   assert_eq!(1, callbacks.generated_session_ids.lock().len());
@@ -57,7 +45,8 @@ async fn test_session_id() {
 async fn try_current_session_id_fails_before_initialization() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
-  let StrategyParts { strategy, .. } = Strategy::fixed(sdk_directory.path(), callbacks.clone());
+  let StrategyWithWorker { strategy, .. } =
+    Strategy::fixed(sdk_directory.path(), callbacks.clone());
 
   let error = strategy.try_current_session_id().unwrap_err();
 
@@ -68,10 +57,10 @@ async fn try_current_session_id_fails_before_initialization() {
 #[tokio::test]
 async fn try_current_session_id_returns_loaded_session() {
   let sdk_directory = TempDir::new().unwrap();
-  let StrategyParts { strategy, .. } =
+  let StrategyWithWorker { strategy, .. } =
     Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   assert_eq!(session_id, strategy.try_current_session_id().unwrap());
 }
@@ -80,17 +69,18 @@ async fn try_current_session_id_returns_loaded_session() {
 async fn test_start_new_session() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
-  let StrategyParts { strategy, .. } = Strategy::fixed(sdk_directory.path(), callbacks.clone());
+  let StrategyWithWorker { strategy, .. } =
+    Strategy::fixed(sdk_directory.path(), callbacks.clone());
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   assert_eq!(1, callbacks.generated_session_ids.lock().len());
   assert_eq!(callbacks.generated_session_ids.lock()[0], session_id);
 
   strategy.start_new_session().unwrap();
-  let next_session_id = strategy.session_id().await.unwrap();
+  let next_session_id = strategy.session_id().unwrap();
 
-  assert_eq!(next_session_id, strategy.session_id().await.unwrap());
+  assert_eq!(next_session_id, strategy.session_id().unwrap());
   assert_eq!(2, callbacks.generated_session_ids.lock().len());
   assert_eq!(callbacks.generated_session_ids.lock()[1], next_session_id);
   assert_eq!(None, strategy.previous_process_session_id());
@@ -99,18 +89,18 @@ async fn test_start_new_session() {
 #[tokio::test]
 async fn test_previous_process_session_id() {
   let sdk_directory = TempDir::new().unwrap();
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy,
     persistence_worker: worker,
   } = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
-  strategy.session_id().await.unwrap();
+  strategy.session_id().unwrap();
   strategy.start_new_session().unwrap();
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   assert!(strategy.previous_process_session_id().is_none());
   flush(strategy.clone(), worker).await;
 
-  let StrategyParts { strategy, .. } =
+  let StrategyWithWorker { strategy, .. } =
     Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
   assert_eq!(Some(session_id), strategy.previous_process_session_id());
 }
@@ -119,16 +109,16 @@ async fn test_previous_process_session_id() {
 async fn session_id_persists_only_after_flush() {
   let sdk_directory = TempDir::new().unwrap();
   let callbacks = Arc::new(MockCallbacks::default());
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy,
     persistence_worker: worker,
   } = Strategy::fixed(sdk_directory.path(), callbacks);
 
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   assert_eq!(session_id, strategy.try_current_session_id().unwrap());
 
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy: restarted,
     ..
   } = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
@@ -136,7 +126,7 @@ async fn session_id_persists_only_after_flush() {
 
   flush(strategy.clone(), worker).await;
 
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy: restarted,
     ..
   } = Strategy::fixed(sdk_directory.path(), Arc::new(UUIDCallbacks));
@@ -154,7 +144,7 @@ impl Callbacks for ReEntryCallbacks {
   fn generate_session_id(&self) -> anyhow::Result<String> {
     if let Some(strategy) = &*self.session_strategy.lock() {
       let _ignored = strategy.start_new_session();
-      let error = expect_ready(strategy.session_id()).unwrap_err();
+      let error = strategy.session_id().unwrap_err();
       *self.inner_session_id_error.lock() = Some(error.to_string());
       let error = strategy.try_current_session_id().unwrap_err();
       *self.inner_try_current_session_id_error.lock() = Some(error.to_string());
@@ -170,12 +160,13 @@ async fn handles_re_entry() {
   let sdk_directory = TempDir::new().unwrap();
 
   let callbacks = Arc::new(ReEntryCallbacks::default());
-  let StrategyParts { strategy, .. } = Strategy::fixed(sdk_directory.path(), callbacks.clone());
+  let StrategyWithWorker { strategy, .. } =
+    Strategy::fixed(sdk_directory.path(), callbacks.clone());
 
   callbacks.session_strategy.lock().replace(strategy.clone());
 
   // Confirm that it doesn't deadlock and returns a reasonable ID.
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
   assert_eq!(36, session_id.len());
   assert_eq!(
     Some("session_id cannot be called from within a session callback".to_string()),
@@ -188,7 +179,7 @@ async fn handles_re_entry() {
 
   // Confirm that it doesn't deadlock and returns a reasonable ID.
   strategy.start_new_session().unwrap();
-  let new_session_id = strategy.session_id().await.unwrap();
+  let new_session_id = strategy.session_id().unwrap();
   assert_eq!(36, new_session_id.len());
 
   assert_ne!(session_id, new_session_id);

--- a/bd-session/src/lib.rs
+++ b/bd-session/src/lib.rs
@@ -725,6 +725,11 @@ impl Strategy {
     .await;
 
     if let Err(e) = result {
+      // Keep the latest in-memory state dirty so the next flush or mutation retries this
+      // best-effort write. Mutations that occurred during I/O are retained by the same flag.
+      if let Some(state) = self.state.lock().as_mut() {
+        state.persistence_pending = true;
+      }
       on_persistence_failure();
       log::warn!("failed to persist coalesced session snapshot: {e}");
     }

--- a/bd-session/src/lib.rs
+++ b/bd-session/src/lib.rs
@@ -51,7 +51,7 @@ use std::path::Path;
 use std::sync::Arc;
 use thread_local::ThreadLocal;
 use time::OffsetDateTime;
-use tokio::sync::{Mutex as AsyncMutex, mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 
 //
 // LoadedState
@@ -64,8 +64,7 @@ pub(crate) struct LoadedState {
   persisted: PersistedSessionState,
   pending_started_sessions: Vec<StartedSessionRecord>,
   last_activity_write: Option<OffsetDateTime>,
-  persistence_generation: u64,
-  completed_persistence_generation: u64,
+  persistence_pending: bool,
 }
 
 //
@@ -102,6 +101,15 @@ pub(crate) struct Initialization {
 #[derive(Clone, Debug)]
 pub(crate) enum DeferredCallback {
   ActivitySessionChanged(String),
+}
+
+//
+// PersistenceRequest
+//
+
+enum PersistenceRequest {
+  Persist,
+  Flush(oneshot::Sender<()>),
 }
 
 //
@@ -175,11 +183,10 @@ pub struct Strategy {
   backend: Backend,
   store: Store,
   state: PlatformMutex<Option<LoadedState>>,
-  persistence_tx: mpsc::Sender<()>,
-  persistence_rx: AsyncMutex<mpsc::Receiver<()>>,
-  // Both the dedicated flusher and an explicit flush can request persistence. This lock keeps
-  // those SDK-owned tasks to one in-flight disk write without ever being taken by a caller thread.
-  persistence_writer: AsyncMutex<()>,
+  persistence_tx: mpsc::Sender<PersistenceRequest>,
+  // The single persistence worker takes this receiver before awaiting any I/O. Session callers
+  // only hold the sender, so they never contend with disk writes or create a second writer.
+  persistence_rx: PlatformMutex<Option<mpsc::Receiver<PersistenceRequest>>>,
   update_tx: watch::Sender<u64>,
   callback_in_progress: Box<ThreadLocal<Cell<bool>>>,
 }
@@ -194,8 +201,7 @@ impl Strategy {
       store: Store::new(sdk_directory),
       state: PlatformMutex::new(None),
       persistence_tx,
-      persistence_rx: AsyncMutex::new(persistence_rx),
-      persistence_writer: AsyncMutex::new(()),
+      persistence_rx: PlatformMutex::new(Some(persistence_rx)),
       update_tx,
       callback_in_progress: Box::new(ThreadLocal::new()),
     }
@@ -219,8 +225,7 @@ impl Strategy {
       store: Store::new(sdk_directory),
       state: PlatformMutex::new(None),
       persistence_tx,
-      persistence_rx: AsyncMutex::new(persistence_rx),
-      persistence_writer: AsyncMutex::new(()),
+      persistence_rx: PlatformMutex::new(Some(persistence_rx)),
       update_tx,
       callback_in_progress: Box::new(ThreadLocal::new()),
     }
@@ -334,28 +339,30 @@ impl Strategy {
     result
   }
 
-  /// Drains the latest coalesced session snapshot. A failed write is a completed best-effort
-  /// attempt; callers never wait indefinitely for durable storage.
+  /// Requests that the persistence worker drain the latest coalesced session snapshot.
+  ///
+  /// The request remains queued until the worker runs, then completes after its best-effort write
+  /// attempt. Session APIs never await this path; only an explicit flush waits for completion.
   pub async fn flush(&self) {
     if self.state.lock().is_none() {
       log::debug!("no session state to flush");
       return;
     }
 
-    self.persist_pending(None).await;
-  }
-
-  /// Drains persistence while recording any durable-write failure through the supplied metric.
-  pub async fn flush_with_persistence_failure_callback(
-    &self,
-    on_persistence_failure: impl Fn() + Send + Sync,
-  ) {
-    if self.state.lock().is_none() {
-      log::debug!("no session state to flush");
+    let (completion_tx, completion_rx) = oneshot::channel();
+    if self
+      .persistence_tx
+      .send(PersistenceRequest::Flush(completion_tx))
+      .await
+      .is_err()
+    {
+      log::debug!("session persistence worker stopped before flush could be queued");
       return;
     }
 
-    self.persist_pending(Some(&on_persistence_failure)).await;
+    if completion_rx.await.is_err() {
+      log::debug!("session persistence worker stopped before completing flush");
+    }
   }
 
   /// Runs the dedicated coalescing writer until `shutdown` resolves.
@@ -366,13 +373,31 @@ impl Strategy {
   ) where
     F: Future<Output = ()> + Send,
   {
-    let mut receiver = self.persistence_rx.lock().await;
+    let Some(mut receiver) = self.persistence_rx.lock().take() else {
+      log::warn!("attempted to start a second session persistence worker");
+      return;
+    };
+
     tokio::pin!(shutdown);
     loop {
       tokio::select! {
-        Some(()) = receiver.recv() => self.persist_pending(Some(&on_persistence_failure)).await,
+        Some(request) = receiver.recv() => {
+          let completion_tx = match request {
+            PersistenceRequest::Persist => None,
+            PersistenceRequest::Flush(completion_tx) => Some(completion_tx),
+          };
+          self.persist_latest(&on_persistence_failure).await;
+          if let Some(completion_tx) = completion_tx {
+            let _ignored = completion_tx.send(());
+          }
+        },
         () = &mut shutdown => {
-          self.persist_pending(Some(&on_persistence_failure)).await;
+          self.persist_latest(&on_persistence_failure).await;
+          while let Ok(request) = receiver.try_recv() {
+            if let PersistenceRequest::Flush(completion_tx) = request {
+              let _ignored = completion_tx.send(());
+            }
+          }
           return;
         },
       }
@@ -478,8 +503,7 @@ impl Strategy {
           persisted: self.store.load_state().unwrap_or_default(),
           pending_started_sessions: self.store.load_pending_started_sessions(),
           last_activity_write: None,
-          persistence_generation: 0,
-          completed_persistence_generation: 0,
+          persistence_pending: false,
         });
       }
 
@@ -503,7 +527,7 @@ impl Strategy {
       state
         .pending_started_sessions
         .drain(.. update.started_sessions.len());
-      state.persistence_generation = state.persistence_generation.wrapping_add(1);
+      state.persistence_pending = true;
       state.pending_started_sessions.clone()
     };
 
@@ -513,7 +537,7 @@ impl Strategy {
       pending_started_sessions.len()
     );
     self.notify_update();
-    let _ignored = self.persistence_tx.try_send(());
+    let _ignored = self.persistence_tx.try_send(PersistenceRequest::Persist);
   }
 
   /// Pretty name of the strategy.
@@ -617,25 +641,20 @@ impl Strategy {
   ) -> Mutation {
     // Once a process has initialized session state, its in-memory snapshot is newer than disk
     // until the coalescing writer catches up. Re-reading disk here would drop rapid rotations.
-    let (persisted, pending_started_sessions, persistence_generation, completed_generation) =
-      guard.as_ref().map_or_else(
-        || {
-          (
-            self.store.load_state(),
-            self.store.load_pending_started_sessions(),
-            0,
-            0,
-          )
-        },
-        |state| {
-          (
-            Some(state.persisted.clone()),
-            state.pending_started_sessions.clone(),
-            state.persistence_generation,
-            state.completed_persistence_generation,
-          )
-        },
-      );
+    let (persisted, pending_started_sessions) = guard.as_ref().map_or_else(
+      || {
+        (
+          self.store.load_state(),
+          self.store.load_pending_started_sessions(),
+        )
+      },
+      |state| {
+        (
+          Some(state.persisted.clone()),
+          state.pending_started_sessions.clone(),
+        )
+      },
+    );
     log::debug!(
       "starting explicit session rotation: backend={}, cached_state={}, has_persisted_state={}, \
        pending_started_sessions={}",
@@ -665,10 +684,7 @@ impl Strategy {
       initialization.state.pending_started_sessions.len()
     );
 
-    let mut state = initialization.state;
-    state.persistence_generation = persistence_generation;
-    state.completed_persistence_generation = completed_generation;
-    **guard = Some(state);
+    **guard = Some(initialization.state);
     initialization.mutation
   }
 
@@ -693,9 +709,9 @@ impl Strategy {
 
     if mutation.persist_state || mutation.persist_pending {
       if let Some(state) = self.state.lock().as_mut() {
-        state.persistence_generation = state.persistence_generation.wrapping_add(1);
+        state.persistence_pending = true;
       }
-      let _ignored = self.persistence_tx.try_send(());
+      let _ignored = self.persistence_tx.try_send(PersistenceRequest::Persist);
     }
     if mutation.persist_pending {
       self.notify_update();
@@ -703,45 +719,36 @@ impl Strategy {
     self.run_callback(mutation.callback);
   }
 
-  async fn persist_pending(&self, on_persistence_failure: Option<&(dyn Fn() + Send + Sync)>) {
-    let _writer = self.persistence_writer.lock().await;
-    loop {
-      let Some((generation, snapshot)) = self.state.lock().as_ref().and_then(|state| {
-        (state.persistence_generation > state.completed_persistence_generation)
-          .then(|| (state.persistence_generation, state.clone()))
-      }) else {
-        return;
-      };
+  async fn persist_latest(&self, on_persistence_failure: &(dyn Fn() + Send + Sync)) {
+    let Some(snapshot) = self.state.lock().as_mut().and_then(|state| {
+      state.persistence_pending.then(|| {
+        state.persistence_pending = false;
+        state.clone()
+      })
+    }) else {
+      return;
+    };
 
-      log::debug!(
-        "persisting coalesced session snapshot: backend={}, generation={}, current_session_id={}, \
-         pending_started_sessions={}",
-        self.type_name(),
-        generation,
-        snapshot.persisted.current_session_id,
-        snapshot.pending_started_sessions.len()
-      );
+    log::debug!(
+      "persisting coalesced session snapshot: backend={}, current_session_id={}, \
+       pending_started_sessions={}",
+      self.type_name(),
+      snapshot.persisted.current_session_id,
+      snapshot.pending_started_sessions.len()
+    );
 
-      let result = async {
-        self.store.persist_state(&snapshot.persisted).await?;
-        self
-          .store
-          .persist_pending_started_sessions(&snapshot.pending_started_sessions)
-          .await
-      }
-      .await;
+    let result = async {
+      self.store.persist_state(&snapshot.persisted).await?;
+      self
+        .store
+        .persist_pending_started_sessions(&snapshot.pending_started_sessions)
+        .await
+    }
+    .await;
 
-      if let Err(e) = result {
-        if let Some(on_persistence_failure) = on_persistence_failure {
-          on_persistence_failure();
-        }
-        log::warn!("failed to persist coalesced session snapshot: {e}");
-      }
-
-      if let Some(state) = self.state.lock().as_mut() {
-        state.completed_persistence_generation =
-          state.completed_persistence_generation.max(generation);
-      }
+    if let Err(e) = result {
+      on_persistence_failure();
+      log::warn!("failed to persist coalesced session snapshot: {e}");
     }
   }
 

--- a/bd-session/src/lib.rs
+++ b/bd-session/src/lib.rs
@@ -46,11 +46,12 @@ use bd_proto::protos::client::api::state_update_request::StartedSession;
 use bd_time::{OffsetDateTimeExt as _, TimeProvider};
 use persistence::{BackendState, PersistedSessionState, StartedSessionRecord, Store};
 use std::cell::Cell;
+use std::future::Future;
 use std::path::Path;
 use std::sync::Arc;
 use thread_local::ThreadLocal;
 use time::OffsetDateTime;
-use tokio::sync::watch;
+use tokio::sync::{Mutex as AsyncMutex, mpsc, watch};
 
 //
 // LoadedState
@@ -63,6 +64,8 @@ pub(crate) struct LoadedState {
   persisted: PersistedSessionState,
   pending_started_sessions: Vec<StartedSessionRecord>,
   last_activity_write: Option<OffsetDateTime>,
+  persistence_generation: u64,
+  completed_persistence_generation: u64,
 }
 
 //
@@ -99,99 +102,6 @@ pub(crate) struct Initialization {
 #[derive(Clone, Debug)]
 pub(crate) enum DeferredCallback {
   ActivitySessionChanged(String),
-}
-
-//
-// PreparedSessionOperation
-//
-
-/// A session operation whose synchronous state transition has already been computed.
-///
-/// Callers can inspect the resulting session ID immediately, persist the durable mutation on a
-/// different thread, and then run any deferred callback back on the originating thread.
-#[derive(Debug)]
-enum PreparedSessionOperationInner {
-  Noop {
-    current_session_id: String,
-  },
-  FollowUp {
-    state: LoadedState,
-    mutation: Mutation,
-  },
-}
-
-#[derive(Debug)]
-pub struct PreparedSessionOperation(PreparedSessionOperationInner);
-
-impl PreparedSessionOperation {
-  fn noop(current_session_id: String) -> Self {
-    Self(PreparedSessionOperationInner::Noop { current_session_id })
-  }
-
-  fn follow_up(state: LoadedState, mutation: Mutation) -> Self {
-    Self(PreparedSessionOperationInner::FollowUp { state, mutation })
-  }
-
-  #[must_use]
-  pub fn current_session_id(&self) -> &str {
-    match &self.0 {
-      PreparedSessionOperationInner::Noop { current_session_id } => current_session_id,
-      PreparedSessionOperationInner::FollowUp { state, .. } => &state.persisted.current_session_id,
-    }
-  }
-
-  #[must_use]
-  pub fn into_current_session_id(self) -> String {
-    match self.0 {
-      PreparedSessionOperationInner::Noop { current_session_id } => current_session_id,
-      PreparedSessionOperationInner::FollowUp { state, .. } => state.persisted.current_session_id,
-    }
-  }
-
-  #[must_use]
-  pub fn has_follow_up_work(&self) -> bool {
-    matches!(self.0, PreparedSessionOperationInner::FollowUp { .. })
-  }
-
-  #[must_use]
-  pub fn estimated_size(&self) -> usize {
-    match &self.0 {
-      PreparedSessionOperationInner::Noop { current_session_id } => {
-        std::mem::size_of_val(self) + current_session_id.len()
-      },
-      PreparedSessionOperationInner::FollowUp { state, mutation } => {
-        let pending_started_sessions_size = state
-          .pending_started_sessions
-          .iter()
-          .map(|started| started.session_id.len())
-          .sum::<usize>();
-        let callback_size = match &mutation.callback {
-          Some(DeferredCallback::ActivitySessionChanged(session_id)) => session_id.len(),
-          None => 0,
-        };
-
-        std::mem::size_of_val(self)
-          + state.persisted.current_session_id.len()
-          + state
-            .persisted
-            .previous_process_session_id
-            .as_ref()
-            .map_or(0, String::len)
-          + pending_started_sessions_size
-          + callback_size
-      },
-    }
-  }
-}
-
-//
-// PreparedSessionCallback
-//
-
-/// A deferred session callback that should run only after persistence has completed.
-#[derive(Debug)]
-pub struct PreparedSessionCallback {
-  callback: Option<DeferredCallback>,
 }
 
 //
@@ -265,6 +175,11 @@ pub struct Strategy {
   backend: Backend,
   store: Store,
   state: PlatformMutex<Option<LoadedState>>,
+  persistence_tx: mpsc::Sender<()>,
+  persistence_rx: AsyncMutex<mpsc::Receiver<()>>,
+  // Both the dedicated flusher and an explicit flush can request persistence. This lock keeps
+  // those SDK-owned tasks to one in-flight disk write without ever being taken by a caller thread.
+  persistence_writer: AsyncMutex<()>,
   update_tx: watch::Sender<u64>,
   callback_in_progress: Box<ThreadLocal<Cell<bool>>>,
 }
@@ -273,10 +188,14 @@ impl Strategy {
   #[must_use]
   pub fn fixed(sdk_directory: impl AsRef<Path>, callbacks: Arc<dyn fixed::Callbacks>) -> Self {
     let (update_tx, _) = watch::channel(0);
+    let (persistence_tx, persistence_rx) = mpsc::channel(1);
     Self {
       backend: Backend::Fixed(fixed::Strategy::new(callbacks)),
       store: Store::new(sdk_directory),
       state: PlatformMutex::new(None),
+      persistence_tx,
+      persistence_rx: AsyncMutex::new(persistence_rx),
+      persistence_writer: AsyncMutex::new(()),
       update_tx,
       callback_in_progress: Box::new(ThreadLocal::new()),
     }
@@ -290,6 +209,7 @@ impl Strategy {
     time_provider: Arc<dyn TimeProvider>,
   ) -> Self {
     let (update_tx, _) = watch::channel(0);
+    let (persistence_tx, persistence_rx) = mpsc::channel(1);
     Self {
       backend: Backend::ActivityBased(activity_based::Strategy::new(
         inactivity_threshold,
@@ -298,6 +218,9 @@ impl Strategy {
       )),
       store: Store::new(sdk_directory),
       state: PlatformMutex::new(None),
+      persistence_tx,
+      persistence_rx: AsyncMutex::new(persistence_rx),
+      persistence_writer: AsyncMutex::new(()),
       update_tx,
       callback_in_progress: Box::new(ThreadLocal::new()),
     }
@@ -319,10 +242,14 @@ impl Strategy {
     Self::loaded_session_id(state)
   }
 
-  pub fn prepare_session_id(&self) -> anyhow::Result<PreparedSessionOperation> {
+  /// Resolves the current session ID and schedules any resulting durable mutation.
+  ///
+  /// This is synchronous so caller-thread APIs do not depend on the logger task making progress.
+  /// Persistence is coalesced by the background flusher after this method returns.
+  pub fn session_id_sync(&self) -> anyhow::Result<String> {
     self.ensure_not_in_callback("session_id")?;
 
-    {
+    let (current_session_id, mutation) = {
       let mut guard = self.state.lock();
       if let Some(state) = guard.as_mut() {
         // Session reads and activity updates share the same mutation path so activity-based
@@ -333,21 +260,7 @@ impl Strategy {
         };
 
         let current_session_id = Self::loaded_session_id(state)?;
-        if mutation.has_follow_up_work() {
-          log::debug!(
-            "session read requires follow-up work: backend={}, current_session_id={}, \
-             persist_state={}, persist_pending={}, callback={}",
-            self.type_name(),
-            current_session_id,
-            mutation.persist_state,
-            mutation.persist_pending,
-            mutation.callback.is_some()
-          );
-
-          Ok(PreparedSessionOperation::follow_up(state.clone(), mutation))
-        } else {
-          Ok(PreparedSessionOperation::noop(current_session_id))
-        }
+        (current_session_id, mutation)
       } else {
         // The first read initializes from durable state and may enqueue a deferred callback if the
         // backend decides the current access should create or rotate a session.
@@ -366,40 +279,35 @@ impl Strategy {
           initialization.state.pending_started_sessions.len()
         );
 
-        if initialization.mutation.has_follow_up_work() {
-          Ok(PreparedSessionOperation::follow_up(
-            initialization.state,
-            initialization.mutation,
-          ))
-        } else {
-          Ok(PreparedSessionOperation::noop(current_session_id))
-        }
+        (current_session_id, initialization.mutation)
       }
-    }
+    };
+
+    self.apply_mutation(mutation);
+    Ok(current_session_id)
   }
 
-  pub fn prepare_start_new_session(&self) -> anyhow::Result<PreparedSessionOperation> {
+  /// Creates a new session and schedules persistence without waiting for disk I/O.
+  pub fn start_new_session_sync(&self) -> anyhow::Result<()> {
     self.ensure_not_in_callback("start_new_session")?;
 
-    let (state, mutation) = {
+    let mutation = {
       let mut guard = self.state.lock();
       self.start_new_session_locked(&mut guard)
     };
 
-    Ok(PreparedSessionOperation::follow_up(state, mutation))
+    self.apply_mutation(mutation);
+    Ok(())
   }
 
+  #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
   pub async fn session_id(&self) -> anyhow::Result<String> {
-    let prepared = self.prepare_session_id()?;
+    self.session_id_sync()
+  }
 
-    if !prepared.has_follow_up_work() {
-      return Ok(prepared.into_current_session_id());
-    }
-
-    let session_id = prepared.current_session_id().to_string();
-    let callback = self.persist_prepared(prepared).await;
-    self.run_prepared_callback(callback);
-    Ok(session_id)
+  #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
+  pub async fn start_new_session(&self) -> anyhow::Result<()> {
+    self.start_new_session_sync()
   }
 
   fn ensure_not_in_callback(&self, operation: &str) -> anyhow::Result<()> {
@@ -426,14 +334,48 @@ impl Strategy {
     result
   }
 
+  /// Drains the latest coalesced session snapshot. A failed write is a completed best-effort
+  /// attempt; callers never wait indefinitely for durable storage.
   pub async fn flush(&self) {
-    let Some(state) = self.state.lock().clone() else {
+    if self.state.lock().is_none() {
       log::debug!("no session state to flush");
       return;
-    };
+    }
 
-    if let Err(e) = self.store.persist_state(&state.persisted).await {
-      log::warn!("failed to persist session state during flush: {e}");
+    self.persist_pending(None).await;
+  }
+
+  /// Drains persistence while recording any durable-write failure through the supplied metric.
+  pub async fn flush_with_persistence_failure_callback(
+    &self,
+    on_persistence_failure: impl Fn() + Send + Sync,
+  ) {
+    if self.state.lock().is_none() {
+      log::debug!("no session state to flush");
+      return;
+    }
+
+    self.persist_pending(Some(&on_persistence_failure)).await;
+  }
+
+  /// Runs the dedicated coalescing writer until `shutdown` resolves.
+  pub async fn run_persistence_flusher<F>(
+    self: Arc<Self>,
+    shutdown: F,
+    on_persistence_failure: impl Fn() + Send + Sync + 'static,
+  ) where
+    F: Future<Output = ()> + Send,
+  {
+    let mut receiver = self.persistence_rx.lock().await;
+    tokio::pin!(shutdown);
+    loop {
+      tokio::select! {
+        Some(()) = receiver.recv() => self.persist_pending(Some(&on_persistence_failure)).await,
+        () = &mut shutdown => {
+          self.persist_pending(Some(&on_persistence_failure)).await;
+          return;
+        },
+      }
     }
   }
 
@@ -450,8 +392,9 @@ impl Strategy {
     )
   }
 
+  #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
   pub async fn handshake_state_update(&self) -> PendingStateUpdate {
-    let state = self.load_state_for_update().await;
+    let state = self.load_state_for_update();
 
     let mut request_started_sessions = state.pending_started_sessions.clone();
     // Handshakes must always include the current session. If the queue only contains older pending
@@ -486,10 +429,11 @@ impl Strategy {
     }
   }
 
+  #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
   pub async fn pending_state_update(&self) -> Option<PendingStateUpdate> {
     // Mid-stream state updates only send the durable queue. Unlike the handshake, they do not
     // synthesize the current session because the queue should already contain every unsent start.
-    let state = self.load_state_for_update().await;
+    let state = self.load_state_for_update();
 
     if state.pending_started_sessions.is_empty() {
       log::debug!(
@@ -521,6 +465,7 @@ impl Strategy {
     })
   }
 
+  #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
   pub async fn acknowledge_state_update(&self, update: &PendingStateUpdate) {
     if update.started_sessions.is_empty() {
       return;
@@ -533,6 +478,8 @@ impl Strategy {
           persisted: self.store.load_state().unwrap_or_default(),
           pending_started_sessions: self.store.load_pending_started_sessions(),
           last_activity_write: None,
+          persistence_generation: 0,
+          completed_persistence_generation: 0,
         });
       }
 
@@ -556,23 +503,17 @@ impl Strategy {
       state
         .pending_started_sessions
         .drain(.. update.started_sessions.len());
+      state.persistence_generation = state.persistence_generation.wrapping_add(1);
       state.pending_started_sessions.clone()
     };
 
-    if let Err(e) = self
-      .store
-      .persist_pending_started_sessions(&pending_started_sessions)
-      .await
-    {
-      log::warn!("failed to persist acknowledged started sessions: {e}");
-    } else {
-      log::debug!(
-        "acknowledged pending started sessions: backend={}, remaining_pending={}",
-        self.type_name(),
-        pending_started_sessions.len()
-      );
-      self.notify_update();
-    }
+    log::debug!(
+      "acknowledged pending started sessions: backend={}, remaining_pending={}",
+      self.type_name(),
+      pending_started_sessions.len()
+    );
+    self.notify_update();
+    let _ignored = self.persistence_tx.try_send(());
   }
 
   /// Pretty name of the strategy.
@@ -635,7 +576,7 @@ impl Strategy {
     }
   }
 
-  async fn load_state_for_update(&self) -> LoadedState {
+  fn load_state_for_update(&self) -> LoadedState {
     let (state, mutation) = {
       let mut guard = self.state.lock();
       if let Some(state) = guard.clone() {
@@ -666,19 +607,35 @@ impl Strategy {
       (initialization.state, initialization.mutation)
     };
 
-    let callback = self.finish_mutation(state.clone(), mutation).await;
-    self.run_callback(callback);
+    self.apply_mutation(mutation);
     state
   }
 
   fn start_new_session_locked(
     &self,
     guard: &mut PlatformMutexGuard<'_, Option<LoadedState>>,
-  ) -> (LoadedState, Mutation) {
-    // Explicit session rotation re-reads persisted state so the durable queue remains the source
-    // of truth even if this process has not initialized the in-memory cache yet.
-    let persisted = self.store.load_state();
-    let pending_started_sessions = self.store.load_pending_started_sessions();
+  ) -> Mutation {
+    // Once a process has initialized session state, its in-memory snapshot is newer than disk
+    // until the coalescing writer catches up. Re-reading disk here would drop rapid rotations.
+    let (persisted, pending_started_sessions, persistence_generation, completed_generation) =
+      guard.as_ref().map_or_else(
+        || {
+          (
+            self.store.load_state(),
+            self.store.load_pending_started_sessions(),
+            0,
+            0,
+          )
+        },
+        |state| {
+          (
+            Some(state.persisted.clone()),
+            state.pending_started_sessions.clone(),
+            state.persistence_generation,
+            state.completed_persistence_generation,
+          )
+        },
+      );
     log::debug!(
       "starting explicit session rotation: backend={}, cached_state={}, has_persisted_state={}, \
        pending_started_sessions={}",
@@ -708,86 +665,89 @@ impl Strategy {
       initialization.state.pending_started_sessions.len()
     );
 
-    **guard = Some(initialization.state.clone());
-    (initialization.state, initialization.mutation)
+    let mut state = initialization.state;
+    state.persistence_generation = persistence_generation;
+    state.completed_persistence_generation = completed_generation;
+    **guard = Some(state);
+    initialization.mutation
   }
 
-  pub async fn persist_prepared(
-    &self,
-    prepared: PreparedSessionOperation,
-  ) -> PreparedSessionCallback {
-    let callback = match prepared.0 {
-      PreparedSessionOperationInner::Noop { .. } => None,
-      PreparedSessionOperationInner::FollowUp { state, mutation } => {
-        self.finish_mutation(state, mutation).await
-      },
-    };
-    PreparedSessionCallback { callback }
-  }
+  fn apply_mutation(&self, mutation: Mutation) {
+    if !mutation.has_follow_up_work() {
+      return;
+    }
 
-  pub fn run_prepared_callback(&self, callback: PreparedSessionCallback) {
-    self.run_callback(callback.callback);
-  }
-
-  async fn finish_mutation(
-    &self,
-    state: LoadedState,
-    mutation: Mutation,
-  ) -> Option<DeferredCallback> {
     log::debug!(
-      "finishing session mutation: backend={}, current_session_id={}, persist_state={}, \
-       persist_pending={}, callback={}, pending_started_sessions={}",
+      "scheduling session mutation: backend={}, persist_state={}, persist_pending={}, \
+       callback={}, pending_started_sessions={}",
       self.type_name(),
-      state.persisted.current_session_id,
       mutation.persist_state,
       mutation.persist_pending,
       mutation.callback.is_some(),
-      state.pending_started_sessions.len()
+      self
+        .state
+        .lock()
+        .as_ref()
+        .map_or(0, |state| state.pending_started_sessions.len())
     );
 
-    let pending_changed = mutation.persist_pending;
-    let callback = mutation.callback.clone();
-    self.persist_loaded_state(&state, &mutation).await;
-    if pending_changed {
+    if mutation.persist_state || mutation.persist_pending {
+      if let Some(state) = self.state.lock().as_mut() {
+        state.persistence_generation = state.persistence_generation.wrapping_add(1);
+      }
+      let _ignored = self.persistence_tx.try_send(());
+    }
+    if mutation.persist_pending {
       self.notify_update();
     }
-    callback
+    self.run_callback(mutation.callback);
   }
 
-  async fn persist_loaded_state(&self, state: &LoadedState, mutation: &Mutation) {
-    // The strategy returns a mutation describing which durable pieces changed. Persist only those
-    // pieces so reads can stay cheap while the on-disk view remains crash-safe.
-    if mutation.persist_state || mutation.persist_pending {
+  async fn persist_pending(&self, on_persistence_failure: Option<&(dyn Fn() + Send + Sync)>) {
+    let _writer = self.persistence_writer.lock().await;
+    loop {
+      let Some((generation, snapshot)) = self.state.lock().as_ref().and_then(|state| {
+        (state.persistence_generation > state.completed_persistence_generation)
+          .then(|| (state.persistence_generation, state.clone()))
+      }) else {
+        return;
+      };
+
       log::debug!(
-        "persisting durable session state: backend={}, current_session_id={}, persist_state={}, \
-         persist_pending={}, pending_started_sessions={}",
+        "persisting coalesced session snapshot: backend={}, generation={}, current_session_id={}, \
+         pending_started_sessions={}",
         self.type_name(),
-        state.persisted.current_session_id,
-        mutation.persist_state,
-        mutation.persist_pending,
-        state.pending_started_sessions.len()
+        generation,
+        snapshot.persisted.current_session_id,
+        snapshot.pending_started_sessions.len()
       );
-    }
 
-    if mutation.persist_state
-      && let Err(e) = self.store.persist_state(&state.persisted).await
-    {
-      log::warn!("failed to persist session state: {e}");
-    }
+      let result = async {
+        self.store.persist_state(&snapshot.persisted).await?;
+        self
+          .store
+          .persist_pending_started_sessions(&snapshot.pending_started_sessions)
+          .await
+      }
+      .await;
 
-    if mutation.persist_pending
-      && let Err(e) = self
-        .store
-        .persist_pending_started_sessions(&state.pending_started_sessions)
-        .await
-    {
-      log::warn!("failed to persist started sessions: {e}");
+      if let Err(e) = result {
+        if let Some(on_persistence_failure) = on_persistence_failure {
+          on_persistence_failure();
+        }
+        log::warn!("failed to persist coalesced session snapshot: {e}");
+      }
+
+      if let Some(state) = self.state.lock().as_mut() {
+        state.completed_persistence_generation =
+          state.completed_persistence_generation.max(generation);
+      }
     }
   }
 
   fn run_callback(&self, callback: Option<DeferredCallback>) {
-    // Deferred callbacks run after state is persisted and locks are dropped so user code cannot
-    // observe half-applied transitions or deadlock against session APIs.
+    // Callbacks run on the calling thread after the state lock is dropped. This keeps platform
+    // integrations responsive and avoids coupling session rotation to best-effort disk I/O.
     match callback {
       Some(DeferredCallback::ActivitySessionChanged(session_id)) => {
         log::debug!(

--- a/bd-session/src/lib.rs
+++ b/bd-session/src/lib.rs
@@ -73,6 +73,7 @@ pub(crate) struct LoadedState {
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct TransitionEffects {
+  persist: bool,
   notify_update: bool,
   callback: Option<DeferredCallback>,
 }
@@ -191,20 +192,35 @@ pub struct PersistenceWorker {
   receiver: mpsc::Receiver<PersistenceRequest>,
 }
 
-/// The strategy and its single persistence worker.
+/// A session strategy paired with its single persistence worker.
 ///
-/// Keep both values together until the logger takes ownership of `persistence_worker`.
+/// Pass this to the logger builder, which splits and owns both components for the logger's
+/// lifetime. Call [`Self::strategy`] when a platform needs the strategy handle before then.
 #[must_use]
-pub struct StrategyParts {
-  pub strategy: Arc<Strategy>,
-  pub persistence_worker: PersistenceWorker,
+pub struct StrategyWithWorker {
+  strategy: Arc<Strategy>,
+  persistence_worker: PersistenceWorker,
+}
+
+impl StrategyWithWorker {
+  /// Returns the strategy handle without consuming the paired persistence worker.
+  #[must_use]
+  pub fn strategy(&self) -> Arc<Strategy> {
+    self.strategy.clone()
+  }
+
+  /// Separates the strategy from its worker for the logger's internal lifecycle management.
+  #[must_use]
+  pub fn into_parts(self) -> (Arc<Strategy>, PersistenceWorker) {
+    (self.strategy, self.persistence_worker)
+  }
 }
 
 impl Strategy {
   pub fn fixed(
     sdk_directory: impl AsRef<Path>,
     callbacks: Arc<dyn fixed::Callbacks>,
-  ) -> StrategyParts {
+  ) -> StrategyWithWorker {
     Self::make_parts(
       Backend::Fixed(fixed::Strategy::new(callbacks)),
       sdk_directory,
@@ -216,7 +232,7 @@ impl Strategy {
     inactivity_threshold: time::Duration,
     callbacks: Arc<dyn activity_based::Callbacks>,
     time_provider: Arc<dyn TimeProvider>,
-  ) -> StrategyParts {
+  ) -> StrategyWithWorker {
     Self::make_parts(
       Backend::ActivityBased(activity_based::Strategy::new(
         inactivity_threshold,
@@ -227,7 +243,7 @@ impl Strategy {
     )
   }
 
-  fn make_parts(backend: Backend, sdk_directory: impl AsRef<Path>) -> StrategyParts {
+  fn make_parts(backend: Backend, sdk_directory: impl AsRef<Path>) -> StrategyWithWorker {
     let (update_tx, _) = watch::channel(0);
     let (persistence_tx, persistence_rx) = mpsc::channel(1);
     let strategy = Arc::new(Self {
@@ -238,7 +254,7 @@ impl Strategy {
       update_tx,
       callback_in_progress: Box::new(ThreadLocal::new()),
     });
-    StrategyParts {
+    StrategyWithWorker {
       strategy: strategy.clone(),
       persistence_worker: PersistenceWorker {
         strategy,
@@ -267,26 +283,21 @@ impl Strategy {
   ///
   /// This is synchronous so caller-thread APIs do not depend on the logger task making progress.
   /// Persistence is coalesced by the background flusher after this method returns.
-  pub fn session_id_sync(&self) -> anyhow::Result<String> {
+  pub fn session_id(&self) -> anyhow::Result<String> {
     self.ensure_not_in_callback("session_id")?;
 
-    let (current_session_id, effects, wake_persistence) = {
+    let (current_session_id, effects) = {
       let mut guard = self.state.lock();
       if let Some(state) = guard.as_mut() {
         // Session reads and activity updates share the same transition path so activity-based
         // sessions can rotate or persist last-activity state while fixed sessions stay unchanged.
-        let was_persistence_pending = state.persistence_pending;
         let effects = match &self.backend {
           Backend::Fixed(_) => fixed::Strategy::on_session_id(state),
           Backend::ActivityBased(strategy) => strategy.on_session_id(state),
         };
 
         let current_session_id = Self::loaded_session_id(state)?;
-        (
-          current_session_id,
-          effects,
-          !was_persistence_pending && state.persistence_pending,
-        )
+        (current_session_id, effects)
       } else {
         // The first read initializes from durable state and may enqueue a deferred callback if the
         // backend decides the current access should create or rotate a session.
@@ -296,24 +307,20 @@ impl Strategy {
         let current_session_id = Self::loaded_session_id(&initialization.state)?;
         log::debug!(
           "initialized session state on first read: backend={}, current_session_id={}, \
-           persistence_pending={}, notify_update={}, callback={}, pending_started_sessions={}",
+           persist={}, notify_update={}, callback={}, pending_started_sessions={}",
           self.type_name(),
           current_session_id,
-          initialization.state.persistence_pending,
+          initialization.effects.persist,
           initialization.effects.notify_update,
           initialization.effects.callback.is_some(),
           initialization.state.pending_started_sessions.len()
         );
 
-        (
-          current_session_id,
-          initialization.effects,
-          initialization.state.persistence_pending,
-        )
+        (current_session_id, initialization.effects)
       }
     };
 
-    self.apply_effects(effects, wake_persistence);
+    self.apply_effects(effects);
     Ok(current_session_id)
   }
 
@@ -321,25 +328,13 @@ impl Strategy {
   pub fn start_new_session(&self) -> anyhow::Result<()> {
     self.ensure_not_in_callback("start_new_session")?;
 
-    let (effects, wake_persistence) = {
+    let effects = {
       let mut guard = self.state.lock();
-      let was_persistence_pending = guard
-        .as_ref()
-        .is_some_and(|state| state.persistence_pending);
-      let effects = self.start_new_session_locked(&mut guard);
-      let wake_persistence = guard
-        .as_ref()
-        .is_some_and(|state| !was_persistence_pending && state.persistence_pending);
-      (effects, wake_persistence)
+      self.start_new_session_locked(&mut guard)
     };
 
-    self.apply_effects(effects, wake_persistence);
+    self.apply_effects(effects);
     Ok(())
-  }
-
-  #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
-  pub async fn session_id(&self) -> anyhow::Result<String> {
-    self.session_id_sync()
   }
 
   fn ensure_not_in_callback(&self, operation: &str) -> anyhow::Result<()> {
@@ -405,8 +400,7 @@ impl Strategy {
     )
   }
 
-  #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
-  pub async fn handshake_state_update(&self) -> PendingStateUpdate {
+  pub fn handshake_state_update(&self) -> PendingStateUpdate {
     let state = self.load_state_for_update();
 
     let mut request_started_sessions = state.pending_started_sessions.clone();
@@ -442,8 +436,7 @@ impl Strategy {
     }
   }
 
-  #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
-  pub async fn pending_state_update(&self) -> Option<PendingStateUpdate> {
+  pub fn pending_state_update(&self) -> Option<PendingStateUpdate> {
     // Mid-stream state updates only send the durable queue. Unlike the handshake, they do not
     // synthesize the current session because the queue should already contain every unsent start.
     let state = self.load_state_for_update();
@@ -478,13 +471,12 @@ impl Strategy {
     })
   }
 
-  #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
-  pub async fn acknowledge_state_update(&self, update: &PendingStateUpdate) {
+  pub fn acknowledge_state_update(&self, update: &PendingStateUpdate) {
     if update.started_sessions.is_empty() {
       return;
     }
 
-    let (pending_started_sessions, wake_persistence) = {
+    let pending_started_sessions = {
       let mut guard = self.state.lock();
       if guard.is_none() {
         *guard = Some(LoadedState {
@@ -512,15 +504,11 @@ impl Strategy {
         return;
       }
 
-      let was_persistence_pending = state.persistence_pending;
       state
         .pending_started_sessions
         .drain(.. update.started_sessions.len());
       state.persistence_pending = true;
-      (
-        state.pending_started_sessions.clone(),
-        !was_persistence_pending,
-      )
+      state.pending_started_sessions.clone()
     };
 
     log::debug!(
@@ -528,13 +516,11 @@ impl Strategy {
       self.type_name(),
       pending_started_sessions.len()
     );
-    self.apply_effects(
-      TransitionEffects {
-        notify_update: true,
-        callback: None,
-      },
-      wake_persistence,
-    );
+    self.apply_effects(TransitionEffects {
+      persist: true,
+      notify_update: true,
+      callback: None,
+    });
   }
 
   /// Pretty name of the strategy.
@@ -598,7 +584,7 @@ impl Strategy {
   }
 
   fn load_state_for_update(&self) -> LoadedState {
-    let (state, effects, wake_persistence) = {
+    let (state, effects) = {
       let mut guard = self.state.lock();
       if let Some(state) = guard.clone() {
         log::debug!(
@@ -617,22 +603,18 @@ impl Strategy {
       *guard = Some(initialization.state.clone());
       log::debug!(
         "initialized session state for update flow: backend={}, current_session_id={}, \
-         persistence_pending={}, notify_update={}, callback={}, pending_started_sessions={}",
+         persist={}, notify_update={}, callback={}, pending_started_sessions={}",
         self.type_name(),
         initialization.state.persisted.current_session_id,
-        initialization.state.persistence_pending,
+        initialization.effects.persist,
         initialization.effects.notify_update,
         initialization.effects.callback.is_some(),
         initialization.state.pending_started_sessions.len()
       );
-      (
-        initialization.state.clone(),
-        initialization.effects,
-        initialization.state.persistence_pending,
-      )
+      (initialization.state.clone(), initialization.effects)
     };
 
-    self.apply_effects(effects, wake_persistence);
+    self.apply_effects(effects);
     state
   }
 
@@ -672,11 +654,11 @@ impl Strategy {
     };
 
     log::debug!(
-      "computed explicit session rotation: backend={}, current_session_id={}, \
-       persistence_pending={}, notify_update={}, callback={}, pending_started_sessions={}",
+      "computed explicit session rotation: backend={}, current_session_id={}, persist={}, \
+       notify_update={}, callback={}, pending_started_sessions={}",
       self.type_name(),
       initialization.state.persisted.current_session_id,
-      initialization.state.persistence_pending,
+      initialization.effects.persist,
       initialization.effects.notify_update,
       initialization.effects.callback.is_some(),
       initialization.state.pending_started_sessions.len()
@@ -686,16 +668,16 @@ impl Strategy {
     initialization.effects
   }
 
-  fn apply_effects(&self, effects: TransitionEffects, wake_persistence: bool) {
-    if !wake_persistence && !effects.notify_update && effects.callback.is_none() {
+  fn apply_effects(&self, effects: TransitionEffects) {
+    if !effects.persist && !effects.notify_update && effects.callback.is_none() {
       return;
     }
 
     log::debug!(
-      "applying session transition effects: backend={}, wake_persistence={}, notify_update={}, \
+      "applying session transition effects: backend={}, persist={}, notify_update={}, \
        callback={}, pending_started_sessions={}",
       self.type_name(),
-      wake_persistence,
+      effects.persist,
       effects.notify_update,
       effects.callback.is_some(),
       self
@@ -705,7 +687,8 @@ impl Strategy {
         .map_or(0, |state| state.pending_started_sessions.len())
     );
 
-    if wake_persistence {
+    if effects.persist {
+      // A full channel already holds a request that will persist the newest in-memory snapshot.
       let _ignored = self.persistence_tx.try_send(PersistenceRequest::Persist);
     }
     if effects.notify_update {
@@ -714,7 +697,7 @@ impl Strategy {
     self.run_callback(effects.callback);
   }
 
-  async fn persist_latest(&self, on_persistence_failure: &(dyn Fn() + Send + Sync)) {
+  async fn persist_current_state(&self, on_persistence_failure: &(dyn Fn() + Send + Sync)) {
     let Some(snapshot) = self.state.lock().as_mut().and_then(|state| {
       state.persistence_pending.then(|| {
         state.persistence_pending = false;
@@ -793,20 +776,25 @@ impl PersistenceWorker {
     loop {
       tokio::select! {
         Some(request) = self.receiver.recv() => {
-          let completion_tx = match request {
-            PersistenceRequest::Persist => None,
-            PersistenceRequest::Flush(completion_tx) => Some(completion_tx),
-          };
-          self.strategy.persist_latest(&on_persistence_failure).await;
-          if let Some(completion_tx) = completion_tx {
-            let _ignored = completion_tx.send(());
+          match request {
+            PersistenceRequest::Persist => {
+              self.strategy.persist_current_state(&on_persistence_failure).await;
+            },
+            PersistenceRequest::Flush(completion_tx) => {
+              // A mutation may have coalesced behind this barrier while it occupied the channel.
+              self.strategy.persist_current_state(&on_persistence_failure).await;
+              let _ignored = completion_tx.send(());
+            },
           }
         },
         () = &mut shutdown => {
-          self.strategy.persist_latest(&on_persistence_failure).await;
+          self.strategy.persist_current_state(&on_persistence_failure).await;
           while let Ok(request) = self.receiver.try_recv() {
-            if let PersistenceRequest::Flush(completion_tx) = request {
-              let _ignored = completion_tx.send(());
+            match request {
+              PersistenceRequest::Persist => {},
+              PersistenceRequest::Flush(completion_tx) => {
+                let _ignored = completion_tx.send(());
+              },
             }
           }
           return;

--- a/bd-session/src/lib.rs
+++ b/bd-session/src/lib.rs
@@ -40,7 +40,7 @@ fn test_global_init() {
   bd_test_helpers_core::test_global_init();
 }
 
-use bd_client_common::{PlatformMutex, PlatformMutexGuard};
+use bd_client_common::PlatformMutex;
 use bd_proto::protos::client::api::StateUpdateRequest;
 use bd_proto::protos::client::api::state_update_request::StartedSession;
 use bd_time::{OffsetDateTimeExt as _, TimeProvider};
@@ -68,30 +68,23 @@ pub(crate) struct LoadedState {
 }
 
 //
-// Mutation
+// TransitionEffects
 //
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct Mutation {
-  persist_state: bool,
-  persist_pending: bool,
+pub(crate) struct TransitionEffects {
+  notify_update: bool,
   callback: Option<DeferredCallback>,
 }
 
-impl Mutation {
-  fn has_follow_up_work(&self) -> bool {
-    self.persist_state || self.persist_pending || self.callback.is_some()
-  }
-}
-
 //
-// Initialization
+// Transition
 //
 
 #[derive(Clone, Debug)]
-pub(crate) struct Initialization {
+pub(crate) struct Transition {
   state: LoadedState,
-  mutation: Mutation,
+  effects: TransitionEffects,
 }
 
 //
@@ -184,50 +177,73 @@ pub struct Strategy {
   store: Store,
   state: PlatformMutex<Option<LoadedState>>,
   persistence_tx: mpsc::Sender<PersistenceRequest>,
-  // The single persistence worker takes this receiver before awaiting any I/O. Session callers
-  // only hold the sender, so they never contend with disk writes or create a second writer.
-  persistence_rx: PlatformMutex<Option<mpsc::Receiver<PersistenceRequest>>>,
   update_tx: watch::Sender<u64>,
   callback_in_progress: Box<ThreadLocal<Cell<bool>>>,
 }
 
+/// Owns the single persistence receiver for a [`Strategy`].
+///
+/// Run this worker for the lifetime of the logger. It serializes persistence and retains queued
+/// flush requests until it starts, while callers of [`Strategy`] only synchronize access to the
+/// in-memory session state.
+pub struct PersistenceWorker {
+  strategy: Arc<Strategy>,
+  receiver: mpsc::Receiver<PersistenceRequest>,
+}
+
+/// The strategy and its single persistence worker.
+///
+/// Keep both values together until the logger takes ownership of `persistence_worker`.
+#[must_use]
+pub struct StrategyParts {
+  pub strategy: Arc<Strategy>,
+  pub persistence_worker: PersistenceWorker,
+}
+
 impl Strategy {
-  #[must_use]
-  pub fn fixed(sdk_directory: impl AsRef<Path>, callbacks: Arc<dyn fixed::Callbacks>) -> Self {
-    let (update_tx, _) = watch::channel(0);
-    let (persistence_tx, persistence_rx) = mpsc::channel(1);
-    Self {
-      backend: Backend::Fixed(fixed::Strategy::new(callbacks)),
-      store: Store::new(sdk_directory),
-      state: PlatformMutex::new(None),
-      persistence_tx,
-      persistence_rx: PlatformMutex::new(Some(persistence_rx)),
-      update_tx,
-      callback_in_progress: Box::new(ThreadLocal::new()),
-    }
+  pub fn fixed(
+    sdk_directory: impl AsRef<Path>,
+    callbacks: Arc<dyn fixed::Callbacks>,
+  ) -> StrategyParts {
+    Self::make_parts(
+      Backend::Fixed(fixed::Strategy::new(callbacks)),
+      sdk_directory,
+    )
   }
 
-  #[must_use]
   pub fn activity_based(
     sdk_directory: impl AsRef<Path>,
     inactivity_threshold: time::Duration,
     callbacks: Arc<dyn activity_based::Callbacks>,
     time_provider: Arc<dyn TimeProvider>,
-  ) -> Self {
-    let (update_tx, _) = watch::channel(0);
-    let (persistence_tx, persistence_rx) = mpsc::channel(1);
-    Self {
-      backend: Backend::ActivityBased(activity_based::Strategy::new(
+  ) -> StrategyParts {
+    Self::make_parts(
+      Backend::ActivityBased(activity_based::Strategy::new(
         inactivity_threshold,
         callbacks,
         time_provider,
       )),
+      sdk_directory,
+    )
+  }
+
+  fn make_parts(backend: Backend, sdk_directory: impl AsRef<Path>) -> StrategyParts {
+    let (update_tx, _) = watch::channel(0);
+    let (persistence_tx, persistence_rx) = mpsc::channel(1);
+    let strategy = Arc::new(Self {
+      backend,
       store: Store::new(sdk_directory),
       state: PlatformMutex::new(None),
       persistence_tx,
-      persistence_rx: PlatformMutex::new(Some(persistence_rx)),
       update_tx,
       callback_in_progress: Box::new(ThreadLocal::new()),
+    });
+    StrategyParts {
+      strategy: strategy.clone(),
+      persistence_worker: PersistenceWorker {
+        strategy,
+        receiver: persistence_rx,
+      },
     }
   }
 
@@ -247,25 +263,30 @@ impl Strategy {
     Self::loaded_session_id(state)
   }
 
-  /// Resolves the current session ID and schedules any resulting durable mutation.
+  /// Resolves the current session ID and schedules any resulting durable transition.
   ///
   /// This is synchronous so caller-thread APIs do not depend on the logger task making progress.
   /// Persistence is coalesced by the background flusher after this method returns.
   pub fn session_id_sync(&self) -> anyhow::Result<String> {
     self.ensure_not_in_callback("session_id")?;
 
-    let (current_session_id, mutation) = {
+    let (current_session_id, effects, wake_persistence) = {
       let mut guard = self.state.lock();
       if let Some(state) = guard.as_mut() {
-        // Session reads and activity updates share the same mutation path so activity-based
+        // Session reads and activity updates share the same transition path so activity-based
         // sessions can rotate or persist last-activity state while fixed sessions stay unchanged.
-        let mutation = match &self.backend {
+        let was_persistence_pending = state.persistence_pending;
+        let effects = match &self.backend {
           Backend::Fixed(_) => fixed::Strategy::on_session_id(state),
           Backend::ActivityBased(strategy) => strategy.on_session_id(state),
         };
 
         let current_session_id = Self::loaded_session_id(state)?;
-        (current_session_id, mutation)
+        (
+          current_session_id,
+          effects,
+          !was_persistence_pending && state.persistence_pending,
+        )
       } else {
         // The first read initializes from durable state and may enqueue a deferred callback if the
         // backend decides the current access should create or rotate a session.
@@ -275,44 +296,50 @@ impl Strategy {
         let current_session_id = Self::loaded_session_id(&initialization.state)?;
         log::debug!(
           "initialized session state on first read: backend={}, current_session_id={}, \
-           persist_state={}, persist_pending={}, callback={}, pending_started_sessions={}",
+           persistence_pending={}, notify_update={}, callback={}, pending_started_sessions={}",
           self.type_name(),
           current_session_id,
-          initialization.mutation.persist_state,
-          initialization.mutation.persist_pending,
-          initialization.mutation.callback.is_some(),
+          initialization.state.persistence_pending,
+          initialization.effects.notify_update,
+          initialization.effects.callback.is_some(),
           initialization.state.pending_started_sessions.len()
         );
 
-        (current_session_id, initialization.mutation)
+        (
+          current_session_id,
+          initialization.effects,
+          initialization.state.persistence_pending,
+        )
       }
     };
 
-    self.apply_mutation(mutation);
+    self.apply_effects(effects, wake_persistence);
     Ok(current_session_id)
   }
 
   /// Creates a new session and schedules persistence without waiting for disk I/O.
-  pub fn start_new_session_sync(&self) -> anyhow::Result<()> {
+  pub fn start_new_session(&self) -> anyhow::Result<()> {
     self.ensure_not_in_callback("start_new_session")?;
 
-    let mutation = {
+    let (effects, wake_persistence) = {
       let mut guard = self.state.lock();
-      self.start_new_session_locked(&mut guard)
+      let was_persistence_pending = guard
+        .as_ref()
+        .is_some_and(|state| state.persistence_pending);
+      let effects = self.start_new_session_locked(&mut guard);
+      let wake_persistence = guard
+        .as_ref()
+        .is_some_and(|state| !was_persistence_pending && state.persistence_pending);
+      (effects, wake_persistence)
     };
 
-    self.apply_mutation(mutation);
+    self.apply_effects(effects, wake_persistence);
     Ok(())
   }
 
   #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
   pub async fn session_id(&self) -> anyhow::Result<String> {
     self.session_id_sync()
-  }
-
-  #[allow(clippy::unused_async)] // Preserve the established asynchronous session API.
-  pub async fn start_new_session(&self) -> anyhow::Result<()> {
-    self.start_new_session_sync()
   }
 
   fn ensure_not_in_callback(&self, operation: &str) -> anyhow::Result<()> {
@@ -362,45 +389,6 @@ impl Strategy {
 
     if completion_rx.await.is_err() {
       log::debug!("session persistence worker stopped before completing flush");
-    }
-  }
-
-  /// Runs the dedicated coalescing writer until `shutdown` resolves.
-  pub async fn run_persistence_flusher<F>(
-    self: Arc<Self>,
-    shutdown: F,
-    on_persistence_failure: impl Fn() + Send + Sync + 'static,
-  ) where
-    F: Future<Output = ()> + Send,
-  {
-    let Some(mut receiver) = self.persistence_rx.lock().take() else {
-      log::warn!("attempted to start a second session persistence worker");
-      return;
-    };
-
-    tokio::pin!(shutdown);
-    loop {
-      tokio::select! {
-        Some(request) = receiver.recv() => {
-          let completion_tx = match request {
-            PersistenceRequest::Persist => None,
-            PersistenceRequest::Flush(completion_tx) => Some(completion_tx),
-          };
-          self.persist_latest(&on_persistence_failure).await;
-          if let Some(completion_tx) = completion_tx {
-            let _ignored = completion_tx.send(());
-          }
-        },
-        () = &mut shutdown => {
-          self.persist_latest(&on_persistence_failure).await;
-          while let Ok(request) = receiver.try_recv() {
-            if let PersistenceRequest::Flush(completion_tx) = request {
-              let _ignored = completion_tx.send(());
-            }
-          }
-          return;
-        },
-      }
     }
   }
 
@@ -496,7 +484,7 @@ impl Strategy {
       return;
     }
 
-    let pending_started_sessions = {
+    let (pending_started_sessions, wake_persistence) = {
       let mut guard = self.state.lock();
       if guard.is_none() {
         *guard = Some(LoadedState {
@@ -524,11 +512,15 @@ impl Strategy {
         return;
       }
 
+      let was_persistence_pending = state.persistence_pending;
       state
         .pending_started_sessions
         .drain(.. update.started_sessions.len());
       state.persistence_pending = true;
-      state.pending_started_sessions.clone()
+      (
+        state.pending_started_sessions.clone(),
+        !was_persistence_pending,
+      )
     };
 
     log::debug!(
@@ -536,8 +528,13 @@ impl Strategy {
       self.type_name(),
       pending_started_sessions.len()
     );
-    self.notify_update();
-    let _ignored = self.persistence_tx.try_send(PersistenceRequest::Persist);
+    self.apply_effects(
+      TransitionEffects {
+        notify_update: true,
+        callback: None,
+      },
+      wake_persistence,
+    );
   }
 
   /// Pretty name of the strategy.
@@ -545,7 +542,7 @@ impl Strategy {
     self.backend.kind().type_name()
   }
 
-  fn initialize_state(&self) -> Initialization {
+  fn initialize_state(&self) -> Transition {
     // The persisted current session and the persisted pending queue are loaded together so the
     // backend makes decisions from a consistent snapshot of durable state.
     let persisted = self.store.load_state();
@@ -586,7 +583,7 @@ impl Strategy {
     &self,
     persisted: PersistedSessionState,
     pending_started_sessions: Vec<StartedSessionRecord>,
-  ) -> Initialization {
+  ) -> Transition {
     // Backend-specific durable fields are not portable, so a strategy switch is treated as a
     // fresh session boundary. We still preserve the old current session as previous-process state
     // by routing through the existing explicit-rotation path.
@@ -601,7 +598,7 @@ impl Strategy {
   }
 
   fn load_state_for_update(&self) -> LoadedState {
-    let (state, mutation) = {
+    let (state, effects, wake_persistence) = {
       let mut guard = self.state.lock();
       if let Some(state) = guard.clone() {
         log::debug!(
@@ -620,28 +617,29 @@ impl Strategy {
       *guard = Some(initialization.state.clone());
       log::debug!(
         "initialized session state for update flow: backend={}, current_session_id={}, \
-         persist_state={}, persist_pending={}, callback={}, pending_started_sessions={}",
+         persistence_pending={}, notify_update={}, callback={}, pending_started_sessions={}",
         self.type_name(),
         initialization.state.persisted.current_session_id,
-        initialization.mutation.persist_state,
-        initialization.mutation.persist_pending,
-        initialization.mutation.callback.is_some(),
+        initialization.state.persistence_pending,
+        initialization.effects.notify_update,
+        initialization.effects.callback.is_some(),
         initialization.state.pending_started_sessions.len()
       );
-      (initialization.state, initialization.mutation)
+      (
+        initialization.state.clone(),
+        initialization.effects,
+        initialization.state.persistence_pending,
+      )
     };
 
-    self.apply_mutation(mutation);
+    self.apply_effects(effects, wake_persistence);
     state
   }
 
-  fn start_new_session_locked(
-    &self,
-    guard: &mut PlatformMutexGuard<'_, Option<LoadedState>>,
-  ) -> Mutation {
+  fn start_new_session_locked(&self, state: &mut Option<LoadedState>) -> TransitionEffects {
     // Once a process has initialized session state, its in-memory snapshot is newer than disk
     // until the coalescing writer catches up. Re-reading disk here would drop rapid rotations.
-    let (persisted, pending_started_sessions) = guard.as_ref().map_or_else(
+    let (persisted, pending_started_sessions) = state.as_ref().map_or_else(
       || {
         (
           self.store.load_state(),
@@ -659,47 +657,47 @@ impl Strategy {
       "starting explicit session rotation: backend={}, cached_state={}, has_persisted_state={}, \
        pending_started_sessions={}",
       self.type_name(),
-      guard.is_some(),
+      state.is_some(),
       persisted.is_some(),
       pending_started_sessions.len()
     );
 
     let initialization = match &self.backend {
       Backend::Fixed(strategy) => self.with_callback_guard(|| {
-        strategy.start_new_session(guard.as_ref(), persisted, pending_started_sessions)
+        strategy.start_new_session(state.as_ref(), persisted, pending_started_sessions)
       }),
       Backend::ActivityBased(strategy) => {
-        strategy.start_new_session(guard.as_ref(), persisted, pending_started_sessions)
+        strategy.start_new_session(state.as_ref(), persisted, pending_started_sessions)
       },
     };
 
     log::debug!(
-      "computed explicit session rotation: backend={}, current_session_id={}, persist_state={}, \
-       persist_pending={}, callback={}, pending_started_sessions={}",
+      "computed explicit session rotation: backend={}, current_session_id={}, \
+       persistence_pending={}, notify_update={}, callback={}, pending_started_sessions={}",
       self.type_name(),
       initialization.state.persisted.current_session_id,
-      initialization.mutation.persist_state,
-      initialization.mutation.persist_pending,
-      initialization.mutation.callback.is_some(),
+      initialization.state.persistence_pending,
+      initialization.effects.notify_update,
+      initialization.effects.callback.is_some(),
       initialization.state.pending_started_sessions.len()
     );
 
-    **guard = Some(initialization.state);
-    initialization.mutation
+    *state = Some(initialization.state);
+    initialization.effects
   }
 
-  fn apply_mutation(&self, mutation: Mutation) {
-    if !mutation.has_follow_up_work() {
+  fn apply_effects(&self, effects: TransitionEffects, wake_persistence: bool) {
+    if !wake_persistence && !effects.notify_update && effects.callback.is_none() {
       return;
     }
 
     log::debug!(
-      "scheduling session mutation: backend={}, persist_state={}, persist_pending={}, \
+      "applying session transition effects: backend={}, wake_persistence={}, notify_update={}, \
        callback={}, pending_started_sessions={}",
       self.type_name(),
-      mutation.persist_state,
-      mutation.persist_pending,
-      mutation.callback.is_some(),
+      wake_persistence,
+      effects.notify_update,
+      effects.callback.is_some(),
       self
         .state
         .lock()
@@ -707,16 +705,13 @@ impl Strategy {
         .map_or(0, |state| state.pending_started_sessions.len())
     );
 
-    if mutation.persist_state || mutation.persist_pending {
-      if let Some(state) = self.state.lock().as_mut() {
-        state.persistence_pending = true;
-      }
+    if wake_persistence {
       let _ignored = self.persistence_tx.try_send(PersistenceRequest::Persist);
     }
-    if mutation.persist_pending {
+    if effects.notify_update {
       self.notify_update();
     }
-    self.run_callback(mutation.callback);
+    self.run_callback(effects.callback);
   }
 
   async fn persist_latest(&self, on_persistence_failure: &(dyn Fn() + Send + Sync)) {
@@ -782,6 +777,42 @@ impl Strategy {
       old_version,
       new_version
     );
+  }
+}
+
+impl PersistenceWorker {
+  /// Runs the dedicated coalescing writer until `shutdown` resolves.
+  pub async fn run<F>(
+    mut self,
+    shutdown: F,
+    on_persistence_failure: impl Fn() + Send + Sync + 'static,
+  ) where
+    F: Future<Output = ()> + Send,
+  {
+    tokio::pin!(shutdown);
+    loop {
+      tokio::select! {
+        Some(request) = self.receiver.recv() => {
+          let completion_tx = match request {
+            PersistenceRequest::Persist => None,
+            PersistenceRequest::Flush(completion_tx) => Some(completion_tx),
+          };
+          self.strategy.persist_latest(&on_persistence_failure).await;
+          if let Some(completion_tx) = completion_tx {
+            let _ignored = completion_tx.send(());
+          }
+        },
+        () = &mut shutdown => {
+          self.strategy.persist_latest(&on_persistence_failure).await;
+          while let Ok(request) = self.receiver.try_recv() {
+            if let PersistenceRequest::Flush(completion_tx) = request {
+              let _ignored = completion_tx.send(());
+            }
+          }
+          return;
+        },
+      }
+    }
   }
 }
 

--- a/bd-session/src/lib_test.rs
+++ b/bd-session/src/lib_test.rs
@@ -5,8 +5,8 @@
 // LICENSE.polyform file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use super::test::{flush, start_new_session};
-use super::{PendingStateUpdate, Strategy};
+use super::test::flush;
+use super::{PendingStateUpdate, Strategy, StrategyParts};
 use crate::persistence::{BackendState, PersistedSessionState, Store};
 use crate::{activity_based, fixed};
 use bd_proto::protos::client::api::StateUpdateRequest;
@@ -54,14 +54,14 @@ impl activity_based::Callbacks for ActivityCallbacks {
   fn session_id_changed(&self, _session_id: &str) {}
 }
 
-fn fixed_strategy(sdk_directory: &TempDir, session_ids: &[&str]) -> Strategy {
+fn fixed_strategy(sdk_directory: &TempDir, session_ids: &[&str]) -> StrategyParts {
   Strategy::fixed(
     sdk_directory.path(),
     Arc::new(FixedCallbacks::new(session_ids)),
   )
 }
 
-fn activity_strategy(sdk_directory: &TempDir, now: OffsetDateTime) -> Strategy {
+fn activity_strategy(sdk_directory: &TempDir, now: OffsetDateTime) -> StrategyParts {
   Strategy::activity_based(
     sdk_directory.path(),
     Duration::minutes(30),
@@ -85,9 +85,12 @@ fn started_session_ids(request: &StateUpdateRequest) -> Vec<String> {
 #[tokio::test]
 async fn persistence_flusher_coalesces_to_latest_state_on_shutdown() {
   let sdk_directory = TempDir::new().unwrap();
-  let strategy = Arc::new(fixed_strategy(&sdk_directory, &["session-1", "session-2"]));
+  let StrategyParts {
+    strategy,
+    persistence_worker: worker,
+  } = fixed_strategy(&sdk_directory, &["session-1", "session-2"]);
   let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
-  let flusher = tokio::spawn(strategy.clone().run_persistence_flusher(
+  let flusher = tokio::spawn(worker.run(
     async move {
       let _ignored = shutdown_rx.await;
     },
@@ -95,7 +98,7 @@ async fn persistence_flusher_coalesces_to_latest_state_on_shutdown() {
   ));
 
   let first_session_id = strategy.session_id().await.unwrap();
-  start_new_session(&strategy).await;
+  strategy.start_new_session().unwrap();
   let second_session_id = strategy.session_id().await.unwrap();
 
   let _ignored = shutdown_tx.send(());
@@ -116,7 +119,10 @@ async fn persistence_flusher_coalesces_to_latest_state_on_shutdown() {
 #[tokio::test]
 async fn flush_request_waits_for_persistence_worker() {
   let sdk_directory = TempDir::new().unwrap();
-  let strategy = Arc::new(fixed_strategy(&sdk_directory, &["session-1"]));
+  let StrategyParts {
+    strategy,
+    persistence_worker: worker,
+  } = fixed_strategy(&sdk_directory, &["session-1"]);
   let session_id = strategy.session_id().await.unwrap();
 
   let flush_strategy = strategy.clone();
@@ -125,7 +131,7 @@ async fn flush_request_waits_for_persistence_worker() {
   assert!(!flush.is_finished());
 
   let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
-  let flusher = tokio::spawn(strategy.clone().run_persistence_flusher(
+  let flusher = tokio::spawn(worker.run(
     async move {
       let _ignored = shutdown_rx.await;
     },
@@ -145,7 +151,7 @@ async fn flush_request_waits_for_persistence_worker() {
 #[tokio::test]
 async fn handshake_synthesizes_current_session_after_pending_queue_is_acked() {
   let sdk_directory = TempDir::new().unwrap();
-  let strategy = fixed_strategy(&sdk_directory, &["session-1"]);
+  let StrategyParts { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1"]);
 
   let session_id = strategy.session_id().await.unwrap();
   let pending = strategy.pending_state_update().await.unwrap();
@@ -167,10 +173,10 @@ async fn handshake_synthesizes_current_session_after_pending_queue_is_acked() {
 #[tokio::test]
 async fn acknowledge_state_update_ignores_non_prefix_updates() {
   let sdk_directory = TempDir::new().unwrap();
-  let strategy = fixed_strategy(&sdk_directory, &["session-1", "session-2"]);
+  let StrategyParts { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1", "session-2"]);
 
   strategy.session_id().await.unwrap();
-  start_new_session(&strategy).await;
+  strategy.start_new_session().unwrap();
 
   let pending = strategy.pending_state_update().await.unwrap();
   assert_eq!(
@@ -195,7 +201,7 @@ async fn acknowledge_state_update_ignores_non_prefix_updates() {
 #[tokio::test]
 async fn subscribe_updates_changes_on_initialization_and_acknowledgement() {
   let sdk_directory = TempDir::new().unwrap();
-  let strategy = fixed_strategy(&sdk_directory, &["session-1"]);
+  let StrategyParts { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1"]);
   let updates = strategy.subscribe_updates();
 
   assert_eq!(0, *updates.borrow());
@@ -211,12 +217,18 @@ async fn subscribe_updates_changes_on_initialization_and_acknowledgement() {
 async fn restart_rebuilds_pending_queue_from_persisted_state() {
   let sdk_directory = TempDir::new().unwrap();
 
-  let first_strategy = Arc::new(fixed_strategy(&sdk_directory, &["session-1"]));
+  let StrategyParts {
+    strategy: first_strategy,
+    persistence_worker: first_worker,
+  } = fixed_strategy(&sdk_directory, &["session-1"]);
   let first_session_id = first_strategy.session_id().await.unwrap();
-  flush(first_strategy.clone()).await;
+  flush(first_strategy.clone(), first_worker).await;
   drop(first_strategy);
 
-  let restarted_strategy = fixed_strategy(&sdk_directory, &["session-2"]);
+  let StrategyParts {
+    strategy: restarted_strategy,
+    ..
+  } = fixed_strategy(&sdk_directory, &["session-2"]);
   let pending = restarted_strategy.pending_state_update().await.unwrap();
 
   assert_eq!(
@@ -232,7 +244,7 @@ async fn restart_rebuilds_pending_queue_from_persisted_state() {
 #[tokio::test]
 async fn handshake_does_not_duplicate_current_session_when_queue_already_contains_it() {
   let sdk_directory = TempDir::new().unwrap();
-  let strategy = fixed_strategy(&sdk_directory, &["session-1"]);
+  let StrategyParts { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1"]);
 
   strategy.session_id().await.unwrap();
 
@@ -248,15 +260,21 @@ async fn handshake_does_not_duplicate_current_session_when_queue_already_contain
 async fn switching_from_fixed_to_activity_resyncs_persisted_backend() {
   let sdk_directory = TempDir::new().unwrap();
 
-  let first_strategy = Arc::new(fixed_strategy(&sdk_directory, &["fixed-session"]));
+  let StrategyParts {
+    strategy: first_strategy,
+    persistence_worker: first_worker,
+  } = fixed_strategy(&sdk_directory, &["fixed-session"]);
   let first_session_id = first_strategy.session_id().await.unwrap();
-  flush(first_strategy.clone()).await;
+  flush(first_strategy.clone(), first_worker).await;
   drop(first_strategy);
 
-  let restarted_strategy = Arc::new(activity_strategy(&sdk_directory, OffsetDateTime::now_utc()));
+  let StrategyParts {
+    strategy: restarted_strategy,
+    persistence_worker: restarted_worker,
+  } = activity_strategy(&sdk_directory, OffsetDateTime::now_utc());
   let pending = restarted_strategy.pending_state_update().await.unwrap();
   let restarted_session_id = restarted_strategy.try_current_session_id().unwrap();
-  flush(restarted_strategy.clone()).await;
+  flush(restarted_strategy.clone(), restarted_worker).await;
 
   assert_ne!(first_session_id, restarted_session_id);
   assert_eq!(
@@ -277,15 +295,21 @@ async fn switching_from_fixed_to_activity_resyncs_persisted_backend() {
 async fn switching_from_activity_to_fixed_resyncs_persisted_backend() {
   let sdk_directory = TempDir::new().unwrap();
 
-  let first_strategy = Arc::new(activity_strategy(&sdk_directory, OffsetDateTime::now_utc()));
+  let StrategyParts {
+    strategy: first_strategy,
+    persistence_worker: first_worker,
+  } = activity_strategy(&sdk_directory, OffsetDateTime::now_utc());
   let first_session_id = first_strategy.session_id().await.unwrap();
-  flush(first_strategy.clone()).await;
+  flush(first_strategy.clone(), first_worker).await;
   drop(first_strategy);
 
-  let restarted_strategy = Arc::new(fixed_strategy(&sdk_directory, &["fixed-session"]));
+  let StrategyParts {
+    strategy: restarted_strategy,
+    persistence_worker: restarted_worker,
+  } = fixed_strategy(&sdk_directory, &["fixed-session"]);
   let pending = restarted_strategy.pending_state_update().await.unwrap();
   let restarted_session_id = restarted_strategy.try_current_session_id().unwrap();
-  flush(restarted_strategy.clone()).await;
+  flush(restarted_strategy.clone(), restarted_worker).await;
 
   assert_ne!(first_session_id, restarted_session_id);
   assert_eq!(

--- a/bd-session/src/lib_test.rs
+++ b/bd-session/src/lib_test.rs
@@ -149,6 +149,39 @@ async fn flush_request_waits_for_persistence_worker() {
 }
 
 #[tokio::test]
+async fn flush_retries_persistence_after_a_failed_write() {
+  let sdk_directory = TempDir::new().unwrap();
+  std::fs::write(sdk_directory.path().join("state"), "not a directory").unwrap();
+  let StrategyWithWorker {
+    strategy,
+    persistence_worker: worker,
+  } = fixed_strategy(&sdk_directory, &["session-1"]);
+  let session_id = strategy.session_id().unwrap();
+
+  let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+  let flusher = tokio::spawn(worker.run(
+    async move {
+      let _ignored = shutdown_rx.await;
+    },
+    || {},
+  ));
+
+  strategy.flush().await;
+  assert!(Store::new(sdk_directory.path()).load_state().is_none());
+
+  std::fs::remove_file(sdk_directory.path().join("state")).unwrap();
+  strategy.flush().await;
+
+  let _ignored = shutdown_tx.send(());
+  flusher.await.unwrap();
+
+  assert_eq!(
+    session_id,
+    persisted_state(&sdk_directory).current_session_id
+  );
+}
+
+#[tokio::test]
 async fn handshake_synthesizes_current_session_after_pending_queue_is_acked() {
   let sdk_directory = TempDir::new().unwrap();
   let StrategyWithWorker { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1"]);

--- a/bd-session/src/lib_test.rs
+++ b/bd-session/src/lib_test.rs
@@ -83,6 +83,37 @@ fn started_session_ids(request: &StateUpdateRequest) -> Vec<String> {
 }
 
 #[tokio::test]
+async fn persistence_flusher_coalesces_to_latest_state_on_shutdown() {
+  let sdk_directory = TempDir::new().unwrap();
+  let strategy = Arc::new(fixed_strategy(&sdk_directory, &["session-1", "session-2"]));
+  let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+  let flusher = tokio::spawn(strategy.clone().run_persistence_flusher(
+    async move {
+      let _ignored = shutdown_rx.await;
+    },
+    || {},
+  ));
+
+  let first_session_id = strategy.session_id().await.unwrap();
+  start_new_session(&strategy).await;
+  let second_session_id = strategy.session_id().await.unwrap();
+
+  let _ignored = shutdown_tx.send(());
+  flusher.await.unwrap();
+
+  let persisted = persisted_state(&sdk_directory);
+  assert_eq!(second_session_id, persisted.current_session_id);
+  assert_eq!(
+    vec![first_session_id, second_session_id],
+    Store::new(sdk_directory.path())
+      .load_pending_started_sessions()
+      .into_iter()
+      .map(|started| started.session_id)
+      .collect::<Vec<_>>()
+  );
+}
+
+#[tokio::test]
 async fn handshake_synthesizes_current_session_after_pending_queue_is_acked() {
   let sdk_directory = TempDir::new().unwrap();
   let strategy = fixed_strategy(&sdk_directory, &["session-1"]);
@@ -153,6 +184,7 @@ async fn restart_rebuilds_pending_queue_from_persisted_state() {
 
   let first_strategy = fixed_strategy(&sdk_directory, &["session-1"]);
   let first_session_id = first_strategy.session_id().await.unwrap();
+  first_strategy.flush().await;
   drop(first_strategy);
 
   let restarted_strategy = fixed_strategy(&sdk_directory, &["session-2"]);
@@ -189,11 +221,13 @@ async fn switching_from_fixed_to_activity_resyncs_persisted_backend() {
 
   let first_strategy = fixed_strategy(&sdk_directory, &["fixed-session"]);
   let first_session_id = first_strategy.session_id().await.unwrap();
+  first_strategy.flush().await;
   drop(first_strategy);
 
   let restarted_strategy = activity_strategy(&sdk_directory, OffsetDateTime::now_utc());
   let pending = restarted_strategy.pending_state_update().await.unwrap();
   let restarted_session_id = restarted_strategy.try_current_session_id().unwrap();
+  restarted_strategy.flush().await;
 
   assert_ne!(first_session_id, restarted_session_id);
   assert_eq!(
@@ -216,11 +250,13 @@ async fn switching_from_activity_to_fixed_resyncs_persisted_backend() {
 
   let first_strategy = activity_strategy(&sdk_directory, OffsetDateTime::now_utc());
   let first_session_id = first_strategy.session_id().await.unwrap();
+  first_strategy.flush().await;
   drop(first_strategy);
 
   let restarted_strategy = fixed_strategy(&sdk_directory, &["fixed-session"]);
   let pending = restarted_strategy.pending_state_update().await.unwrap();
   let restarted_session_id = restarted_strategy.try_current_session_id().unwrap();
+  restarted_strategy.flush().await;
 
   assert_ne!(first_session_id, restarted_session_id);
   assert_eq!(

--- a/bd-session/src/lib_test.rs
+++ b/bd-session/src/lib_test.rs
@@ -6,7 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use super::test::flush;
-use super::{PendingStateUpdate, Strategy, StrategyParts};
+use super::{PendingStateUpdate, Strategy, StrategyWithWorker};
 use crate::persistence::{BackendState, PersistedSessionState, Store};
 use crate::{activity_based, fixed};
 use bd_proto::protos::client::api::StateUpdateRequest;
@@ -54,14 +54,14 @@ impl activity_based::Callbacks for ActivityCallbacks {
   fn session_id_changed(&self, _session_id: &str) {}
 }
 
-fn fixed_strategy(sdk_directory: &TempDir, session_ids: &[&str]) -> StrategyParts {
+fn fixed_strategy(sdk_directory: &TempDir, session_ids: &[&str]) -> StrategyWithWorker {
   Strategy::fixed(
     sdk_directory.path(),
     Arc::new(FixedCallbacks::new(session_ids)),
   )
 }
 
-fn activity_strategy(sdk_directory: &TempDir, now: OffsetDateTime) -> StrategyParts {
+fn activity_strategy(sdk_directory: &TempDir, now: OffsetDateTime) -> StrategyWithWorker {
   Strategy::activity_based(
     sdk_directory.path(),
     Duration::minutes(30),
@@ -85,7 +85,7 @@ fn started_session_ids(request: &StateUpdateRequest) -> Vec<String> {
 #[tokio::test]
 async fn persistence_flusher_coalesces_to_latest_state_on_shutdown() {
   let sdk_directory = TempDir::new().unwrap();
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy,
     persistence_worker: worker,
   } = fixed_strategy(&sdk_directory, &["session-1", "session-2"]);
@@ -97,9 +97,9 @@ async fn persistence_flusher_coalesces_to_latest_state_on_shutdown() {
     || {},
   ));
 
-  let first_session_id = strategy.session_id().await.unwrap();
+  let first_session_id = strategy.session_id().unwrap();
   strategy.start_new_session().unwrap();
-  let second_session_id = strategy.session_id().await.unwrap();
+  let second_session_id = strategy.session_id().unwrap();
 
   let _ignored = shutdown_tx.send(());
   flusher.await.unwrap();
@@ -119,11 +119,11 @@ async fn persistence_flusher_coalesces_to_latest_state_on_shutdown() {
 #[tokio::test]
 async fn flush_request_waits_for_persistence_worker() {
   let sdk_directory = TempDir::new().unwrap();
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy,
     persistence_worker: worker,
   } = fixed_strategy(&sdk_directory, &["session-1"]);
-  let session_id = strategy.session_id().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
 
   let flush_strategy = strategy.clone();
   let flush = tokio::spawn(async move { flush_strategy.flush().await });
@@ -151,21 +151,21 @@ async fn flush_request_waits_for_persistence_worker() {
 #[tokio::test]
 async fn handshake_synthesizes_current_session_after_pending_queue_is_acked() {
   let sdk_directory = TempDir::new().unwrap();
-  let StrategyParts { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1"]);
+  let StrategyWithWorker { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1"]);
 
-  let session_id = strategy.session_id().await.unwrap();
-  let pending = strategy.pending_state_update().await.unwrap();
+  let session_id = strategy.session_id().unwrap();
+  let pending = strategy.pending_state_update().unwrap();
 
   assert_eq!(
     vec![session_id.clone()],
     started_session_ids(pending.request())
   );
 
-  strategy.acknowledge_state_update(&pending).await;
+  strategy.acknowledge_state_update(&pending);
 
-  assert!(strategy.pending_state_update().await.is_none());
+  assert!(strategy.pending_state_update().is_none());
 
-  let handshake = strategy.handshake_state_update().await;
+  let handshake = strategy.handshake_state_update();
   assert_eq!(vec![session_id], started_session_ids(handshake.request()));
   assert!(handshake.started_sessions.is_empty());
 }
@@ -173,12 +173,13 @@ async fn handshake_synthesizes_current_session_after_pending_queue_is_acked() {
 #[tokio::test]
 async fn acknowledge_state_update_ignores_non_prefix_updates() {
   let sdk_directory = TempDir::new().unwrap();
-  let StrategyParts { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1", "session-2"]);
+  let StrategyWithWorker { strategy, .. } =
+    fixed_strategy(&sdk_directory, &["session-1", "session-2"]);
 
-  strategy.session_id().await.unwrap();
+  strategy.session_id().unwrap();
   strategy.start_new_session().unwrap();
 
-  let pending = strategy.pending_state_update().await.unwrap();
+  let pending = strategy.pending_state_update().unwrap();
   assert_eq!(
     vec!["session-1".to_string(), "session-2".to_string()],
     started_session_ids(pending.request())
@@ -189,9 +190,9 @@ async fn acknowledge_state_update_ignores_non_prefix_updates() {
     started_sessions: vec![pending.started_sessions[1].clone()],
   };
 
-  strategy.acknowledge_state_update(&fake_update).await;
+  strategy.acknowledge_state_update(&fake_update);
 
-  let still_pending = strategy.pending_state_update().await.unwrap();
+  let still_pending = strategy.pending_state_update().unwrap();
   assert_eq!(
     vec!["session-1".to_string(), "session-2".to_string()],
     started_session_ids(still_pending.request())
@@ -201,15 +202,15 @@ async fn acknowledge_state_update_ignores_non_prefix_updates() {
 #[tokio::test]
 async fn subscribe_updates_changes_on_initialization_and_acknowledgement() {
   let sdk_directory = TempDir::new().unwrap();
-  let StrategyParts { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1"]);
+  let StrategyWithWorker { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1"]);
   let updates = strategy.subscribe_updates();
 
   assert_eq!(0, *updates.borrow());
 
-  let pending = strategy.pending_state_update().await.unwrap();
+  let pending = strategy.pending_state_update().unwrap();
   assert_eq!(1, *updates.borrow());
 
-  strategy.acknowledge_state_update(&pending).await;
+  strategy.acknowledge_state_update(&pending);
   assert_eq!(2, *updates.borrow());
 }
 
@@ -217,19 +218,19 @@ async fn subscribe_updates_changes_on_initialization_and_acknowledgement() {
 async fn restart_rebuilds_pending_queue_from_persisted_state() {
   let sdk_directory = TempDir::new().unwrap();
 
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy: first_strategy,
     persistence_worker: first_worker,
   } = fixed_strategy(&sdk_directory, &["session-1"]);
-  let first_session_id = first_strategy.session_id().await.unwrap();
+  let first_session_id = first_strategy.session_id().unwrap();
   flush(first_strategy.clone(), first_worker).await;
   drop(first_strategy);
 
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy: restarted_strategy,
     ..
   } = fixed_strategy(&sdk_directory, &["session-2"]);
-  let pending = restarted_strategy.pending_state_update().await.unwrap();
+  let pending = restarted_strategy.pending_state_update().unwrap();
 
   assert_eq!(
     vec![first_session_id, "session-2".to_string()],
@@ -244,11 +245,11 @@ async fn restart_rebuilds_pending_queue_from_persisted_state() {
 #[tokio::test]
 async fn handshake_does_not_duplicate_current_session_when_queue_already_contains_it() {
   let sdk_directory = TempDir::new().unwrap();
-  let StrategyParts { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1"]);
+  let StrategyWithWorker { strategy, .. } = fixed_strategy(&sdk_directory, &["session-1"]);
 
-  strategy.session_id().await.unwrap();
+  strategy.session_id().unwrap();
 
-  let handshake = strategy.handshake_state_update().await;
+  let handshake = strategy.handshake_state_update();
   assert_eq!(
     vec!["session-1".to_string()],
     started_session_ids(handshake.request())
@@ -260,19 +261,19 @@ async fn handshake_does_not_duplicate_current_session_when_queue_already_contain
 async fn switching_from_fixed_to_activity_resyncs_persisted_backend() {
   let sdk_directory = TempDir::new().unwrap();
 
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy: first_strategy,
     persistence_worker: first_worker,
   } = fixed_strategy(&sdk_directory, &["fixed-session"]);
-  let first_session_id = first_strategy.session_id().await.unwrap();
+  let first_session_id = first_strategy.session_id().unwrap();
   flush(first_strategy.clone(), first_worker).await;
   drop(first_strategy);
 
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy: restarted_strategy,
     persistence_worker: restarted_worker,
   } = activity_strategy(&sdk_directory, OffsetDateTime::now_utc());
-  let pending = restarted_strategy.pending_state_update().await.unwrap();
+  let pending = restarted_strategy.pending_state_update().unwrap();
   let restarted_session_id = restarted_strategy.try_current_session_id().unwrap();
   flush(restarted_strategy.clone(), restarted_worker).await;
 
@@ -295,19 +296,19 @@ async fn switching_from_fixed_to_activity_resyncs_persisted_backend() {
 async fn switching_from_activity_to_fixed_resyncs_persisted_backend() {
   let sdk_directory = TempDir::new().unwrap();
 
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy: first_strategy,
     persistence_worker: first_worker,
   } = activity_strategy(&sdk_directory, OffsetDateTime::now_utc());
-  let first_session_id = first_strategy.session_id().await.unwrap();
+  let first_session_id = first_strategy.session_id().unwrap();
   flush(first_strategy.clone(), first_worker).await;
   drop(first_strategy);
 
-  let StrategyParts {
+  let StrategyWithWorker {
     strategy: restarted_strategy,
     persistence_worker: restarted_worker,
   } = fixed_strategy(&sdk_directory, &["fixed-session"]);
-  let pending = restarted_strategy.pending_state_update().await.unwrap();
+  let pending = restarted_strategy.pending_state_update().unwrap();
   let restarted_session_id = restarted_strategy.try_current_session_id().unwrap();
   flush(restarted_strategy.clone(), restarted_worker).await;
 

--- a/bd-session/src/lib_test.rs
+++ b/bd-session/src/lib_test.rs
@@ -5,7 +5,7 @@
 // LICENSE.polyform file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use super::test::start_new_session;
+use super::test::{flush, start_new_session};
 use super::{PendingStateUpdate, Strategy};
 use crate::persistence::{BackendState, PersistedSessionState, Store};
 use crate::{activity_based, fixed};
@@ -114,6 +114,35 @@ async fn persistence_flusher_coalesces_to_latest_state_on_shutdown() {
 }
 
 #[tokio::test]
+async fn flush_request_waits_for_persistence_worker() {
+  let sdk_directory = TempDir::new().unwrap();
+  let strategy = Arc::new(fixed_strategy(&sdk_directory, &["session-1"]));
+  let session_id = strategy.session_id().await.unwrap();
+
+  let flush_strategy = strategy.clone();
+  let flush = tokio::spawn(async move { flush_strategy.flush().await });
+  tokio::task::yield_now().await;
+  assert!(!flush.is_finished());
+
+  let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+  let flusher = tokio::spawn(strategy.clone().run_persistence_flusher(
+    async move {
+      let _ignored = shutdown_rx.await;
+    },
+    || {},
+  ));
+
+  flush.await.unwrap();
+  let _ignored = shutdown_tx.send(());
+  flusher.await.unwrap();
+
+  assert_eq!(
+    session_id,
+    persisted_state(&sdk_directory).current_session_id
+  );
+}
+
+#[tokio::test]
 async fn handshake_synthesizes_current_session_after_pending_queue_is_acked() {
   let sdk_directory = TempDir::new().unwrap();
   let strategy = fixed_strategy(&sdk_directory, &["session-1"]);
@@ -182,9 +211,9 @@ async fn subscribe_updates_changes_on_initialization_and_acknowledgement() {
 async fn restart_rebuilds_pending_queue_from_persisted_state() {
   let sdk_directory = TempDir::new().unwrap();
 
-  let first_strategy = fixed_strategy(&sdk_directory, &["session-1"]);
+  let first_strategy = Arc::new(fixed_strategy(&sdk_directory, &["session-1"]));
   let first_session_id = first_strategy.session_id().await.unwrap();
-  first_strategy.flush().await;
+  flush(first_strategy.clone()).await;
   drop(first_strategy);
 
   let restarted_strategy = fixed_strategy(&sdk_directory, &["session-2"]);
@@ -219,15 +248,15 @@ async fn handshake_does_not_duplicate_current_session_when_queue_already_contain
 async fn switching_from_fixed_to_activity_resyncs_persisted_backend() {
   let sdk_directory = TempDir::new().unwrap();
 
-  let first_strategy = fixed_strategy(&sdk_directory, &["fixed-session"]);
+  let first_strategy = Arc::new(fixed_strategy(&sdk_directory, &["fixed-session"]));
   let first_session_id = first_strategy.session_id().await.unwrap();
-  first_strategy.flush().await;
+  flush(first_strategy.clone()).await;
   drop(first_strategy);
 
-  let restarted_strategy = activity_strategy(&sdk_directory, OffsetDateTime::now_utc());
+  let restarted_strategy = Arc::new(activity_strategy(&sdk_directory, OffsetDateTime::now_utc()));
   let pending = restarted_strategy.pending_state_update().await.unwrap();
   let restarted_session_id = restarted_strategy.try_current_session_id().unwrap();
-  restarted_strategy.flush().await;
+  flush(restarted_strategy.clone()).await;
 
   assert_ne!(first_session_id, restarted_session_id);
   assert_eq!(
@@ -248,15 +277,15 @@ async fn switching_from_fixed_to_activity_resyncs_persisted_backend() {
 async fn switching_from_activity_to_fixed_resyncs_persisted_backend() {
   let sdk_directory = TempDir::new().unwrap();
 
-  let first_strategy = activity_strategy(&sdk_directory, OffsetDateTime::now_utc());
+  let first_strategy = Arc::new(activity_strategy(&sdk_directory, OffsetDateTime::now_utc()));
   let first_session_id = first_strategy.session_id().await.unwrap();
-  first_strategy.flush().await;
+  flush(first_strategy.clone()).await;
   drop(first_strategy);
 
-  let restarted_strategy = fixed_strategy(&sdk_directory, &["fixed-session"]);
+  let restarted_strategy = Arc::new(fixed_strategy(&sdk_directory, &["fixed-session"]));
   let pending = restarted_strategy.pending_state_update().await.unwrap();
   let restarted_session_id = restarted_strategy.try_current_session_id().unwrap();
-  restarted_strategy.flush().await;
+  flush(restarted_strategy.clone()).await;
 
   assert_ne!(first_session_id, restarted_session_id);
   assert_eq!(

--- a/bd-session/src/test.rs
+++ b/bd-session/src/test.rs
@@ -9,17 +9,15 @@ use crate::Strategy;
 
 // External integration tests still need the previous best-effort start-new-session behavior so
 // they can exercise queueing and re-entrancy flows without relying on a production-only wrapper.
+#[allow(clippy::unused_async)] // Preserve this helper's external asynchronous test API.
 pub async fn start_new_session(strategy: &Strategy) {
-  let prepared = match strategy.prepare_start_new_session() {
-    Ok(prepared) => prepared,
+  match strategy.start_new_session_sync() {
+    Ok(()) => {},
     Err(e) => {
       log::error!("bitdrift Capture failed to start new session: {e:?}");
       return;
     },
-  };
+  }
 
-  let session_id = prepared.current_session_id().to_string();
-  let callback = strategy.persist_prepared(prepared).await;
-  strategy.run_prepared_callback(callback);
-  log::info!("bitdrift Capture started new session: {session_id:?}");
+  log::info!("bitdrift Capture started new session");
 }

--- a/bd-session/src/test.rs
+++ b/bd-session/src/test.rs
@@ -5,28 +5,13 @@
 // LICENSE.polyform file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::Strategy;
+use crate::{PersistenceWorker, Strategy};
 use std::sync::Arc;
 
-// External integration tests still need the previous best-effort start-new-session behavior so
-// they can exercise queueing and re-entrancy flows without relying on a production-only wrapper.
-#[allow(clippy::unused_async)] // Preserve this helper's external asynchronous test API.
-pub async fn start_new_session(strategy: &Strategy) {
-  match strategy.start_new_session_sync() {
-    Ok(()) => {},
-    Err(e) => {
-      log::error!("bitdrift Capture failed to start new session: {e:?}");
-      return;
-    },
-  }
-
-  log::info!("bitdrift Capture started new session");
-}
-
 /// Runs a test-only worker around an explicit persistence barrier.
-pub async fn flush(strategy: Arc<Strategy>) {
+pub async fn flush(strategy: Arc<Strategy>, worker: PersistenceWorker) {
   let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
-  let flusher = tokio::spawn(strategy.clone().run_persistence_flusher(
+  let flusher = tokio::spawn(worker.run(
     async move {
       let _ignored = shutdown_rx.await;
     },

--- a/bd-session/src/test.rs
+++ b/bd-session/src/test.rs
@@ -6,6 +6,7 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use crate::Strategy;
+use std::sync::Arc;
 
 // External integration tests still need the previous best-effort start-new-session behavior so
 // they can exercise queueing and re-entrancy flows without relying on a production-only wrapper.
@@ -20,4 +21,19 @@ pub async fn start_new_session(strategy: &Strategy) {
   }
 
   log::info!("bitdrift Capture started new session");
+}
+
+/// Runs a test-only worker around an explicit persistence barrier.
+pub async fn flush(strategy: Arc<Strategy>) {
+  let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+  let flusher = tokio::spawn(strategy.clone().run_persistence_flusher(
+    async move {
+      let _ignored = shutdown_rx.await;
+    },
+    || {},
+  ));
+
+  strategy.flush().await;
+  let _ignored = shutdown_tx.send(());
+  let _ignored = flusher.await;
 }

--- a/logger-cli/src/logger.rs
+++ b/logger-cli/src/logger.rs
@@ -15,7 +15,7 @@ use crate::types::{Platform, RuntimeValueType};
 use bd_log_primitives::LogFields;
 use bd_logger::{Block, CaptureSession, InitParams, Logger, MetadataProvider};
 use bd_proto::protos::logging::payload::LogType as ProtoLogType;
-use bd_session::{Strategy, StrategyParts, activity_based, fixed};
+use bd_session::{Strategy, StrategyWithWorker, activity_based, fixed};
 use bd_time::TimeProvider;
 use parking_lot::Mutex;
 use std::collections::HashMap;
@@ -285,7 +285,10 @@ async fn fetch_device_code(args: &LoggerArgs, device_id: &str) -> anyhow::Result
   Ok(device_code_response.code)
 }
 
-fn make_session_strategy(sdk_directory: &Path, config: &SessionStrategyConfig) -> StrategyParts {
+fn make_session_strategy(
+  sdk_directory: &Path,
+  config: &SessionStrategyConfig,
+) -> StrategyWithWorker {
   make_session_strategy_with_time_provider(
     sdk_directory,
     config,
@@ -297,7 +300,7 @@ fn make_session_strategy_with_time_provider(
   sdk_directory: &Path,
   config: &SessionStrategyConfig,
   time_provider: Arc<dyn TimeProvider>,
-) -> StrategyParts {
+) -> StrategyWithWorker {
   match config {
     SessionStrategyConfig::Fixed => Strategy::fixed(sdk_directory, Arc::new(fixed::UUIDCallbacks)),
     SessionStrategyConfig::ActivityBased {
@@ -325,7 +328,7 @@ pub struct LoggerArgs {
 
 pub async fn make_logger(sdk_directory: &Path, args: &LoggerArgs) -> anyhow::Result<LoggerHolder> {
   let session = make_session_strategy(sdk_directory, &args.session_strategy);
-  let session_strategy = session.strategy.clone();
+  let session_strategy = session.strategy();
   let storage_db = sdk_directory.join("defaults.db");
   let storage = SQLiteStorage::new(&storage_db);
   let store = Arc::new(bd_key_value::Store::new(Box::new(storage)));

--- a/logger-cli/src/logger.rs
+++ b/logger-cli/src/logger.rs
@@ -15,7 +15,7 @@ use crate::types::{Platform, RuntimeValueType};
 use bd_log_primitives::LogFields;
 use bd_logger::{Block, CaptureSession, InitParams, Logger, MetadataProvider};
 use bd_proto::protos::logging::payload::LogType as ProtoLogType;
-use bd_session::{Strategy, activity_based, fixed};
+use bd_session::{Strategy, StrategyParts, activity_based, fixed};
 use bd_time::TimeProvider;
 use parking_lot::Mutex;
 use std::collections::HashMap;
@@ -285,7 +285,7 @@ async fn fetch_device_code(args: &LoggerArgs, device_id: &str) -> anyhow::Result
   Ok(device_code_response.code)
 }
 
-fn make_session_strategy(sdk_directory: &Path, config: &SessionStrategyConfig) -> Arc<Strategy> {
+fn make_session_strategy(sdk_directory: &Path, config: &SessionStrategyConfig) -> StrategyParts {
   make_session_strategy_with_time_provider(
     sdk_directory,
     config,
@@ -297,8 +297,8 @@ fn make_session_strategy_with_time_provider(
   sdk_directory: &Path,
   config: &SessionStrategyConfig,
   time_provider: Arc<dyn TimeProvider>,
-) -> Arc<Strategy> {
-  Arc::new(match config {
+) -> StrategyParts {
+  match config {
     SessionStrategyConfig::Fixed => Strategy::fixed(sdk_directory, Arc::new(fixed::UUIDCallbacks)),
     SessionStrategyConfig::ActivityBased {
       inactivity_threshold_mins,
@@ -308,7 +308,7 @@ fn make_session_strategy_with_time_provider(
       Arc::new(ActivitySessionCallbacks),
       time_provider,
     ),
-  })
+  }
 }
 
 pub struct LoggerArgs {
@@ -324,7 +324,8 @@ pub struct LoggerArgs {
 }
 
 pub async fn make_logger(sdk_directory: &Path, args: &LoggerArgs) -> anyhow::Result<LoggerHolder> {
-  let session_strategy = make_session_strategy(sdk_directory, &args.session_strategy);
+  let session = make_session_strategy(sdk_directory, &args.session_strategy);
+  let session_strategy = session.strategy.clone();
   let storage_db = sdk_directory.join("defaults.db");
   let storage = SQLiteStorage::new(&storage_db);
   let store = Arc::new(bd_key_value::Store::new(Box::new(storage)));
@@ -358,7 +359,7 @@ pub async fn make_logger(sdk_directory: &Path, args: &LoggerArgs) -> anyhow::Res
   let (logger, _, future, _) = bd_logger::LoggerBuilder::new(InitParams {
     sdk_directory: sdk_directory.to_path_buf(),
     api_key: args.api_key.clone(),
-    session_strategy: session_strategy.clone(),
+    session,
     metadata_provider: Arc::new(LiveTimestampMetadata {
       ootb_fields: [(
         "_app_version_code".into(),

--- a/logger-cli/src/logger_test.rs
+++ b/logger-cli/src/logger_test.rs
@@ -48,16 +48,14 @@ async fn fixed_sessions_do_not_persist_across_restarts() {
   let sdk_directory = TestSdkDirectory::new();
   let config = SessionStrategyConfig::Fixed;
 
-  let bd_session::StrategyParts {
-    strategy: first_strategy,
-    persistence_worker: first_worker,
-  } = make_session_strategy(sdk_directory.path(), &config);
-  let first_session_id = first_strategy.session_id().await.unwrap();
+  let (first_strategy, first_worker) =
+    make_session_strategy(sdk_directory.path(), &config).into_parts();
+  let first_session_id = first_strategy.session_id().unwrap();
   bd_session::test::flush(first_strategy.clone(), first_worker).await;
   drop(first_strategy);
 
-  let restarted_strategy = make_session_strategy(sdk_directory.path(), &config).strategy;
-  let restarted_session_id = restarted_strategy.session_id().await.unwrap();
+  let restarted_strategy = make_session_strategy(sdk_directory.path(), &config).strategy();
+  let restarted_session_id = restarted_strategy.session_id().unwrap();
 
   assert_ne!(first_session_id, restarted_session_id);
   assert_eq!(
@@ -75,20 +73,19 @@ async fn activity_based_sessions_persist_across_restarts_within_threshold() {
     inactivity_threshold_mins: 30,
   };
 
-  let bd_session::StrategyParts {
-    strategy: first_strategy,
-    persistence_worker: first_worker,
-  } =
-    make_session_strategy_with_time_provider(sdk_directory.path(), &config, time_provider.clone());
-  let first_session_id = first_strategy.session_id().await.unwrap();
+  let (first_strategy, first_worker) =
+    make_session_strategy_with_time_provider(sdk_directory.path(), &config, time_provider.clone())
+      .into_parts();
+  let first_session_id = first_strategy.session_id().unwrap();
   bd_session::test::flush(first_strategy.clone(), first_worker).await;
   drop(first_strategy);
 
   time_provider.advance(Duration::minutes(5));
 
   let restarted_strategy =
-    make_session_strategy_with_time_provider(sdk_directory.path(), &config, time_provider).strategy;
-  let restarted_session_id = restarted_strategy.session_id().await.unwrap();
+    make_session_strategy_with_time_provider(sdk_directory.path(), &config, time_provider)
+      .strategy();
+  let restarted_session_id = restarted_strategy.session_id().unwrap();
 
   assert_eq!(first_session_id, restarted_session_id);
   assert_eq!(

--- a/logger-cli/src/logger_test.rs
+++ b/logger-cli/src/logger_test.rs
@@ -48,12 +48,15 @@ async fn fixed_sessions_do_not_persist_across_restarts() {
   let sdk_directory = TestSdkDirectory::new();
   let config = SessionStrategyConfig::Fixed;
 
-  let first_strategy = make_session_strategy(sdk_directory.path(), &config);
+  let bd_session::StrategyParts {
+    strategy: first_strategy,
+    persistence_worker: first_worker,
+  } = make_session_strategy(sdk_directory.path(), &config);
   let first_session_id = first_strategy.session_id().await.unwrap();
-  first_strategy.flush().await;
+  bd_session::test::flush(first_strategy.clone(), first_worker).await;
   drop(first_strategy);
 
-  let restarted_strategy = make_session_strategy(sdk_directory.path(), &config);
+  let restarted_strategy = make_session_strategy(sdk_directory.path(), &config).strategy;
   let restarted_session_id = restarted_strategy.session_id().await.unwrap();
 
   assert_ne!(first_session_id, restarted_session_id);
@@ -72,16 +75,19 @@ async fn activity_based_sessions_persist_across_restarts_within_threshold() {
     inactivity_threshold_mins: 30,
   };
 
-  let first_strategy =
+  let bd_session::StrategyParts {
+    strategy: first_strategy,
+    persistence_worker: first_worker,
+  } =
     make_session_strategy_with_time_provider(sdk_directory.path(), &config, time_provider.clone());
   let first_session_id = first_strategy.session_id().await.unwrap();
-  first_strategy.flush().await;
+  bd_session::test::flush(first_strategy.clone(), first_worker).await;
   drop(first_strategy);
 
   time_provider.advance(Duration::minutes(5));
 
   let restarted_strategy =
-    make_session_strategy_with_time_provider(sdk_directory.path(), &config, time_provider);
+    make_session_strategy_with_time_provider(sdk_directory.path(), &config, time_provider).strategy;
   let restarted_session_id = restarted_strategy.session_id().await.unwrap();
 
   assert_eq!(first_session_id, restarted_session_id);


### PR DESCRIPTION
This updates bd-session to use a single persistence worker task instead which is responsible for persisting the session changes to disk. This means that startNewSession etc will no longer block on session persistence and instead just notifies the persistence thread that the state is dirty. This simplifies the session persistence logic substantially and means that we no longer depend on the ALB to handle session persistence which will be a blocked for the future EventBuffer work. 

We are intentionally weakening the contract between startNewSession and the persistence guarantees here, relying the background task to write to disk and flush()-driven barriers.

Fixes BIT-9297
Fixes BIT-9602