### PR TITLE
bd-logger: support dynamic OOTB fields

### DIFF
--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -95,6 +95,7 @@ impl ReportProcessor for () {
 #[derive(Debug)]
 pub enum StateUpdateMessage {
   AddLogField(String, DataValue),
+  UpdateOotbLogField(String, DataValue),
   RemoveLogField(String),
   SetFeatureFlagExposure(String, Option<String>),
   SetMemoryPressureLevel { level: MemoryPressureLevel },
@@ -106,7 +107,9 @@ impl MemorySized for StateUpdateMessage {
   fn size(&self) -> usize {
     size_of_val(self)
       + match self {
-        Self::AddLogField(key, value) => key.size() + value.size(),
+        Self::AddLogField(key, value) | Self::UpdateOotbLogField(key, value) => {
+          key.size() + value.size()
+        },
         Self::RemoveLogField(field_name) => field_name.len(),
         Self::SetFeatureFlagExposure(flag, variant) => {
           flag.len() + variant.as_ref().map_or(0, String::len)
@@ -906,6 +909,9 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
                   {
                     log::warn!("failed to add log field ({key:?}): {e}");
                   }
+                },
+                StateUpdateMessage::UpdateOotbLogField(key, value) => {
+                  self.metadata_collector.update_ootb_field(key.into(), value);
                 },
                 StateUpdateMessage::RemoveLogField(field_name) => {
                   self.metadata_collector.remove_field(field_name.into());

--- a/bd-logger/src/logger.rs
+++ b/bd-logger/src/logger.rs
@@ -456,6 +456,34 @@ impl LoggerHandle {
     );
   }
 
+  /// Adds or replaces an SDK-owned OOTB field on all subsequently processed logs.
+  ///
+  /// Unlike custom global fields, OOTB fields may use reserved names and take precedence over
+  /// fields supplied by providers and individual log calls.
+  ///
+  /// This operation is non-blocking and best effort. It can be dropped when the bounded state
+  /// update buffer is full, so callers must tolerate missed transient updates.
+  pub fn update_ootb_log_field(&self, key: String, value: LogFieldValue) {
+    with_reentrancy_guard!(
+      {
+        let field_name = key.clone();
+        let result =
+          self
+            .tx
+            .try_send_state_update(async_log_buffer::StateUpdateMessage::UpdateOotbLogField(
+              key, value,
+            ));
+
+        if let Err(e) = result {
+          log::warn!("failed to update {field_name:?} OOTB log field: {e:?}");
+        }
+      },
+      "failed to update {:?} OOTB log field, updating log fields from within a field provider is \
+       not allowed",
+      key
+    );
+  }
+
   pub fn remove_log_field(&self, field_name: &str) {
     with_reentrancy_guard!(
       {

--- a/bd-logger/src/metadata.rs
+++ b/bd-logger/src/metadata.rs
@@ -228,6 +228,10 @@ impl MetadataCollector {
     Ok(())
   }
 
+  pub(crate) fn update_ootb_field(&mut self, key: LogFieldKey, value: LogFieldValue) {
+    self.fields.insert(key, AnnotatedLogField::new_ootb(value));
+  }
+
   pub(crate) fn remove_field(&mut self, field_key: LogFieldKey) {
     if let Entry::Occupied(entry) = self.fields.entry(field_key)
       && entry.get().kind != LogFieldKind::Ootb

--- a/bd-logger/src/metadata_test.rs
+++ b/bd-logger/src/metadata_test.rs
@@ -263,6 +263,28 @@ fn collector_does_not_mutate_initial_ootb_fields() {
 }
 
 #[test]
+fn collector_updates_ootb_fields() {
+  let provider = Arc::new(LogMetadata {
+    timestamp: Mutex::new(time::OffsetDateTime::now_utc()),
+    ..Default::default()
+  });
+  let mut collector =
+    MetadataCollector::new(provider, [("initial_key".into(), "initial".into())].into());
+
+  collector.update_ootb_field("initial_key".into(), "updated".into());
+  collector.update_ootb_field("_dynamic_key".into(), "dynamic".into());
+
+  assert_eq!(
+    &AnnotatedLogField::new_ootb("updated"),
+    &collector.fields["initial_key"]
+  );
+  assert_eq!(
+    &AnnotatedLogField::new_ootb("dynamic"),
+    &collector.fields["_dynamic_key"]
+  );
+}
+
+#[test]
 fn collector_initial_ootb_fields_override_provider_custom_fields() {
   let provider = Arc::new(LogMetadata {
     timestamp: Mutex::new(time::OffsetDateTime::now_utc()),


### PR DESCRIPTION
Adds a way to update the OOTB fields via a addField-like API. Only the internal logger will call this as a replacement for FieldProviders.

OOTB updates are non-blocking and best effort. If the bounded state-update buffer is full, an update is dropped and logged; callers must tolerate missed transient updates. Platform SDKs must provide values that need to appear on the first log through `initial_ootb_fields` before constructing the logger.