### PR TITLE
enable platform events by default

### DIFF
--- a/bd-events/src/lib.rs
+++ b/bd-events/src/lib.rs
@@ -47,9 +47,9 @@ pub trait ListenerTarget {
 pub struct Listener {
   target: Box<dyn ListenerTarget + Send + Sync>,
 
-  // Whether the events listener has seen at least one update to the value of the `is_enabled`
-  // flag.
-  has_seen_is_enabled_flag_update: bool,
+  // Tracks whether the target is currently running so runtime updates only transition it when
+  // needed.
+  target_is_active: bool,
 
   is_enabled_flag: BoolWatch<ListenerEnabledFlag>,
 }
@@ -63,7 +63,7 @@ impl Listener {
 
     Self {
       target,
-      has_seen_is_enabled_flag_update: false,
+      target_is_active: false,
       is_enabled_flag,
     }
   }
@@ -76,6 +76,13 @@ impl Listener {
   }
 
   pub async fn run_with_shutdown(&mut self, mut shutdown: ComponentShutdown) {
+    // The listener's default is enabled, so start it even when no runtime update has arrived.
+    if *self.is_enabled_flag.read_mark_update() {
+      log::debug!("events listener start");
+      self.target.start();
+      self.target_is_active = true;
+    }
+
     let local_shutdown = shutdown.cancelled();
     tokio::pin!(local_shutdown);
 
@@ -83,16 +90,15 @@ impl Listener {
       tokio::select! {
         _ = self.is_enabled_flag.changed() => {
           let new_is_enabled = *self.is_enabled_flag.read();
-          if new_is_enabled {
+          if new_is_enabled && !self.target_is_active {
             log::debug!("events listener start");
             self.target.start();
-          } else if self.has_seen_is_enabled_flag_update {
-            // Stop only if event listener was previously started.
+            self.target_is_active = true;
+          } else if !new_is_enabled && self.target_is_active {
             log::debug!("events listener stop");
             self.target.stop();
+            self.target_is_active = false;
           }
-
-          self.has_seen_is_enabled_flag_update = true;
         }
         () = &mut local_shutdown => {
           break;

--- a/bd-events/src/lib.rs
+++ b/bd-events/src/lib.rs
@@ -77,7 +77,7 @@ impl Listener {
 
   pub async fn run_with_shutdown(&mut self, mut shutdown: ComponentShutdown) {
     // The listener's default is enabled, so start it even when no runtime update has arrived.
-    if *self.is_enabled_flag.read_mark_update() {
+    if *self.is_enabled_flag.read_mark_update() && !self.target_is_active {
       log::debug!("events listener start");
       self.target.start();
       self.target_is_active = true;

--- a/bd-events/src/listener_test.rs
+++ b/bd-events/src/listener_test.rs
@@ -120,6 +120,33 @@ async fn starts_target_by_default() {
 }
 
 #[tokio::test]
+async fn does_not_restart_an_active_target() {
+  let setup = Setup::new();
+
+  let target = Box::new(MockListenerTarget::default());
+  let state = target.state.clone();
+
+  let mut listener = setup.create_listener(target);
+
+  // A cancelled shutdown makes each call complete after the initial startup check. This models
+  // the log buffer recreating the listener future while retaining the listener itself.
+  for _ in 0 .. 2 {
+    let shutdown_trigger = ComponentShutdownTrigger::default();
+    let shutdown = shutdown_trigger.make_shutdown();
+
+    let shutdown_task = tokio::task::spawn(async move {
+      shutdown_trigger.shutdown().await;
+    });
+    listener.run_with_shutdown(shutdown).await;
+    assert_ok!(shutdown_task.await);
+  }
+
+  assert_eq!(1, state.lock().start_calls_count);
+  assert_eq!(0, state.lock().stop_calls_count);
+  assert!(state.lock().is_active.unwrap());
+}
+
+#[tokio::test]
 async fn switches_target_off_and_back_on() {
   let setup = Setup::new();
 

--- a/bd-events/src/listener_test.rs
+++ b/bd-events/src/listener_test.rs
@@ -9,10 +9,8 @@ use crate::{Listener, ListenerTarget};
 use bd_runtime::runtime::{ConfigLoader, FeatureFlag};
 use bd_shutdown::ComponentShutdownTrigger;
 use bd_test_helpers::runtime::{ValueKind, make_simple_update};
-use bd_time::TimeDurationExt;
 use std::sync::Arc;
 use tempfile::TempDir;
-use time::ext::NumericalDuration;
 use tokio_test::assert_ok;
 
 //
@@ -38,7 +36,6 @@ impl Setup {
     Listener::new(target, &self.runtime)
   }
 
-  #[allow(dead_code)]
   async fn make_runtime_update(&self, events_listener_enabled: bool) {
     self
       .runtime
@@ -69,6 +66,8 @@ struct State {
 #[derive(Default)]
 struct MockListenerTarget {
   state: Arc<parking_lot::Mutex<State>>,
+  started: Arc<tokio::sync::Notify>,
+  stopped: Arc<tokio::sync::Notify>,
 }
 
 impl super::ListenerTarget for MockListenerTarget {
@@ -78,7 +77,8 @@ impl super::ListenerTarget for MockListenerTarget {
       start_calls_count: state.start_calls_count + 1,
       stop_calls_count: state.stop_calls_count,
       is_active: Some(true),
-    }
+    };
+    self.started.notify_one();
   }
 
   fn stop(&self) {
@@ -87,16 +87,18 @@ impl super::ListenerTarget for MockListenerTarget {
       start_calls_count: state.start_calls_count,
       stop_calls_count: state.stop_calls_count + 1,
       is_active: Some(false),
-    }
+    };
+    self.stopped.notify_one();
   }
 }
 
 #[tokio::test]
-async fn does_not_interact_with_target_if_listener_is_disabled() {
+async fn starts_target_by_default() {
   let setup = Setup::new();
 
   let target = Box::new(MockListenerTarget::default());
   let state = target.state.clone();
+  let started = target.started.clone();
 
   let mut listener = setup.create_listener(target);
 
@@ -107,37 +109,7 @@ async fn does_not_interact_with_target_if_listener_is_disabled() {
     () = listener.run_with_shutdown(shutdown).await;
   });
 
-  setup.make_runtime_update(false).await;
-
-  200.milliseconds().sleep().await;
-
-  shutdown_trigger.shutdown().await;
-  assert_ok!(listener_task.await);
-
-  assert_eq!(0, state.lock().start_calls_count);
-  assert_eq!(0, state.lock().stop_calls_count);
-  assert!(state.lock().is_active.is_none());
-}
-
-#[tokio::test]
-async fn starts_target() {
-  let setup = Setup::new();
-
-  let target = Box::new(MockListenerTarget::default());
-  let state = target.state.clone();
-
-  let mut listener = setup.create_listener(target);
-
-  let shutdown_trigger = ComponentShutdownTrigger::default();
-  let shutdown = shutdown_trigger.make_shutdown();
-
-  let listener_task = tokio::task::spawn(async move {
-    () = listener.run_with_shutdown(shutdown).await;
-  });
-
-  setup.make_runtime_update(true).await;
-
-  200.milliseconds().sleep().await;
+  started.notified().await;
 
   shutdown_trigger.shutdown().await;
   assert_ok!(listener_task.await);
@@ -148,11 +120,13 @@ async fn starts_target() {
 }
 
 #[tokio::test]
-async fn starts_and_stops_target() {
+async fn switches_target_off_and_back_on() {
   let setup = Setup::new();
 
   let target = Box::new(MockListenerTarget::default());
   let state = target.state.clone();
+  let started = target.started.clone();
+  let stopped = target.stopped.clone();
 
   let mut listener = setup.create_listener(target);
 
@@ -163,16 +137,18 @@ async fn starts_and_stops_target() {
     () = listener.run_with_shutdown(shutdown).await;
   });
 
-  setup.make_runtime_update(true).await;
-  200.milliseconds().sleep().await;
+  started.notified().await;
 
   setup.make_runtime_update(false).await;
-  200.milliseconds().sleep().await;
+  stopped.notified().await;
+
+  setup.make_runtime_update(true).await;
+  started.notified().await;
 
   shutdown_trigger.shutdown().await;
   assert_ok!(listener_task.await);
 
-  assert_eq!(1, state.lock().start_calls_count);
+  assert_eq!(2, state.lock().start_calls_count);
   assert_eq!(1, state.lock().stop_calls_count);
-  assert!(!state.lock().is_active.unwrap());
+  assert!(state.lock().is_active.unwrap());
 }

--- a/bd-logger/src/async_log_buffer_test.rs
+++ b/bd-logger/src/async_log_buffer_test.rs
@@ -624,10 +624,6 @@ async fn logs_resource_utilization_log() {
         ValueKind::Bool(true),
       ),
       (
-        bd_runtime::runtime::platform_events::ListenerEnabledFlag::path(),
-        ValueKind::Bool(true),
-      ),
-      (
         bd_runtime::runtime::resource_utilization::ResourceUtilizationEnabledFlag::path(),
         ValueKind::Bool(true),
       ),

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -693,7 +693,9 @@ fn api_bandwidth_counters() {
       );
       assert!(bandwidth_tx > 100, "bandwidth_tx = {bandwidth_tx}");
       assert!(bandwidth_rx < 400, "bandwidth_rx = {bandwidth_rx}");
-      assert_eq!(upload.get_counter("api:bandwidth_rx_decompressed", labels! {}), Some(279));
+      // Platform events are now enabled by default, so this runtime update only carries the
+      // resource-utilization override.
+      assert_eq!(upload.get_counter("api:bandwidth_rx_decompressed", labels! {}), Some(248));
       assert_eq!(upload.get_counter("api:stream_total", labels! {}), Some(1));
   });
 }

--- a/bd-logger/src/test/setup.rs
+++ b/bd-logger/src/test/setup.rs
@@ -394,10 +394,6 @@ impl Setup {
   pub fn get_default_runtime_values() -> Vec<(&'static str, ValueKind)> {
     vec![
       (
-        bd_runtime::runtime::platform_events::ListenerEnabledFlag::path(),
-        ValueKind::Bool(true),
-      ),
-      (
         bd_runtime::runtime::log_upload::BatchSizeFlag::path(),
         bd_test_helpers::runtime::ValueKind::Int(10),
       ),

--- a/bd-runtime/src/runtime.rs
+++ b/bd-runtime/src/runtime.rs
@@ -1021,7 +1021,7 @@ pub mod platform_events {
   // Controls whether the platform events listener is enabled or not. In practice, it determines
   // whether the platform layer emits events in response to various host platform-provided events
   // such as memory warnings or application lifecycle changes.
-  bool_feature_flag!(ListenerEnabledFlag, "platform_events.enabled", false);
+  bool_feature_flag!(ListenerEnabledFlag, "platform_events.enabled", true);
 }
 
 pub mod artifact_upload {


### PR DESCRIPTION
This ensures that clients come up with this on a fresh app install so we can start relying on these events for dynamically setting ootb fields.

 The feature can still be explicitly disabled via runtime push
