### PR TITLE
bd-event-buffer: add admission benchmarks

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -59,6 +59,13 @@ To run the benchmarks on linux use for example:
 cargo bench -p bd-workflows
 ```
 
+The event-buffer admission benchmark exercises insertion and eviction paths, including
+single-entry, multi-entry, and multi-lane eviction:
+
+```sh
+cargo bench -p bd-event-buffer --bench main
+```
+
 `bd-workflow-bench` provides the same two modes for end-to-end workflow replay. Its default
 checked-in fixture is appropriate for repeatable Criterion wall-time benchmarks and Callgrind
 instruction profiles; both wrappers also accept local config and log paths for a live corpus. See

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -66,6 +66,12 @@ single-entry, multi-entry, and multi-lane eviction:
 cargo bench -p bd-event-buffer --bench main
 ```
 
+For wall-clock measurements of the same cases, run:
+
+```sh
+cargo bench -p bd-event-buffer --bench criterion
+```
+
 `bd-workflow-bench` provides the same two modes for end-to-end workflow replay. Its default
 checked-in fixture is appropriate for repeatable Criterion wall-time benchmarks and Callgrind
 instruction profiles; both wrappers also accept local config and log paths for a live corpus. See

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "bd-macros",
  "bd-proto",
  "bd-workspace-hack",
+ "criterion",
  "gungraun",
  "proptest",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "bd-macros",
  "bd-proto",
  "bd-workspace-hack",
+ "gungraun",
  "proptest",
  "time",
  "tokio",

--- a/bd-event-buffer/Cargo.toml
+++ b/bd-event-buffer/Cargo.toml
@@ -16,6 +16,7 @@ time.workspace              = true
 tokio.workspace             = true
 
 [dev-dependencies]
+criterion          = "0.8.2"
 proptest.workspace = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
@@ -24,3 +25,7 @@ gungraun = { version = "0.19.4", features = ["client_requests"] }
 [[bench]]
 harness = false
 name    = "main"
+
+[[bench]]
+harness = false
+name    = "criterion"

--- a/bd-event-buffer/Cargo.toml
+++ b/bd-event-buffer/Cargo.toml
@@ -17,3 +17,10 @@ tokio.workspace             = true
 
 [dev-dependencies]
 proptest.workspace = true
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+gungraun = { version = "0.19.4", features = ["client_requests"] }
+
+[[bench]]
+harness = false
+name    = "main"

--- a/bd-event-buffer/benches/criterion.rs
+++ b/bd-event-buffer/benches/criterion.rs
@@ -42,13 +42,15 @@ fn admission(criterion: &mut Criterion) {
 
 fn ingress_and_admission(criterion: &mut Criterion) {
   let mut group = criterion.benchmark_group("event_buffer_ingress_and_admission");
-  group.bench_function("log_1_kib", |bench| {
-    bench.iter_batched_ref(
-      ingress_and_insertion_setup,
-      |buffer| black_box(ingress_and_admit(buffer)),
-      BatchSize::SmallInput,
-    );
-  });
+  for (name, bytes) in [("empty", 0), ("log_1_kib", 1024)] {
+    group.bench_function(name, |bench| {
+      bench.iter_batched_ref(
+        || ingress_and_insertion_setup(bytes),
+        |buffer| black_box(ingress_and_admit(buffer, bytes)),
+        BatchSize::SmallInput,
+      );
+    });
+  }
   group.finish();
 }
 

--- a/bd-event-buffer/benches/criterion.rs
+++ b/bd-event-buffer/benches/criterion.rs
@@ -1,0 +1,56 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE.polyform file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+mod scenarios;
+
+use crate::scenarios::{
+  AdmissionSetup,
+  ingress_and_admit,
+  ingress_and_insertion_setup,
+  insertion_setup,
+  insertion_with_capacity_setup,
+  multi_lane_eviction_setup,
+  multiple_victims_setup,
+  single_victim_setup,
+};
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+fn admission(criterion: &mut Criterion) {
+  let mut group = criterion.benchmark_group("event_buffer_admission");
+  for (name, setup) in [
+    ("insert_empty", insertion_setup as fn() -> AdmissionSetup),
+    ("insert_with_capacity", insertion_with_capacity_setup),
+    ("single_victim", single_victim_setup),
+    ("multiple_victims", multiple_victims_setup),
+    ("multi_lane_eviction", multi_lane_eviction_setup),
+  ] {
+    group.bench_function(name, |bench| {
+      bench.iter_batched_ref(
+        setup,
+        |setup| black_box(setup.admit()),
+        BatchSize::SmallInput,
+      );
+    });
+  }
+  group.finish();
+}
+
+fn ingress_and_admission(criterion: &mut Criterion) {
+  let mut group = criterion.benchmark_group("event_buffer_ingress_and_admission");
+  group.bench_function("log_1_kib", |bench| {
+    bench.iter_batched_ref(
+      ingress_and_insertion_setup,
+      |buffer| black_box(ingress_and_admit(buffer)),
+      BatchSize::SmallInput,
+    );
+  });
+  group.finish();
+}
+
+criterion_group!(benches, admission, ingress_and_admission);
+criterion_main!(benches);

--- a/bd-event-buffer/benches/linux_only/layout.rs
+++ b/bd-event-buffer/benches/linux_only/layout.rs
@@ -52,10 +52,10 @@ fn bench_admission(setup: AdmissionSetup) {
         .entry_point(EntryPoint::None)
     )
 )]
-#[bench::log_1_kib(ingress_and_insertion_setup())]
+#[bench::log_1_kib(ingress_and_insertion_setup(1024))]
 fn bench_ingress_and_admission(buffer: EventBuffer) {
   gungraun::client_requests::callgrind::start_instrumentation();
-  let outcome = ingress_and_admit(&buffer);
+  let outcome = ingress_and_admit(&buffer, 1024);
   gungraun::client_requests::callgrind::stop_instrumentation();
   black_box(outcome);
 }

--- a/bd-event-buffer/benches/linux_only/layout.rs
+++ b/bd-event-buffer/benches/linux_only/layout.rs
@@ -5,19 +5,17 @@
 // LICENSE.polyform file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use bd_event_buffer::{
-  AdmissionContext,
-  AdmissionOutcome,
-  EventBuffer,
-  EventBufferEntry,
-  EventBufferLimits,
-  EventContext,
-  LoggerIngressEvent,
-  ProviderSnapshot,
+use crate::scenarios::{
+  AdmissionSetup,
+  ingress_and_admit,
+  ingress_and_insertion_setup,
+  insertion_setup,
+  insertion_with_capacity_setup,
+  multi_lane_eviction_setup,
+  multiple_victims_setup,
+  single_victim_setup,
 };
-use bd_log_primitives::{AnnotatedLogFields, LogFields, LogLine, log_level};
-use bd_macros::ApproximateSize;
-use bd_proto::protos::logging::payload::LogType;
+use bd_event_buffer::EventBuffer;
 use gungraun::{
   Callgrind,
   EntryPoint,
@@ -26,167 +24,6 @@ use gungraun::{
   library_benchmark_group,
 };
 use std::hint::black_box;
-use time::OffsetDateTime;
-
-//
-// AdmissionSetup
-//
-
-/// Setup work is passed through Gungraun's `bench` argument, so Callgrind measures just one
-/// admission. Eviction scenarios fill the buffer before admission, including the destination
-/// lane when measuring its `VecDeque` reservation before lower-priority entries are evicted.
-struct AdmissionSetup {
-  buffer: EventBuffer,
-  incoming: EventBufferEntry,
-}
-
-fn current_process_context() -> EventContext {
-  EventContext::CurrentProcess(AdmissionContext {
-    session_id: String::new(),
-    provider: ProviderSnapshot {
-      timestamp: OffsetDateTime::UNIX_EPOCH,
-      ootb_fields: LogFields::default(),
-      custom_fields: LogFields::default(),
-    },
-    admitted_at: OffsetDateTime::UNIX_EPOCH,
-  })
-}
-
-fn log(
-  level: bd_log_primitives::LogLevel,
-  bytes: usize,
-  context: EventContext,
-) -> EventBufferEntry {
-  EventBufferEntry::ingress(LoggerIngressEvent::log(
-    LogLine {
-      log_level: level,
-      log_type: LogType::NORMAL,
-      message: "x".repeat(bytes).into(),
-      fields: AnnotatedLogFields::default(),
-      matching_fields: AnnotatedLogFields::default(),
-      attributes_overrides: None,
-      capture_session: None,
-    },
-    context,
-    None,
-  ))
-}
-
-fn low_log(bytes: usize) -> EventBufferEntry {
-  log(log_level::DEBUG, bytes, current_process_context())
-}
-
-fn high_log(bytes: usize) -> EventBufferEntry {
-  log(log_level::INFO, bytes, current_process_context())
-}
-
-fn protected_log(bytes: usize) -> EventBufferEntry {
-  // Previous-process logs use the protected lane even when their payload is an ordinary log.
-  log(
-    log_level::INFO,
-    bytes,
-    EventContext::PreviousProcess {
-      logged_at: OffsetDateTime::UNIX_EPOCH,
-    },
-  )
-}
-
-fn limits(log_limit_bytes: usize, total_limit_bytes: usize) -> EventBufferLimits {
-  EventBufferLimits {
-    log_limit_bytes,
-    total_limit_bytes,
-  }
-}
-
-fn admit(buffer: &EventBuffer, entry: EventBufferEntry) {
-  assert_eq!(AdmissionOutcome::Admitted, buffer.admit(entry));
-}
-
-fn insertion_setup() -> AdmissionSetup {
-  let incoming = high_log(0);
-  let size = incoming.approximate_size_bytes();
-
-  AdmissionSetup {
-    buffer: EventBuffer::new(limits(size, size)),
-    incoming,
-  }
-}
-
-fn insertion_with_capacity_setup() -> AdmissionSetup {
-  let entry_size = high_log(0).approximate_size_bytes();
-  let buffer = EventBuffer::new(limits(8 * entry_size, 8 * entry_size));
-  admit(&buffer, high_log(0));
-
-  AdmissionSetup {
-    buffer,
-    incoming: high_log(0),
-  }
-}
-
-fn ingress_and_insertion_setup() -> EventBuffer {
-  let size = high_log(1024).approximate_size_bytes();
-  EventBuffer::new(limits(size, size))
-}
-
-fn single_victim_setup() -> AdmissionSetup {
-  let low_size = low_log(0).approximate_size_bytes();
-  let high_base_size = high_log(0).approximate_size_bytes();
-  let buffer = EventBuffer::new(limits(low_size, low_size));
-  admit(&buffer, low_log(0));
-
-  AdmissionSetup {
-    buffer,
-    incoming: high_log(low_size.saturating_sub(high_base_size)),
-  }
-}
-
-fn multiple_victims_setup() -> AdmissionSetup {
-  const VICTIM_COUNT: usize = 8;
-
-  let low_size = low_log(0).approximate_size_bytes();
-  let high_base_size = high_log(0).approximate_size_bytes();
-  let limit = VICTIM_COUNT * low_size;
-  let buffer = EventBuffer::new(limits(limit, limit));
-  for _ in 0 .. VICTIM_COUNT {
-    admit(&buffer, low_log(0));
-  }
-
-  AdmissionSetup {
-    buffer,
-    incoming: high_log(limit.saturating_sub(high_base_size)),
-  }
-}
-
-fn multi_lane_eviction_setup() -> AdmissionSetup {
-  const PROTECTED_RETAINED_COUNT: usize = 4;
-  const LOW_VICTIM_COUNT: usize = 4;
-  const HIGH_VICTIM_COUNT: usize = 8;
-  const HIGH_EVICTION_COUNT: usize = 2;
-
-  let low_size = low_log(0).approximate_size_bytes();
-  let high_size = high_log(0).approximate_size_bytes();
-  let protected_size = protected_log(0).approximate_size_bytes();
-  let evictable_bytes = LOW_VICTIM_COUNT * low_size + HIGH_VICTIM_COUNT * high_size;
-  let total_retained_bytes = PROTECTED_RETAINED_COUNT * protected_size + evictable_bytes;
-  let incoming_bytes = LOW_VICTIM_COUNT * low_size + HIGH_EVICTION_COUNT * high_size;
-  let buffer = EventBuffer::new(limits(evictable_bytes, total_retained_bytes));
-  // Fill the incoming lane's initial allocation before it evicts lower-priority work. This
-  // measures the `VecDeque` growth that boxing would make cheaper.
-  for _ in 0 .. PROTECTED_RETAINED_COUNT {
-    admit(&buffer, protected_log(0));
-  }
-  for _ in 0 .. LOW_VICTIM_COUNT {
-    admit(&buffer, low_log(0));
-  }
-  for _ in 0 .. HIGH_VICTIM_COUNT {
-    admit(&buffer, high_log(0));
-  }
-
-  AdmissionSetup {
-    buffer,
-    incoming: protected_log(incoming_bytes.saturating_sub(protected_size)),
-  }
-}
 
 #[library_benchmark(
   config = LibraryBenchmarkConfig::default()
@@ -202,7 +39,7 @@ fn multi_lane_eviction_setup() -> AdmissionSetup {
 #[bench::multi_lane_eviction(multi_lane_eviction_setup())]
 fn bench_admission(setup: AdmissionSetup) {
   gungraun::client_requests::callgrind::start_instrumentation();
-  let outcome = setup.buffer.admit(setup.incoming);
+  let outcome = setup.admit();
   gungraun::client_requests::callgrind::stop_instrumentation();
   black_box(outcome);
 }
@@ -218,7 +55,7 @@ fn bench_admission(setup: AdmissionSetup) {
 #[bench::log_1_kib(ingress_and_insertion_setup())]
 fn bench_ingress_and_admission(buffer: EventBuffer) {
   gungraun::client_requests::callgrind::start_instrumentation();
-  let outcome = buffer.admit(high_log(1024));
+  let outcome = ingress_and_admit(&buffer);
   gungraun::client_requests::callgrind::stop_instrumentation();
   black_box(outcome);
 }

--- a/bd-event-buffer/benches/linux_only/layout.rs
+++ b/bd-event-buffer/benches/linux_only/layout.rs
@@ -1,0 +1,229 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE.polyform file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use bd_event_buffer::{
+  AdmissionContext,
+  AdmissionOutcome,
+  EventBuffer,
+  EventBufferEntry,
+  EventBufferLimits,
+  EventContext,
+  LoggerIngressEvent,
+  ProviderSnapshot,
+};
+use bd_log_primitives::{AnnotatedLogFields, LogFields, LogLine, log_level};
+use bd_macros::ApproximateSize;
+use bd_proto::protos::logging::payload::LogType;
+use gungraun::{
+  Callgrind,
+  EntryPoint,
+  LibraryBenchmarkConfig,
+  library_benchmark,
+  library_benchmark_group,
+};
+use std::hint::black_box;
+use time::OffsetDateTime;
+
+//
+// AdmissionSetup
+//
+
+/// Setup work is passed through Gungraun's `bench` argument, so Callgrind measures just one
+/// admission. Eviction scenarios fill the buffer before admission, including the destination
+/// lane when measuring its `VecDeque` reservation before lower-priority entries are evicted.
+struct AdmissionSetup {
+  buffer: EventBuffer,
+  incoming: EventBufferEntry,
+}
+
+fn current_process_context() -> EventContext {
+  EventContext::CurrentProcess(AdmissionContext {
+    session_id: String::new(),
+    provider: ProviderSnapshot {
+      timestamp: OffsetDateTime::UNIX_EPOCH,
+      ootb_fields: LogFields::default(),
+      custom_fields: LogFields::default(),
+    },
+    admitted_at: OffsetDateTime::UNIX_EPOCH,
+  })
+}
+
+fn log(
+  level: bd_log_primitives::LogLevel,
+  bytes: usize,
+  context: EventContext,
+) -> EventBufferEntry {
+  EventBufferEntry::ingress(LoggerIngressEvent::log(
+    LogLine {
+      log_level: level,
+      log_type: LogType::NORMAL,
+      message: "x".repeat(bytes).into(),
+      fields: AnnotatedLogFields::default(),
+      matching_fields: AnnotatedLogFields::default(),
+      attributes_overrides: None,
+      capture_session: None,
+    },
+    context,
+    None,
+  ))
+}
+
+fn low_log(bytes: usize) -> EventBufferEntry {
+  log(log_level::DEBUG, bytes, current_process_context())
+}
+
+fn high_log(bytes: usize) -> EventBufferEntry {
+  log(log_level::INFO, bytes, current_process_context())
+}
+
+fn protected_log(bytes: usize) -> EventBufferEntry {
+  // Previous-process logs use the protected lane even when their payload is an ordinary log.
+  log(
+    log_level::INFO,
+    bytes,
+    EventContext::PreviousProcess {
+      logged_at: OffsetDateTime::UNIX_EPOCH,
+    },
+  )
+}
+
+fn limits(log_limit_bytes: usize, total_limit_bytes: usize) -> EventBufferLimits {
+  EventBufferLimits {
+    log_limit_bytes,
+    total_limit_bytes,
+  }
+}
+
+fn admit(buffer: &EventBuffer, entry: EventBufferEntry) {
+  assert_eq!(AdmissionOutcome::Admitted, buffer.admit(entry));
+}
+
+fn insertion_setup() -> AdmissionSetup {
+  let incoming = high_log(0);
+  let size = incoming.approximate_size_bytes();
+
+  AdmissionSetup {
+    buffer: EventBuffer::new(limits(size, size)),
+    incoming,
+  }
+}
+
+fn insertion_with_capacity_setup() -> AdmissionSetup {
+  let entry_size = high_log(0).approximate_size_bytes();
+  let buffer = EventBuffer::new(limits(8 * entry_size, 8 * entry_size));
+  admit(&buffer, high_log(0));
+
+  AdmissionSetup {
+    buffer,
+    incoming: high_log(0),
+  }
+}
+
+fn ingress_and_insertion_setup() -> EventBuffer {
+  let size = high_log(1024).approximate_size_bytes();
+  EventBuffer::new(limits(size, size))
+}
+
+fn single_victim_setup() -> AdmissionSetup {
+  let low_size = low_log(0).approximate_size_bytes();
+  let high_base_size = high_log(0).approximate_size_bytes();
+  let buffer = EventBuffer::new(limits(low_size, low_size));
+  admit(&buffer, low_log(0));
+
+  AdmissionSetup {
+    buffer,
+    incoming: high_log(low_size.saturating_sub(high_base_size)),
+  }
+}
+
+fn multiple_victims_setup() -> AdmissionSetup {
+  const VICTIM_COUNT: usize = 8;
+
+  let low_size = low_log(0).approximate_size_bytes();
+  let high_base_size = high_log(0).approximate_size_bytes();
+  let limit = VICTIM_COUNT * low_size;
+  let buffer = EventBuffer::new(limits(limit, limit));
+  for _ in 0 .. VICTIM_COUNT {
+    admit(&buffer, low_log(0));
+  }
+
+  AdmissionSetup {
+    buffer,
+    incoming: high_log(limit.saturating_sub(high_base_size)),
+  }
+}
+
+fn multi_lane_eviction_setup() -> AdmissionSetup {
+  const PROTECTED_RETAINED_COUNT: usize = 4;
+  const LOW_VICTIM_COUNT: usize = 4;
+  const HIGH_VICTIM_COUNT: usize = 8;
+  const HIGH_EVICTION_COUNT: usize = 2;
+
+  let low_size = low_log(0).approximate_size_bytes();
+  let high_size = high_log(0).approximate_size_bytes();
+  let protected_size = protected_log(0).approximate_size_bytes();
+  let evictable_bytes = LOW_VICTIM_COUNT * low_size + HIGH_VICTIM_COUNT * high_size;
+  let total_retained_bytes = PROTECTED_RETAINED_COUNT * protected_size + evictable_bytes;
+  let incoming_bytes = LOW_VICTIM_COUNT * low_size + HIGH_EVICTION_COUNT * high_size;
+  let buffer = EventBuffer::new(limits(evictable_bytes, total_retained_bytes));
+  // Fill the incoming lane's initial allocation before it evicts lower-priority work. This
+  // measures the `VecDeque` growth that boxing would make cheaper.
+  for _ in 0 .. PROTECTED_RETAINED_COUNT {
+    admit(&buffer, protected_log(0));
+  }
+  for _ in 0 .. LOW_VICTIM_COUNT {
+    admit(&buffer, low_log(0));
+  }
+  for _ in 0 .. HIGH_VICTIM_COUNT {
+    admit(&buffer, high_log(0));
+  }
+
+  AdmissionSetup {
+    buffer,
+    incoming: protected_log(incoming_bytes.saturating_sub(protected_size)),
+  }
+}
+
+#[library_benchmark(
+  config = LibraryBenchmarkConfig::default()
+    .tool(
+      Callgrind::with_args(["--instr-atstart=no", "--dump-instr=yes"])
+        .entry_point(EntryPoint::None)
+    )
+)]
+#[bench::insert_empty(insertion_setup())]
+#[bench::insert_with_capacity(insertion_with_capacity_setup())]
+#[bench::single_victim(single_victim_setup())]
+#[bench::multiple_victims(multiple_victims_setup())]
+#[bench::multi_lane_eviction(multi_lane_eviction_setup())]
+fn bench_admission(setup: AdmissionSetup) {
+  gungraun::client_requests::callgrind::start_instrumentation();
+  let outcome = setup.buffer.admit(setup.incoming);
+  gungraun::client_requests::callgrind::stop_instrumentation();
+  black_box(outcome);
+}
+
+// Includes creation of the entry so a future boxed variant accounts for its extra allocation.
+#[library_benchmark(
+  config = LibraryBenchmarkConfig::default()
+    .tool(
+      Callgrind::with_args(["--instr-atstart=no", "--dump-instr=yes"])
+        .entry_point(EntryPoint::None)
+    )
+)]
+#[bench::log_1_kib(ingress_and_insertion_setup())]
+fn bench_ingress_and_admission(buffer: EventBuffer) {
+  gungraun::client_requests::callgrind::start_instrumentation();
+  let outcome = buffer.admit(high_log(1024));
+  gungraun::client_requests::callgrind::stop_instrumentation();
+  black_box(outcome);
+}
+
+library_benchmark_group!(
+  name = benches;
+  benchmarks = bench_admission, bench_ingress_and_admission
+);

--- a/bd-event-buffer/benches/linux_only/mod.rs
+++ b/bd-event-buffer/benches/linux_only/mod.rs
@@ -1,0 +1,8 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE.polyform file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+pub mod layout;

--- a/bd-event-buffer/benches/main.rs
+++ b/bd-event-buffer/benches/main.rs
@@ -1,0 +1,23 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE.polyform file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+#[cfg(target_os = "linux")]
+mod linux_only;
+
+#[cfg(target_os = "linux")]
+fn main() {
+  use crate::linux_only::layout::benches;
+  use gungraun::main;
+
+  main!(library_benchmark_groups = benches);
+  main();
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+  println!("event buffer benchmarks are only available on Linux");
+}

--- a/bd-event-buffer/benches/main.rs
+++ b/bd-event-buffer/benches/main.rs
@@ -7,6 +7,8 @@
 
 #[cfg(target_os = "linux")]
 mod linux_only;
+#[cfg(target_os = "linux")]
+mod scenarios;
 
 #[cfg(target_os = "linux")]
 fn main() {

--- a/bd-event-buffer/benches/scenarios.rs
+++ b/bd-event-buffer/benches/scenarios.rs
@@ -1,0 +1,194 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE.polyform file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+use bd_event_buffer::{
+  AdmissionContext,
+  AdmissionOutcome,
+  EventBuffer,
+  EventBufferEntry,
+  EventBufferLimits,
+  EventContext,
+  LoggerIngressEvent,
+  ProviderSnapshot,
+};
+use bd_log_primitives::{AnnotatedLogFields, LogFields, LogLine, log_level};
+use bd_macros::ApproximateSize;
+use bd_proto::protos::logging::payload::LogType;
+use time::OffsetDateTime;
+
+//
+// AdmissionSetup
+//
+
+/// An admission setup shared by the instruction-count and wall-clock benchmarks.
+pub struct AdmissionSetup {
+  buffer: EventBuffer,
+  incoming: Option<EventBufferEntry>,
+}
+
+impl AdmissionSetup {
+  pub fn admit(&mut self) -> AdmissionOutcome {
+    self.buffer.admit(
+      self
+        .incoming
+        .take()
+        .expect("each benchmark setup admits exactly one entry"),
+    )
+  }
+}
+
+fn current_process_context() -> EventContext {
+  EventContext::CurrentProcess(AdmissionContext {
+    session_id: String::new(),
+    provider: ProviderSnapshot {
+      timestamp: OffsetDateTime::UNIX_EPOCH,
+      ootb_fields: LogFields::default(),
+      custom_fields: LogFields::default(),
+    },
+    admitted_at: OffsetDateTime::UNIX_EPOCH,
+  })
+}
+
+fn log(
+  level: bd_log_primitives::LogLevel,
+  bytes: usize,
+  context: EventContext,
+) -> EventBufferEntry {
+  EventBufferEntry::ingress(LoggerIngressEvent::log(
+    LogLine {
+      log_level: level,
+      log_type: LogType::NORMAL,
+      message: "x".repeat(bytes).into(),
+      fields: AnnotatedLogFields::default(),
+      matching_fields: AnnotatedLogFields::default(),
+      attributes_overrides: None,
+      capture_session: None,
+    },
+    context,
+    None,
+  ))
+}
+
+fn low_log(bytes: usize) -> EventBufferEntry {
+  log(log_level::DEBUG, bytes, current_process_context())
+}
+
+fn high_log(bytes: usize) -> EventBufferEntry {
+  log(log_level::INFO, bytes, current_process_context())
+}
+
+fn protected_log(bytes: usize) -> EventBufferEntry {
+  // Previous-process logs use the protected lane even when their payload is an ordinary log.
+  log(
+    log_level::INFO,
+    bytes,
+    EventContext::PreviousProcess {
+      logged_at: OffsetDateTime::UNIX_EPOCH,
+    },
+  )
+}
+
+fn limits(log_limit_bytes: usize, total_limit_bytes: usize) -> EventBufferLimits {
+  EventBufferLimits {
+    log_limit_bytes,
+    total_limit_bytes,
+  }
+}
+
+fn assert_admitted(buffer: &EventBuffer, entry: EventBufferEntry) {
+  assert_eq!(AdmissionOutcome::Admitted, buffer.admit(entry));
+}
+
+pub fn insertion_setup() -> AdmissionSetup {
+  let incoming = high_log(0);
+  let size = incoming.approximate_size_bytes();
+
+  AdmissionSetup {
+    buffer: EventBuffer::new(limits(size, size)),
+    incoming: Some(incoming),
+  }
+}
+
+pub fn insertion_with_capacity_setup() -> AdmissionSetup {
+  let entry_size = high_log(0).approximate_size_bytes();
+  let buffer = EventBuffer::new(limits(8 * entry_size, 8 * entry_size));
+  assert_admitted(&buffer, high_log(0));
+
+  AdmissionSetup {
+    buffer,
+    incoming: Some(high_log(0)),
+  }
+}
+
+pub fn ingress_and_insertion_setup() -> EventBuffer {
+  let size = high_log(1024).approximate_size_bytes();
+  EventBuffer::new(limits(size, size))
+}
+
+pub fn single_victim_setup() -> AdmissionSetup {
+  let low_size = low_log(0).approximate_size_bytes();
+  let high_base_size = high_log(0).approximate_size_bytes();
+  let buffer = EventBuffer::new(limits(low_size, low_size));
+  assert_admitted(&buffer, low_log(0));
+
+  AdmissionSetup {
+    buffer,
+    incoming: Some(high_log(low_size.saturating_sub(high_base_size))),
+  }
+}
+
+pub fn multiple_victims_setup() -> AdmissionSetup {
+  const VICTIM_COUNT: usize = 8;
+
+  let low_size = low_log(0).approximate_size_bytes();
+  let high_base_size = high_log(0).approximate_size_bytes();
+  let limit = VICTIM_COUNT * low_size;
+  let buffer = EventBuffer::new(limits(limit, limit));
+  for _ in 0 .. VICTIM_COUNT {
+    assert_admitted(&buffer, low_log(0));
+  }
+
+  AdmissionSetup {
+    buffer,
+    incoming: Some(high_log(limit.saturating_sub(high_base_size))),
+  }
+}
+
+pub fn multi_lane_eviction_setup() -> AdmissionSetup {
+  const PROTECTED_RETAINED_COUNT: usize = 4;
+  const LOW_VICTIM_COUNT: usize = 4;
+  const HIGH_VICTIM_COUNT: usize = 8;
+  const HIGH_EVICTION_COUNT: usize = 2;
+
+  let low_size = low_log(0).approximate_size_bytes();
+  let high_size = high_log(0).approximate_size_bytes();
+  let protected_size = protected_log(0).approximate_size_bytes();
+  let evictable_bytes = LOW_VICTIM_COUNT * low_size + HIGH_VICTIM_COUNT * high_size;
+  let total_retained_bytes = PROTECTED_RETAINED_COUNT * protected_size + evictable_bytes;
+  let incoming_bytes = LOW_VICTIM_COUNT * low_size + HIGH_EVICTION_COUNT * high_size;
+  let buffer = EventBuffer::new(limits(evictable_bytes, total_retained_bytes));
+  // Fill the incoming lane's initial allocation before it evicts lower-priority work. This
+  // measures the `VecDeque` growth that boxing would make cheaper.
+  for _ in 0 .. PROTECTED_RETAINED_COUNT {
+    assert_admitted(&buffer, protected_log(0));
+  }
+  for _ in 0 .. LOW_VICTIM_COUNT {
+    assert_admitted(&buffer, low_log(0));
+  }
+  for _ in 0 .. HIGH_VICTIM_COUNT {
+    assert_admitted(&buffer, high_log(0));
+  }
+
+  AdmissionSetup {
+    buffer,
+    incoming: Some(protected_log(incoming_bytes.saturating_sub(protected_size))),
+  }
+}
+
+pub fn ingress_and_admit(buffer: &EventBuffer) -> AdmissionOutcome {
+  buffer.admit(high_log(1024))
+}

--- a/bd-event-buffer/benches/scenarios.rs
+++ b/bd-event-buffer/benches/scenarios.rs
@@ -124,8 +124,8 @@ pub fn insertion_with_capacity_setup() -> AdmissionSetup {
   }
 }
 
-pub fn ingress_and_insertion_setup() -> EventBuffer {
-  let size = high_log(1024).approximate_size_bytes();
+pub fn ingress_and_insertion_setup(bytes: usize) -> EventBuffer {
+  let size = high_log(bytes).approximate_size_bytes();
   EventBuffer::new(limits(size, size))
 }
 
@@ -189,6 +189,6 @@ pub fn multi_lane_eviction_setup() -> AdmissionSetup {
   }
 }
 
-pub fn ingress_and_admit(buffer: &EventBuffer) -> AdmissionOutcome {
-  buffer.admit(high_log(1024))
+pub fn ingress_and_admit(buffer: &EventBuffer, bytes: usize) -> AdmissionOutcome {
+  buffer.admit(high_log(bytes))
 }


### PR DESCRIPTION
Adds reproducible Callgrind and Criterion benchmarks for event-buffer admission paths, including empty and full insertion, single and multi-entry eviction, multi-lane contention, and end-to-end ingress. The shared scenarios keep setup and teardown outside the measured operation so both harnesses measure the same hot paths.