### PR TITLE
Add EventBuffer outcome metrics

### DIFF
--- a/bd-event-buffer/Cargo.toml
+++ b/bd-event-buffer/Cargo.toml
@@ -7,10 +7,12 @@ version      = "1.0.0"
 
 [dependencies]
 bd-client-common.path       = "../bd-client-common"
+bd-client-stats-store.path  = "../bd-client-stats-store"
 bd-completion.path          = "../bd-completion"
 bd-log-primitives.path      = "../bd-log-primitives"
 bd-macros.path              = "../bd-macros"
 bd-proto.path               = "../bd-proto"
+bd-stats-common.path        = "../bd-stats-common"
 bd-workspace-hack.workspace = true
 time.workspace              = true
 tokio.workspace             = true

--- a/bd-event-buffer/src/lib.rs
+++ b/bd-event-buffer/src/lib.rs
@@ -6,10 +6,12 @@
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
 use bd_client_common::PlatformMutex;
+use bd_client_stats_store::{Counter, Scope};
 use bd_log_primitives::{DataValue, LogFields, LogLevel, LogLine, log_level};
 use bd_macros::ApproximateSize;
 use bd_proto::flatbuffers::report::bitdrift_public::fbs::issue_reporting::v_1::MemoryPressureLevel;
 use bd_proto::protos::logging::payload::LogType;
+use bd_stats_common::{Counter as _, labels};
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tokio::sync::Notify;
@@ -216,6 +218,7 @@ pub struct EventBuffer {
 struct EventBufferInner {
   state: PlatformMutex<LoggerEventBufferState>,
   notify: Notify,
+  stats: Option<EventBufferStats>,
   #[cfg(test)]
   test_hooks: Option<Arc<dyn TestHooks>>,
 }
@@ -233,7 +236,20 @@ impl EventBuffer {
     }
     #[cfg(not(test))]
     {
-      Self::new_inner(limits)
+      Self::new_inner(limits, None)
+    }
+  }
+
+  /// Creates an `EventBuffer` that emits bounded per-lane admission outcome metrics.
+  #[must_use]
+  pub fn new_with_stats(limits: EventBufferLimits, scope: &Scope) -> Self {
+    #[cfg(test)]
+    {
+      Self::new_inner(limits, Some(EventBufferStats::new(scope)), None)
+    }
+    #[cfg(not(test))]
+    {
+      Self::new_inner(limits, Some(EventBufferStats::new(scope)))
     }
   }
 
@@ -242,11 +258,12 @@ impl EventBuffer {
     limits: EventBufferLimits,
     test_hooks: Option<Arc<dyn TestHooks>>,
   ) -> Self {
-    Self::new_inner(limits, test_hooks)
+    Self::new_inner(limits, None, test_hooks)
   }
 
   fn new_inner(
     limits: EventBufferLimits,
+    stats: Option<EventBufferStats>,
     #[cfg(test)] test_hooks: Option<Arc<dyn TestHooks>>,
   ) -> Self {
     Self {
@@ -255,6 +272,7 @@ impl EventBuffer {
           retention: EventBufferState::new(limits),
         }),
         notify: Notify::new(),
+        stats,
         #[cfg(test)]
         test_hooks,
       }),
@@ -267,12 +285,17 @@ impl EventBuffer {
 
   #[must_use]
   pub fn admit(&self, entry: EventBufferEntry) -> AdmissionOutcome {
+    let lane = entry.lane();
     let outcome = {
       let mut state = self.inner.state.lock();
-      state
-        .retention
-        .admit(entry.lane(), entry.approximate_size_bytes(), entry)
+      state.retention.admit_with_evictions(
+        lane,
+        entry.approximate_size_bytes(),
+        entry,
+        |evicted_lane| self.record_eviction(evicted_lane),
+      )
     };
+    self.record_outcome(lane, outcome);
     if outcome == AdmissionOutcome::Admitted {
       self.inner.notify.notify_one();
     }
@@ -311,6 +334,93 @@ impl EventBuffer {
       state.retention.close();
     }
     self.inner.notify.notify_waiters();
+  }
+
+  fn record_outcome(&self, lane: RetentionLane, outcome: AdmissionOutcome) {
+    if let Some(stats) = &self.inner.stats {
+      stats.record_outcome(lane, outcome);
+    }
+  }
+
+  fn record_eviction(&self, lane: RetentionLane) {
+    if let Some(stats) = &self.inner.stats {
+      stats.record_eviction(lane);
+    }
+  }
+}
+
+//
+// EventBufferStats
+//
+
+/// Bounded `EventBuffer` outcome metrics, labeled only by the fixed retention lane and outcome.
+struct EventBufferStats {
+  admitted: LaneCounters,
+  evicted: LaneCounters,
+  rejected_full: LaneCounters,
+  rejected_oversized: LaneCounters,
+  closed: LaneCounters,
+}
+
+impl EventBufferStats {
+  fn new(scope: &Scope) -> Self {
+    Self {
+      admitted: LaneCounters::new(scope, "admitted"),
+      evicted: LaneCounters::new(scope, "evicted"),
+      rejected_full: LaneCounters::new(scope, "rejected_full"),
+      rejected_oversized: LaneCounters::new(scope, "rejected_oversized"),
+      closed: LaneCounters::new(scope, "closed"),
+    }
+  }
+
+  fn record_outcome(&self, lane: RetentionLane, outcome: AdmissionOutcome) {
+    match outcome {
+      AdmissionOutcome::Admitted => self.admitted.inc(lane),
+      AdmissionOutcome::RejectedFull => self.rejected_full.inc(lane),
+      AdmissionOutcome::RejectedOversized => self.rejected_oversized.inc(lane),
+      AdmissionOutcome::Closed => self.closed.inc(lane),
+    }
+  }
+
+  fn record_eviction(&self, lane: RetentionLane) {
+    self.evicted.inc(lane);
+  }
+}
+
+//
+// LaneCounters
+//
+
+struct LaneCounters {
+  low: Counter,
+  high: Counter,
+  protected: Counter,
+}
+
+impl LaneCounters {
+  fn new(scope: &Scope, outcome: &'static str) -> Self {
+    Self {
+      low: scope.counter_with_labels(
+        "entry_outcomes",
+        labels!("lane" => "low", "outcome" => outcome),
+      ),
+      high: scope.counter_with_labels(
+        "entry_outcomes",
+        labels!("lane" => "high", "outcome" => outcome),
+      ),
+      protected: scope.counter_with_labels(
+        "entry_outcomes",
+        labels!("lane" => "protected", "outcome" => outcome),
+      ),
+    }
+  }
+
+  fn inc(&self, lane: RetentionLane) {
+    match lane {
+      RetentionLane::Low => self.low.inc(),
+      RetentionLane::High => self.high.inc(),
+      RetentionLane::Protected => self.protected.inc(),
+    }
   }
 }
 

--- a/bd-event-buffer/src/lib_test.rs
+++ b/bd-event-buffer/src/lib_test.rs
@@ -20,9 +20,12 @@ use super::{
   RetentionLane,
   retention_lane,
 };
+use bd_client_stats_store::Collector;
+use bd_client_stats_store::test::StatsHelper;
 use bd_log_primitives::{AnnotatedLogFields, DataValue, LogFields, LogLine, log_level};
 use bd_macros::ApproximateSize;
 use bd_proto::protos::logging::payload::LogType;
+use bd_stats_common::labels;
 use std::sync::Arc;
 use time::OffsetDateTime;
 use tokio::sync::{oneshot, watch};
@@ -73,6 +76,61 @@ fn limits(bytes: usize) -> EventBufferLimits {
 
 fn buffer(bytes: usize) -> EventBuffer {
   EventBuffer::new(limits(bytes))
+}
+
+#[test]
+fn records_admission_outcomes_per_retention_lane() {
+  let collector = Collector::default();
+  let low = log(log_level::DEBUG, LogType::NORMAL, 4096);
+  let high = log(log_level::INFO, LogType::NORMAL, 4096);
+  let protected = log(log_level::INFO, LogType::LIFECYCLE, 4096);
+  let limit = low
+    .approximate_size_bytes()
+    .max(high.approximate_size_bytes())
+    .max(protected.approximate_size_bytes());
+  let buffer = EventBuffer::new_with_stats(limits(limit), &collector.scope("event_buffer"));
+
+  assert_eq!(AdmissionOutcome::Admitted, buffer.admit(low));
+  assert_eq!(AdmissionOutcome::Admitted, buffer.admit(high));
+  assert_eq!(
+    AdmissionOutcome::RejectedFull,
+    buffer.admit(log(log_level::INFO, LogType::NORMAL, 4096))
+  );
+  assert_eq!(AdmissionOutcome::Admitted, buffer.admit(protected));
+  assert_eq!(
+    AdmissionOutcome::RejectedFull,
+    buffer.admit(log(log_level::INFO, LogType::LIFECYCLE, 4096))
+  );
+  assert_eq!(
+    AdmissionOutcome::RejectedOversized,
+    buffer.admit(log(log_level::DEBUG, LogType::NORMAL, limit))
+  );
+
+  collector.assert_counter_eq(
+    1,
+    "event_buffer:entry_outcomes",
+    labels!("lane" => "low", "outcome" => "evicted"),
+  );
+  collector.assert_counter_eq(
+    1,
+    "event_buffer:entry_outcomes",
+    labels!("lane" => "high", "outcome" => "evicted"),
+  );
+  collector.assert_counter_eq(
+    1,
+    "event_buffer:entry_outcomes",
+    labels!("lane" => "high", "outcome" => "rejected_full"),
+  );
+  collector.assert_counter_eq(
+    1,
+    "event_buffer:entry_outcomes",
+    labels!("lane" => "protected", "outcome" => "rejected_full"),
+  );
+  collector.assert_counter_eq(
+    1,
+    "event_buffer:entry_outcomes",
+    labels!("lane" => "low", "outcome" => "rejected_oversized"),
+  );
 }
 
 //

--- a/bd-event-buffer/src/retention.rs
+++ b/bd-event-buffer/src/retention.rs
@@ -49,8 +49,20 @@ impl<T> EventBufferState<T> {
   }
 
   /// Applies staged limits, then admits or drops an entry while the owner holds its mutex.
+  #[cfg(test)]
   pub(crate) fn admit(&mut self, lane: RetentionLane, bytes: usize, entry: T) -> AdmissionOutcome {
-    self.apply_pending_limits();
+    self.admit_with_evictions(lane, bytes, entry, |_| {})
+  }
+
+  /// Admits an entry and reports every retained entry displaced by pressure or a budget shrink.
+  pub(crate) fn admit_with_evictions(
+    &mut self,
+    lane: RetentionLane,
+    bytes: usize,
+    entry: T,
+    mut on_eviction: impl FnMut(RetentionLane),
+  ) -> AdmissionOutcome {
+    self.apply_pending_limits(&mut on_eviction);
     if self.closed {
       return AdmissionOutcome::Closed;
     }
@@ -65,7 +77,7 @@ impl<T> EventBufferState<T> {
     if !self.can_make_room(lane, bytes) || !self.reserve(lane) {
       return AdmissionOutcome::RejectedFull;
     }
-    self.make_room(lane, bytes);
+    self.make_room(lane, bytes, &mut on_eviction);
 
     let admission_id = self.next_admission_id;
     self.next_admission_id = self.next_admission_id.wrapping_add(1);
@@ -126,7 +138,7 @@ impl<T> EventBufferState<T> {
     .map(|(lane, _)| lane)
   }
 
-  fn apply_pending_limits(&mut self) {
+  fn apply_pending_limits(&mut self, on_eviction: &mut impl FnMut(RetentionLane)) {
     let Some(limits) = self.pending_limits.take() else {
       return;
     };
@@ -135,8 +147,8 @@ impl<T> EventBufferState<T> {
     // entries, while the total limit also includes protected entries. Enforce them separately,
     // recalculating the total overage after the first eviction pass. Both passes evict low before
     // high and never evict protected entries.
-    self.evict_for_budget_shrink(self.log_bytes_over_limit());
-    self.evict_for_budget_shrink(self.total_bytes_over_limit());
+    self.evict_for_budget_shrink(self.log_bytes_over_limit(), on_eviction);
+    self.evict_for_budget_shrink(self.total_bytes_over_limit(), on_eviction);
   }
 
   fn can_make_room(&self, lane: RetentionLane, incoming_bytes: usize) -> bool {
@@ -147,9 +159,14 @@ impl<T> EventBufferState<T> {
     self.evictable_bytes_available_to(lane) >= bytes_needed
   }
 
-  fn make_room(&mut self, lane: RetentionLane, incoming_bytes: usize) {
+  fn make_room(
+    &mut self,
+    lane: RetentionLane,
+    incoming_bytes: usize,
+    on_eviction: &mut impl FnMut(RetentionLane),
+  ) {
     let bytes_needed = self.required_eviction_bytes(lane, incoming_bytes);
-    self.evict_for_limit(lane, bytes_needed);
+    self.evict_for_limit(lane, bytes_needed, on_eviction);
   }
 
   fn required_eviction_bytes(&self, lane: RetentionLane, incoming_bytes: usize) -> usize {
@@ -170,7 +187,12 @@ impl<T> EventBufferState<T> {
     log_needed.max(total_needed)
   }
 
-  fn evict_for_limit(&mut self, incoming_lane: RetentionLane, mut bytes_needed: usize) {
+  fn evict_for_limit(
+    &mut self,
+    incoming_lane: RetentionLane,
+    mut bytes_needed: usize,
+    on_eviction: &mut impl FnMut(RetentionLane),
+  ) {
     // Evict the newest eligible entries first. This retains the oldest entries in each lane and
     // ensures an incoming entry only displaces work of lower priority.
     match incoming_lane {
@@ -178,15 +200,15 @@ impl<T> EventBufferState<T> {
         debug_assert_eq!(0, bytes_needed, "low entries cannot displace entries");
       },
       RetentionLane::High => {
-        bytes_needed = self.evict_from_lane(RetentionLane::Low, bytes_needed);
+        bytes_needed = self.evict_from_lane(RetentionLane::Low, bytes_needed, on_eviction);
         debug_assert_eq!(
           0, bytes_needed,
           "admission preflight guarantees enough lower-priority bytes"
         );
       },
       RetentionLane::Protected => {
-        bytes_needed = self.evict_from_lane(RetentionLane::Low, bytes_needed);
-        bytes_needed = self.evict_from_lane(RetentionLane::High, bytes_needed);
+        bytes_needed = self.evict_from_lane(RetentionLane::Low, bytes_needed, on_eviction);
+        bytes_needed = self.evict_from_lane(RetentionLane::High, bytes_needed, on_eviction);
         debug_assert_eq!(
           0, bytes_needed,
           "admission preflight guarantees enough lower-priority bytes"
@@ -195,17 +217,28 @@ impl<T> EventBufferState<T> {
     }
   }
 
-  fn evict_for_budget_shrink(&mut self, mut bytes_needed: usize) {
+  fn evict_for_budget_shrink(
+    &mut self,
+    mut bytes_needed: usize,
+    on_eviction: &mut impl FnMut(RetentionLane),
+  ) {
     // A limit change has no incoming priority, so it uses the least-destructive policy: discard
     // low entries first, then high entries, and leave protected entries intact even when they
     // alone exceed the new total limit.
     for lane in [RetentionLane::Low, RetentionLane::High] {
-      bytes_needed = self.evict_from_lane(lane, bytes_needed);
+      bytes_needed = self.evict_from_lane(lane, bytes_needed, on_eviction);
     }
   }
 
-  fn evict_from_lane(&mut self, lane: RetentionLane, bytes_needed: usize) -> usize {
-    let freed_bytes = self.lane_mut(lane).evict_newest(bytes_needed);
+  fn evict_from_lane(
+    &mut self,
+    lane: RetentionLane,
+    bytes_needed: usize,
+    on_eviction: &mut impl FnMut(RetentionLane),
+  ) -> usize {
+    let freed_bytes = self
+      .lane_mut(lane)
+      .evict_newest(bytes_needed, || on_eviction(lane));
     bytes_needed.saturating_sub(freed_bytes)
   }
 
@@ -291,7 +324,7 @@ impl<T> LaneState<T> {
     Some(entry)
   }
 
-  fn evict_newest(&mut self, bytes_needed: usize) -> usize {
+  fn evict_newest(&mut self, bytes_needed: usize, mut on_eviction: impl FnMut()) -> usize {
     // Remove and drop a newest-first suffix. The remaining prefix retains its FIFO ordering.
     let mut freed_bytes = 0;
     while freed_bytes < bytes_needed {
@@ -300,6 +333,7 @@ impl<T> LaneState<T> {
       };
       freed_bytes += entry.bytes;
       self.bytes -= entry.bytes;
+      on_eviction();
     }
     freed_bytes
   }


### PR DESCRIPTION
Adds bounded EventBuffer outcome counters by retention lane, covering admission, rejection, eviction, and deferred budget shrink. The metrics API and focused coverage are self-contained; logger migration remains outside this PR.