### PR TITLE
Add strict streaming state-journal recovery

### DIFF
--- a/bd-resilient-kv/src/lib.rs
+++ b/bd-resilient-kv/src/lib.rs
@@ -28,11 +28,26 @@ mod tests;
 mod scope;
 pub mod versioned_kv_journal;
 
+/// Maximum decompressed state journal accepted by server-side readers.
+pub const MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES: usize = 10 * 1024 * 1024;
+
+/// Maximum compressed state journal accepted by server-side readers.
+///
+/// This limits request memory and decompressor input work independently of the expanded journal
+/// limit above.
+pub const MAX_COMPRESSED_STATE_SNAPSHOT_BYTES: usize = 10 * 1024 * 1024;
+
 pub use bd_proto::protos::state::payload::StateValue;
 pub use bd_proto::protos::state::payload::state_value::Value_type;
 pub use scope::Scope;
 pub use versioned_kv_journal::filename::SnapshotFilename;
-pub use versioned_kv_journal::recovery::VersionedRecovery;
+pub use versioned_kv_journal::recovery::{
+  DecodedStateChange,
+  VersionedRecovery,
+  decode_compressed_journal,
+  decode_journal,
+  extract_non_empty_string_values_from_compressed_journal,
+};
 pub use versioned_kv_journal::retention::{RetentionHandle, RetentionRegistry};
 pub use versioned_kv_journal::store::{DataLoss, ScopedMaps, VersionedKVStore};
 pub use versioned_kv_journal::{

--- a/bd-resilient-kv/src/tests/versioned_recovery_error_test.rs
+++ b/bd-resilient-kv/src/tests/versioned_recovery_error_test.rs
@@ -29,6 +29,7 @@ use bd_time::TestTimeProvider;
 use crc32fast::Hasher;
 use flate2::Compression;
 use flate2::write::ZlibEncoder;
+use protobuf::Message;
 use std::io::Write;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -58,10 +59,24 @@ fn append_varint(mut value: u64, output: &mut Vec<u8>) {
 }
 
 fn encode_raw_frame(scope: Scope, key: &str, timestamp_micros: u64, payload: &[u8]) -> Vec<u8> {
+  let mut key_len = Vec::new();
+  append_varint(key.len().try_into().unwrap(), &mut key_len);
+  let mut timestamp = Vec::new();
+  append_varint(timestamp_micros, &mut timestamp);
+  encode_raw_frame_with_inner_varints(scope, key, &key_len, &timestamp, payload)
+}
+
+fn encode_raw_frame_with_inner_varints(
+  scope: Scope,
+  key: &str,
+  key_len: &[u8],
+  timestamp: &[u8],
+  payload: &[u8],
+) -> Vec<u8> {
   let mut frame_data = vec![scope.to_u8()];
-  append_varint(key.len().try_into().unwrap(), &mut frame_data);
+  frame_data.extend_from_slice(key_len);
   frame_data.extend_from_slice(key.as_bytes());
-  append_varint(timestamp_micros, &mut frame_data);
+  frame_data.extend_from_slice(timestamp);
   frame_data.extend_from_slice(payload);
 
   let mut hasher = Hasher::new();
@@ -499,6 +514,48 @@ fn streaming_scanner_rejects_invalid_frame_lengths() {
       &frame_past_journal_end,
       MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,
       1,
+    )
+    .is_err()
+  );
+}
+
+#[test]
+fn streaming_scanner_rejects_overlong_inner_varints() {
+  let payload = make_string_value("session-a").write_to_bytes().unwrap();
+  let overlong_key_length = compressed_journal(
+    vec![encode_raw_frame_with_inner_varints(
+      Scope::System,
+      "sid",
+      &[0x82, 0x00],
+      &[0x01],
+      &payload,
+    )],
+    0,
+  );
+  let overlong_timestamp = compressed_journal(
+    vec![encode_raw_frame_with_inner_varints(
+      Scope::System,
+      "sid",
+      &[0x03],
+      &[0x81, 0x00],
+      &payload,
+    )],
+    0,
+  );
+
+  assert!(
+    scan_session_ids(
+      &overlong_key_length,
+      MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,
+      1
+    )
+    .is_err()
+  );
+  assert!(
+    scan_session_ids(
+      &overlong_timestamp,
+      MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,
+      1
     )
     .is_err()
   );

--- a/bd-resilient-kv/src/tests/versioned_recovery_error_test.rs
+++ b/bd-resilient-kv/src/tests/versioned_recovery_error_test.rs
@@ -9,16 +9,99 @@
 #![allow(clippy::case_sensitive_file_extension_comparisons)]
 
 use crate::tests::decompress_zlib;
-use crate::versioned_kv_journal::make_string_value;
+use crate::versioned_kv_journal::framing::Frame;
 use crate::versioned_kv_journal::recovery::VersionedRecovery;
 use crate::versioned_kv_journal::retention::RetentionRegistry;
 use crate::versioned_kv_journal::store::PersistentStoreConfig;
-use crate::{Scope, VersionedKVStore};
+use crate::versioned_kv_journal::{HEADER_SIZE, make_string_value};
+use crate::{
+  MAX_COMPRESSED_STATE_SNAPSHOT_BYTES,
+  MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,
+  Scope,
+  StateValue,
+  Value_type,
+  VersionedKVStore,
+  decode_compressed_journal,
+  decode_journal,
+  extract_non_empty_string_values_from_compressed_journal,
+};
 use bd_time::TestTimeProvider;
+use crc32fast::Hasher;
+use flate2::Compression;
+use flate2::write::ZlibEncoder;
+use std::io::Write;
 use std::sync::Arc;
 use tempfile::TempDir;
 use time::ext::NumericalDuration;
 use time::macros::datetime;
+
+fn compress(data: &[u8]) -> Vec<u8> {
+  let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+  encoder.write_all(data).unwrap();
+  encoder.finish().unwrap()
+}
+
+fn encode_frame(scope: Scope, key: &str, timestamp_micros: u64, value: StateValue) -> Vec<u8> {
+  let frame = Frame::new(scope, key, timestamp_micros, value);
+  let mut encoded = vec![0; frame.encoded_size()];
+  let encoded_len = frame.encode(&mut encoded).unwrap();
+  encoded.truncate(encoded_len);
+  encoded
+}
+
+fn append_varint(mut value: u64, output: &mut Vec<u8>) {
+  while value >= 0x80 {
+    output.push(u8::try_from(value & 0x7f).unwrap() | 0x80);
+    value >>= 7;
+  }
+  output.push(u8::try_from(value).unwrap());
+}
+
+fn encode_raw_frame(scope: Scope, key: &str, timestamp_micros: u64, payload: &[u8]) -> Vec<u8> {
+  let mut frame_data = vec![scope.to_u8()];
+  append_varint(key.len().try_into().unwrap(), &mut frame_data);
+  frame_data.extend_from_slice(key.as_bytes());
+  append_varint(timestamp_micros, &mut frame_data);
+  frame_data.extend_from_slice(payload);
+
+  let mut hasher = Hasher::new();
+  hasher.update(&frame_data);
+  frame_data.extend_from_slice(&hasher.finalize().to_le_bytes());
+
+  let mut encoded = Vec::new();
+  append_varint(frame_data.len().try_into().unwrap(), &mut encoded);
+  encoded.extend_from_slice(&frame_data);
+  encoded
+}
+
+fn compressed_journal(encoded_frames: Vec<Vec<u8>>, padding_bytes: usize) -> Vec<u8> {
+  let encoded_frames_len: usize = encoded_frames.iter().map(Vec::len).sum();
+  let position = HEADER_SIZE + encoded_frames_len;
+  let mut journal = vec![0; position + padding_bytes];
+  journal[0] = 1;
+  journal[1 .. 9].copy_from_slice(&(position as u64).to_le_bytes());
+  let mut offset = HEADER_SIZE;
+  for frame in encoded_frames {
+    let end = offset + frame.len();
+    journal[offset .. end].copy_from_slice(&frame);
+    offset = end;
+  }
+  compress(&journal)
+}
+
+fn scan_session_ids(
+  compressed: &[u8],
+  max_decompressed_bytes: usize,
+  max_values: usize,
+) -> anyhow::Result<Vec<String>> {
+  extract_non_empty_string_values_from_compressed_journal(
+    compressed,
+    max_decompressed_bytes,
+    Scope::System,
+    "sid",
+    max_values,
+  )
+}
 
 #[test]
 fn test_recovery_buffer_too_small() {
@@ -182,15 +265,292 @@ fn test_recovery_with_corrupted_frame() {
   // (random bytes that won't decode as a valid frame)
   buffer[9 .. 50].fill(0xFF);
 
-  // This should not panic, but should handle the corrupted frame gracefully
-  let result = VersionedRecovery::new(vec![(&buffer, 1000)]);
-  // The recovery should succeed even with corrupted frames (it will just stop reading)
-  assert!(result.is_ok());
+  // Local recovery remains tolerant of an incomplete crash-time journal.
+  let recovery = VersionedRecovery::new(vec![(&buffer, 1000)]).unwrap();
+  assert!(recovery.recover_current().is_ok());
 
-  let recovery = result.unwrap();
-  let state = recovery.recover_current();
-  // Should return empty state since frames are corrupted
-  assert!(state.is_ok());
+  // Remote artifact ingestion uses the strict reader instead.
+  assert!(decode_journal(&buffer).is_err());
+}
+
+#[test]
+fn test_strict_decoder_rejects_truncated_frame() {
+  let frame = Frame::new(
+    Scope::FeatureFlagExposure,
+    "flag",
+    1,
+    make_string_value("enabled"),
+  );
+  let mut encoded_frame = vec![0; frame.encoded_size()];
+  let encoded_len = frame.encode(&mut encoded_frame).unwrap();
+
+  let mut buffer = vec![0; HEADER_SIZE + encoded_len - 1];
+  let position = buffer.len() as u64;
+  buffer[0] = 1;
+  buffer[1 .. 9].copy_from_slice(&position.to_le_bytes());
+  buffer[HEADER_SIZE ..].copy_from_slice(&encoded_frame[.. encoded_len - 1]);
+
+  let state = decode_journal(&buffer);
+  assert!(state.is_err());
+  assert!(
+    state
+      .unwrap_err()
+      .to_string()
+      .contains("Invalid journal frame")
+  );
+}
+
+#[test]
+fn test_compressed_recovery_rejects_oversized_snapshot() {
+  let compressed = compress(&vec![0; 1_024]);
+
+  let result = decode_compressed_journal(&compressed, 1_023);
+  assert!(result.is_err());
+  assert!(
+    result
+      .unwrap_err()
+      .to_string()
+      .contains("decompressed-size limit")
+  );
+}
+
+#[test]
+fn test_compressed_recovery_rejects_oversized_compressed_snapshot() {
+  let compressed = vec![0; MAX_COMPRESSED_STATE_SNAPSHOT_BYTES + 1];
+
+  let result = decode_compressed_journal(&compressed, 1);
+  assert!(result.is_err());
+  assert!(
+    result
+      .unwrap_err()
+      .to_string()
+      .contains("compressed-size limit")
+  );
+}
+
+#[test]
+fn compressed_decoder_preserves_typed_changes_and_tombstones() {
+  let flag_value = make_string_value("treatment");
+  let compressed = compressed_journal(
+    vec![
+      encode_frame(
+        Scope::FeatureFlagExposure,
+        "checkout-experiment",
+        10,
+        flag_value.clone(),
+      ),
+      encode_frame(
+        Scope::FeatureFlagExposure,
+        "checkout-experiment",
+        20,
+        StateValue::default(),
+      ),
+    ],
+    0,
+  );
+
+  let changes =
+    decode_compressed_journal(&compressed, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES).unwrap();
+
+  assert_eq!(changes.len(), 2);
+  assert_eq!(changes[0].scope, Scope::FeatureFlagExposure);
+  assert_eq!(changes[0].key, "checkout-experiment");
+  assert_eq!(changes[0].timestamp_micros, 10);
+  assert_eq!(changes[0].value, flag_value);
+  assert_eq!(changes[1].timestamp_micros, 20);
+  assert!(changes[1].value.value_type.is_none());
+}
+
+#[test]
+fn streaming_scanner_selects_requested_values_and_deduplicates_them() {
+  let compressed = compressed_journal(
+    vec![
+      encode_frame(
+        Scope::System,
+        "other",
+        1,
+        make_string_value("not-a-session"),
+      ),
+      encode_frame(
+        Scope::FeatureFlagExposure,
+        "sid",
+        2,
+        make_string_value("not-a-session"),
+      ),
+      encode_frame(Scope::System, "sid", 3, make_string_value("")),
+      encode_frame(Scope::System, "sid", 4, make_string_value("session-a")),
+      encode_frame(Scope::System, "sid", 5, make_string_value("session-a")),
+      encode_frame(Scope::System, "sid", 6, make_string_value("session-b")),
+    ],
+    0,
+  );
+
+  assert_eq!(
+    scan_session_ids(&compressed, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES, 2).unwrap(),
+    ["session-a", "session-b"]
+  );
+}
+
+#[test]
+fn streaming_scanner_ignores_non_string_and_empty_matching_values() {
+  let compressed = compressed_journal(
+    vec![
+      encode_frame(Scope::System, "sid", 1, StateValue::default()),
+      encode_frame(
+        Scope::System,
+        "sid",
+        2,
+        StateValue {
+          value_type: Some(Value_type::BoolValue(true)),
+          ..Default::default()
+        },
+      ),
+      encode_frame(Scope::System, "sid", 3, make_string_value("")),
+    ],
+    0,
+  );
+
+  assert!(
+    scan_session_ids(&compressed, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES, 1)
+      .unwrap()
+      .is_empty()
+  );
+}
+
+#[test]
+fn streaming_scanner_only_requires_valid_protobuf_for_the_selected_state_key() {
+  let compressed = compressed_journal(
+    vec![
+      encode_frame(Scope::System, "sid", 1, make_string_value("session-a")),
+      encode_raw_frame(Scope::FeatureFlagExposure, "flag", 2, &[0x0a]),
+    ],
+    0,
+  );
+
+  assert_eq!(
+    scan_session_ids(&compressed, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES, 1).unwrap(),
+    ["session-a"]
+  );
+}
+
+#[test]
+fn streaming_scanner_rejects_invalid_selected_state_value() {
+  let compressed = compressed_journal(vec![encode_raw_frame(Scope::System, "sid", 1, &[0x0a])], 0);
+
+  assert!(scan_session_ids(&compressed, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES, 1).is_err());
+}
+
+#[test]
+fn state_decoders_reject_corrupt_or_truncated_zlib_streams() {
+  let compressed = compressed_journal(
+    vec![encode_frame(
+      Scope::System,
+      "sid",
+      1,
+      make_string_value("session-a"),
+    )],
+    0,
+  );
+  let mut corrupt = compressed.clone();
+  *corrupt.last_mut().unwrap() ^= 0xff;
+  let mut trailing_data = compressed.clone();
+  trailing_data.push(0);
+
+  assert!(scan_session_ids(&corrupt, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES, 1).is_err());
+  assert!(scan_session_ids(&trailing_data, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES, 1).is_err());
+  assert!(
+    scan_session_ids(
+      &compressed[.. compressed.len() - 1],
+      MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,
+      1,
+    )
+    .is_err()
+  );
+  assert!(decode_compressed_journal(&corrupt, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES).is_err());
+  assert!(
+    decode_compressed_journal(&trailing_data, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,).is_err()
+  );
+  assert!(
+    decode_compressed_journal(
+      &compressed[.. compressed.len() - 1],
+      MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,
+    )
+    .is_err()
+  );
+}
+
+#[test]
+fn streaming_scanner_enforces_the_decompressed_limit_while_draining_padding() {
+  let frame = encode_frame(Scope::System, "sid", 1, make_string_value("session-a"));
+  let journal_size = HEADER_SIZE + frame.len();
+  let compressed = compressed_journal(vec![frame], 1);
+
+  assert!(scan_session_ids(&compressed, journal_size, 1).is_err());
+}
+
+#[test]
+fn streaming_scanner_rejects_invalid_frame_lengths() {
+  let malformed_varint = compressed_journal(vec![vec![0x80; 10]], 0);
+  let frame_past_journal_end = compressed_journal(vec![vec![0x7f]], 0);
+
+  assert!(scan_session_ids(&malformed_varint, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES, 1).is_err());
+  assert!(
+    scan_session_ids(
+      &frame_past_journal_end,
+      MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,
+      1,
+    )
+    .is_err()
+  );
+}
+
+#[test]
+fn streaming_scanner_rejects_invalid_headers_and_frame_checksums() {
+  let mut invalid_version = vec![0; HEADER_SIZE];
+  invalid_version[0] = 2;
+  invalid_version[1 .. 9].copy_from_slice(&(HEADER_SIZE as u64).to_le_bytes());
+
+  let mut corrupt_checksum = encode_frame(Scope::System, "sid", 1, make_string_value("session-a"));
+  *corrupt_checksum.last_mut().unwrap() ^= 0xff;
+
+  assert!(
+    scan_session_ids(
+      &compress(&invalid_version),
+      MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,
+      1,
+    )
+    .is_err()
+  );
+  assert!(
+    scan_session_ids(
+      &compressed_journal(vec![corrupt_checksum], 0),
+      MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,
+      1,
+    )
+    .is_err()
+  );
+}
+
+#[test]
+fn streaming_scanner_enforces_value_and_compressed_size_limits() {
+  let compressed = compressed_journal(
+    vec![
+      encode_frame(Scope::System, "sid", 1, make_string_value("session-a")),
+      encode_frame(Scope::System, "sid", 2, make_string_value("session-b")),
+    ],
+    0,
+  );
+
+  assert!(scan_session_ids(&compressed, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES, 0).is_err());
+  assert!(scan_session_ids(&compressed, MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES, 1).is_err());
+  assert!(
+    scan_session_ids(
+      &vec![0; MAX_COMPRESSED_STATE_SNAPSHOT_BYTES + 1],
+      MAX_DECOMPRESSED_STATE_SNAPSHOT_BYTES,
+      1,
+    )
+    .is_err()
+  );
 }
 
 #[tokio::test]

--- a/bd-resilient-kv/src/versioned_kv_journal/framing.rs
+++ b/bd-resilient-kv/src/versioned_kv_journal/framing.rs
@@ -33,6 +33,95 @@ mod varint;
 
 const CRC_LEN: usize = 4;
 
+/// A validated journal frame whose payload remains unparsed.
+///
+/// This supports readers that need only routing metadata from a journal and should not allocate
+/// or protobuf-decode every state value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawFrame<'a> {
+  /// Scope identifier for namespacing.
+  pub scope: Scope,
+  /// Key for this entry.
+  pub key: &'a str,
+  /// Timestamp in microseconds since UNIX epoch.
+  pub timestamp_micros: u64,
+  /// Opaque encoded payload bytes.
+  pub payload: &'a [u8],
+}
+
+/// Decode and validate a single journal frame without decoding its payload.
+pub fn decode_raw_frame(buf: &[u8]) -> anyhow::Result<(RawFrame<'_>, usize)> {
+  // Decode frame length varint.
+  let (frame_len_u64, length_len) =
+    varint::decode(buf).ok_or_else(|| anyhow::anyhow!("Invalid length varint"))?;
+  let frame_len = usize::try_from(frame_len_u64)
+    .map_err(|_| anyhow::anyhow!("Frame length too large: {frame_len_u64}"))?;
+  let total_len = length_len
+    .checked_add(frame_len)
+    .ok_or_else(|| anyhow::anyhow!("Frame length overflow"))?;
+  if buf.len() < total_len {
+    anyhow::bail!(
+      "Incomplete frame: need {} bytes, have {} bytes",
+      total_len,
+      buf.len()
+    );
+  }
+
+  let frame_data = &buf[length_len .. total_len];
+  if frame_data.is_empty() {
+    anyhow::bail!("Frame too small for scope");
+  }
+  let scope = Scope::from_repr(frame_data[0])
+    .ok_or_else(|| anyhow::anyhow!("Invalid scope value: {}", frame_data[0]))?;
+  let mut offset = 1;
+
+  let (key_len_u64, key_len_varint_len) = varint::decode(&frame_data[offset ..])
+    .ok_or_else(|| anyhow::anyhow!("Invalid key length varint"))?;
+  let key_len = usize::try_from(key_len_u64)
+    .map_err(|_| anyhow::anyhow!("Key length too large: {key_len_u64}"))?;
+  offset = offset
+    .checked_add(key_len_varint_len)
+    .ok_or_else(|| anyhow::anyhow!("Key length overflow"))?;
+  let key_end = offset
+    .checked_add(key_len)
+    .ok_or_else(|| anyhow::anyhow!("Key length overflow"))?;
+  if frame_data.len() < key_end {
+    anyhow::bail!("Frame too small for key");
+  }
+  let key = str::from_utf8(&frame_data[offset .. key_end])
+    .map_err(|error| anyhow::anyhow!("Invalid UTF-8 in key: {error}"))?;
+  offset = key_end;
+
+  let (timestamp_micros, timestamp_len) = varint::decode(&frame_data[offset ..])
+    .ok_or_else(|| anyhow::anyhow!("Invalid timestamp varint"))?;
+  offset = offset
+    .checked_add(timestamp_len)
+    .ok_or_else(|| anyhow::anyhow!("Timestamp length overflow"))?;
+  if frame_data.len() < offset + CRC_LEN {
+    anyhow::bail!("Frame too small for CRC");
+  }
+
+  let payload_end = frame_data.len() - CRC_LEN;
+  let payload = &frame_data[offset .. payload_end];
+  let stored_crc = u32::from_le_bytes(frame_data[payload_end ..].try_into()?);
+  let mut hasher = Hasher::new();
+  hasher.update(&frame_data[.. payload_end]);
+  let computed_crc = hasher.finalize();
+  if stored_crc != computed_crc {
+    anyhow::bail!("CRC mismatch: expected 0x{stored_crc:08x}, got 0x{computed_crc:08x}");
+  }
+
+  Ok((
+    RawFrame {
+      scope,
+      key,
+      timestamp_micros,
+      payload,
+    },
+    total_len,
+  ))
+}
+
 /// Frame structure for a journal entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Frame<'a, M> {
@@ -174,74 +263,12 @@ impl<'a, M: protobuf::Message> Frame<'a, M> {
   ///
   /// Returns (Frame, `bytes_consumed`) or error if invalid/incomplete.
   pub fn decode(buf: &'a [u8]) -> anyhow::Result<(Self, usize)> {
-    // Decode frame length varint
-    let (frame_len_u64, length_len) =
-      varint::decode(buf).ok_or_else(|| anyhow::anyhow!("Invalid length varint"))?;
-
-    let frame_len = usize::try_from(frame_len_u64)
-      .map_err(|_| anyhow::anyhow!("Frame length too large: {frame_len_u64}"))?;
-
-    // Check if we have the complete frame
-    let total_len = length_len + frame_len; // length varint + frame content
-    if buf.len() < total_len {
-      anyhow::bail!(
-        "Incomplete frame: need {} bytes, have {} bytes",
-        total_len,
-        buf.len()
-      );
-    }
-
-    let frame_data = &buf[length_len .. total_len];
-
-    // Decode scope (u8)
-    if frame_data.is_empty() {
-      anyhow::bail!("Frame too small for scope");
-    }
-    let scope = Scope::from_repr(frame_data[0])
-      .ok_or_else(|| anyhow::anyhow!("Invalid scope value: {}", frame_data[0]))?;
-    let mut offset = 1;
-
-    // Decode key length varint
-    let (key_len_u64, key_len_varint_len) = varint::decode(&frame_data[offset ..])
-      .ok_or_else(|| anyhow::anyhow!("Invalid key length varint"))?;
-    let key_len = usize::try_from(key_len_u64)
-      .map_err(|_| anyhow::anyhow!("Key length too large: {key_len_u64}"))?;
-    offset += key_len_varint_len;
-
-    // Decode key
-    if frame_data.len() < offset + key_len {
-      anyhow::bail!("Frame too small for key");
-    }
-    let key = str::from_utf8(&frame_data[offset .. offset + key_len])
-      .map_err(|e| anyhow::anyhow!("Invalid UTF-8 in key: {e}"))?;
-    offset += key_len;
-
-    // Decode timestamp varint
-    let (timestamp_micros, timestamp_len) = varint::decode(&frame_data[offset ..])
-      .ok_or_else(|| anyhow::anyhow!("Invalid timestamp varint"))?;
-    offset += timestamp_len;
-
-    // Extract payload and CRC
-    if frame_data.len() < offset + CRC_LEN {
-      anyhow::bail!("Frame too small for CRC");
-    }
-
-    let payload_end = frame_data.len() - CRC_LEN;
-    let payload = frame_data[offset .. payload_end].to_vec();
-    let stored_crc = u32::from_le_bytes(frame_data[payload_end ..].try_into()?);
-
-    // Verify CRC
-    let mut hasher = Hasher::new();
-    hasher.update(&frame_data[.. payload_end]); // Everything except CRC
-    let computed_crc = hasher.finalize();
-
-    if stored_crc != computed_crc {
-      anyhow::bail!("CRC mismatch: expected 0x{stored_crc:08x}, got 0x{computed_crc:08x}");
-    }
-
-    let payload =
-      M::parse_from_bytes(&payload).map_err(|e| anyhow::anyhow!("Failed to parse payload: {e}"))?;
-
-    Ok((Self::new(scope, key, timestamp_micros, payload), total_len))
+    let (frame, bytes_consumed) = decode_raw_frame(buf)?;
+    let payload = M::parse_from_bytes(frame.payload)
+      .map_err(|error| anyhow::anyhow!("Failed to parse payload: {error}"))?;
+    Ok((
+      Self::new(frame.scope, frame.key, frame.timestamp_micros, payload),
+      bytes_consumed,
+    ))
   }
 }

--- a/bd-resilient-kv/src/versioned_kv_journal/framing/varint.rs
+++ b/bd-resilient-kv/src/versioned_kv_journal/framing/varint.rs
@@ -36,10 +36,21 @@ pub fn encode(value: u64, mut buf: &mut [u8]) -> usize {
 /// Returns (value, `bytes_read`) or None if buffer is incomplete/invalid.
 #[must_use]
 pub fn decode(buf: &[u8]) -> Option<(u64, usize)> {
-  let value = protobuf::CodedInputStream::from_bytes(buf)
-    .read_raw_varint64()
-    .ok()?;
+  let mut value = 0_u64;
+  for (index, byte) in buf.iter().copied().take(MAX_SIZE).enumerate() {
+    let bits = u64::from(byte & 0x7f);
+    // A u64's tenth varint byte can contain only its most significant bit.
+    if index == MAX_SIZE - 1 && (byte & 0x80 != 0 || bits > 1) {
+      return None;
+    }
+    value |= bits << (index * 7);
 
-  let bytes_read = compute_size(value);
-  Some((value, bytes_read))
+    if byte & 0x80 == 0 {
+      let bytes_read = index + 1;
+      // Journal frames always use the canonical encoding emitted by encode(). Rejecting
+      // overlong values prevents a following field from being interpreted at the wrong offset.
+      return (compute_size(value) == bytes_read).then_some((value, bytes_read));
+    }
+  }
+  None
 }

--- a/bd-resilient-kv/src/versioned_kv_journal/framing_test.rs
+++ b/bd-resilient-kv/src/versioned_kv_journal/framing_test.rs
@@ -88,6 +88,11 @@ fn varint_too_long() {
 }
 
 #[test]
+fn varint_overlong_encoding_is_rejected() {
+  assert!(varint::decode(&[0x81, 0x00]).is_none());
+}
+
+#[test]
 fn frame_encode_decode() {
   let frame = Frame::new(
     Scope::FeatureFlagExposure,

--- a/bd-resilient-kv/src/versioned_kv_journal/journal.rs
+++ b/bd-resilient-kv/src/versioned_kv_journal/journal.rs
@@ -65,7 +65,7 @@ pub struct VersionedJournal<'a, M> {
 // purposes we can abstract out the enum we want to use for frame types.
 
 // The journal format version.
-const VERSION: u8 = 1;
+pub const VERSION: u8 = 1;
 
 // Size of the journal header in bytes. The header consists of:
 // - 1 byte for the version (u8)

--- a/bd-resilient-kv/src/versioned_kv_journal/recovery.rs
+++ b/bd-resilient-kv/src/versioned_kv_journal/recovery.rs
@@ -5,12 +5,15 @@
 // LICENSE.polyform file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::Scope;
 use crate::versioned_kv_journal::TimestampedValue;
-use crate::versioned_kv_journal::framing::Frame;
-use crate::versioned_kv_journal::journal::HEADER_SIZE;
-use ahash::AHashMap;
+use crate::versioned_kv_journal::framing::{Frame, decode_raw_frame};
+use crate::versioned_kv_journal::journal::{HEADER_SIZE, VERSION};
+use crate::{MAX_COMPRESSED_STATE_SNAPSHOT_BYTES, Scope};
+use ahash::{AHashMap, AHashSet};
 use bd_proto::protos::state::payload::StateValue;
+use flate2::{Decompress, FlushDecompress, Status};
+use protobuf::Message;
+use std::io::{ErrorKind, Read};
 
 /// A utility for recovering state at arbitrary timestamps from journal snapshots.
 ///
@@ -32,6 +35,352 @@ pub struct VersionedRecovery {
 struct SnapshotInfo {
   data: Vec<u8>,
   snapshot_timestamp: u64,
+}
+
+/// A fully validated state mutation decoded from a versioned journal.
+///
+/// A missing [`StateValue::value_type`] is the journal's tombstone representation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DecodedStateChange {
+  pub scope: Scope,
+  pub key: String,
+  pub value: StateValue,
+  pub timestamp_micros: u64,
+}
+
+fn journal_position(data: &[u8]) -> anyhow::Result<usize> {
+  if data.len() < HEADER_SIZE {
+    anyhow::bail!("Buffer too small: {}", data.len());
+  }
+
+  if data[0] != VERSION {
+    anyhow::bail!("Unsupported version: {}, expected {VERSION}", data[0]);
+  }
+
+  let position_bytes: [u8; 8] = data[1 .. 9]
+    .try_into()
+    .map_err(|_| anyhow::anyhow!("Failed to read position"))?;
+  let position_u64 = u64::from_le_bytes(position_bytes);
+  let position = usize::try_from(position_u64)
+    .map_err(|_| anyhow::anyhow!("Position {position_u64} too large for usize"))?;
+
+  if position < HEADER_SIZE {
+    anyhow::bail!("Invalid position: {position}, must be at least {HEADER_SIZE}");
+  }
+  Ok(position)
+}
+
+fn journal_end(data: &[u8]) -> anyhow::Result<usize> {
+  let position = journal_position(data)?;
+  if position > data.len() {
+    anyhow::bail!("Invalid position: {position}, buffer size: {}", data.len());
+  }
+
+  Ok(position)
+}
+
+fn validate_compressed_journal_size(compressed: &[u8]) -> anyhow::Result<()> {
+  if compressed.is_empty() {
+    anyhow::bail!("State snapshot is empty");
+  }
+  if compressed.len() > MAX_COMPRESSED_STATE_SNAPSHOT_BYTES {
+    anyhow::bail!(
+      "State snapshot exceeds compressed-size limit: {} > {MAX_COMPRESSED_STATE_SNAPSHOT_BYTES}",
+      compressed.len()
+    );
+  }
+
+  Ok(())
+}
+
+fn decompress_journal(compressed: &[u8], max_decompressed_bytes: usize) -> anyhow::Result<Vec<u8>> {
+  validate_compressed_journal_size(compressed)?;
+
+  let max_bytes_with_sentinel = max_decompressed_bytes
+    .checked_add(1)
+    .ok_or_else(|| anyhow::anyhow!("Invalid decompressed-size limit"))?;
+  let mut decoder = StrictZlibReader::new(compressed);
+  let mut journal = Vec::new();
+  decoder
+    .by_ref()
+    .take(max_bytes_with_sentinel as u64)
+    .read_to_end(&mut journal)?;
+  if journal.len() > max_decompressed_bytes {
+    anyhow::bail!(
+      "State snapshot exceeds decompressed-size limit: {} > {max_decompressed_bytes}",
+      journal.len()
+    );
+  }
+
+  Ok(journal)
+}
+
+//
+// StrictZlibReader
+//
+
+/// A zlib reader that requires the stream to end cleanly and consumes all input bytes.
+///
+/// `flate2::read::ZlibDecoder` may yield decoded bytes before it has observed a complete zlib
+/// trailer. Artifact ingestion must not accept that truncated prefix as a valid snapshot.
+struct StrictZlibReader<'a> {
+  decompressor: Decompress,
+  input: &'a [u8],
+  input_offset: usize,
+  stream_finished: bool,
+}
+
+impl<'a> StrictZlibReader<'a> {
+  fn new(input: &'a [u8]) -> Self {
+    Self {
+      decompressor: Decompress::new(true),
+      input,
+      input_offset: 0,
+      stream_finished: false,
+    }
+  }
+}
+
+impl Read for StrictZlibReader<'_> {
+  fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+    if output.is_empty() || self.stream_finished {
+      return Ok(0);
+    }
+
+    loop {
+      let input_before = self.decompressor.total_in();
+      let output_before = self.decompressor.total_out();
+      let status = self
+        .decompressor
+        .decompress(
+          &self.input[self.input_offset ..],
+          output,
+          FlushDecompress::None,
+        )
+        .map_err(|error| std::io::Error::new(ErrorKind::InvalidData, error))?;
+      let consumed = usize::try_from(self.decompressor.total_in() - input_before)
+        .map_err(|_| std::io::Error::other("zlib input offset overflow"))?;
+      let produced = usize::try_from(self.decompressor.total_out() - output_before)
+        .map_err(|_| std::io::Error::other("zlib output offset overflow"))?;
+      self.input_offset += consumed;
+
+      if status == Status::StreamEnd {
+        if self.input_offset != self.input.len() {
+          return Err(std::io::Error::new(
+            ErrorKind::InvalidData,
+            "State snapshot has trailing data after the zlib stream",
+          ));
+        }
+        self.stream_finished = true;
+        return Ok(produced);
+      }
+      if produced != 0 {
+        return Ok(produced);
+      }
+      if self.input_offset == self.input.len() {
+        return Err(std::io::Error::new(
+          ErrorKind::UnexpectedEof,
+          "State snapshot ended before the zlib stream completed",
+        ));
+      }
+      if consumed == 0 {
+        return Err(std::io::Error::new(
+          ErrorKind::InvalidData,
+          "State snapshot zlib decoder made no progress",
+        ));
+      }
+    }
+  }
+}
+
+//
+// LimitedReader
+//
+
+/// A decompression reader that accepts at most the configured number of output bytes.
+struct LimitedReader<R> {
+  reader: R,
+  bytes_read: usize,
+  max_bytes: usize,
+}
+
+impl<R> LimitedReader<R> {
+  fn new(reader: R, max_bytes: usize) -> Self {
+    Self {
+      reader,
+      bytes_read: 0,
+      max_bytes,
+    }
+  }
+}
+
+impl<R: Read> Read for LimitedReader<R> {
+  fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+    if buffer.is_empty() {
+      return Ok(0);
+    }
+
+    if self.bytes_read == self.max_bytes {
+      let mut sentinel = [0; 1];
+      if self.reader.read(&mut sentinel)? == 0 {
+        return Ok(0);
+      }
+      return Err(std::io::Error::new(
+        ErrorKind::InvalidData,
+        "State snapshot exceeds decompressed-size limit",
+      ));
+    }
+
+    let readable_bytes = buffer.len().min(self.max_bytes - self.bytes_read);
+    let read = self.reader.read(&mut buffer[.. readable_bytes])?;
+    self.bytes_read += read;
+    Ok(read)
+  }
+}
+
+fn read_frame<R: Read>(reader: &mut R, remaining_bytes: usize) -> anyhow::Result<(Vec<u8>, usize)> {
+  let mut length_bytes = Vec::with_capacity(10);
+  let mut frame_len = 0_u64;
+  for index in 0 .. 10 {
+    let mut byte = [0; 1];
+    reader.read_exact(&mut byte)?;
+    length_bytes.push(byte[0]);
+
+    let value = u64::from(byte[0] & 0x7f);
+    if index == 9 && value > 1 {
+      anyhow::bail!("Invalid frame length varint");
+    }
+    let shift = index * 7;
+    frame_len |= value
+      .checked_shl(shift)
+      .ok_or_else(|| anyhow::anyhow!("Invalid frame length varint"))?;
+    if byte[0] & 0x80 == 0 {
+      let frame_len = usize::try_from(frame_len)
+        .map_err(|_| anyhow::anyhow!("Frame length too large: {frame_len}"))?;
+      let encoded_len = length_bytes
+        .len()
+        .checked_add(frame_len)
+        .ok_or_else(|| anyhow::anyhow!("Frame length overflow"))?;
+      if encoded_len > remaining_bytes {
+        anyhow::bail!("Frame extends past the journal end");
+      }
+
+      let mut frame = length_bytes;
+      frame.resize(encoded_len, 0);
+      let frame_data_start = encoded_len - frame_len;
+      reader.read_exact(&mut frame[frame_data_start ..])?;
+      return Ok((frame, encoded_len));
+    }
+  }
+
+  anyhow::bail!("Invalid frame length varint")
+}
+
+fn drain_to_end<R: Read>(reader: &mut R) -> anyhow::Result<()> {
+  let mut buffer = [0; 8 * 1024];
+  while reader.read(&mut buffer)? != 0 {}
+  Ok(())
+}
+
+/// Decode every frame in an uncompressed versioned state journal.
+///
+/// Unlike local journal recovery, which may tolerate partial data loss after a crash, callers
+/// ingesting a remotely uploaded snapshot must reject any malformed or truncated frame. This
+/// function therefore validates the complete range declared by the journal header before
+/// returning a single state change.
+pub fn decode_journal(data: &[u8]) -> anyhow::Result<Vec<DecodedStateChange>> {
+  let position = journal_end(data)?;
+  let mut changes = Vec::new();
+  let mut offset = HEADER_SIZE;
+  while offset < position {
+    let (frame, bytes_read) = Frame::<StateValue>::decode(&data[offset .. position])
+      .map_err(|error| anyhow::anyhow!("Invalid journal frame at offset {offset}: {error}"))?;
+    changes.push(DecodedStateChange {
+      scope: frame.scope,
+      key: frame.key.to_string(),
+      value: frame.payload,
+      timestamp_micros: frame.timestamp_micros,
+    });
+    offset += bytes_read;
+  }
+
+  Ok(changes)
+}
+
+/// Boundedly decompress a state snapshot and extract all distinct non-empty string values for a
+/// single state key.
+///
+/// The scanner validates the journal header, every frame's bounds, and every frame's checksum. It
+/// only protobuf-decodes payloads for the requested `(scope, key)`, avoiding unnecessary state
+/// deserialization in routing-only consumers. It retains only one encoded frame at a time rather
+/// than materializing the entire decompressed journal.
+pub fn extract_non_empty_string_values_from_compressed_journal(
+  compressed: &[u8],
+  max_decompressed_bytes: usize,
+  scope: Scope,
+  key: &str,
+  max_values: usize,
+) -> anyhow::Result<Vec<String>> {
+  if max_values == 0 {
+    anyhow::bail!("State snapshot value limit must be positive");
+  }
+  validate_compressed_journal_size(compressed)?;
+  let mut reader = LimitedReader::new(StrictZlibReader::new(compressed), max_decompressed_bytes);
+  let mut header = [0; HEADER_SIZE];
+  reader.read_exact(&mut header)?;
+  let position = journal_position(&header)?;
+  if position > max_decompressed_bytes {
+    anyhow::bail!(
+      "State snapshot exceeds decompressed-size limit: {position} > {max_decompressed_bytes}"
+    );
+  }
+  let mut values = Vec::new();
+  let mut seen_values = AHashSet::new();
+  let mut offset = HEADER_SIZE;
+  while offset < position {
+    let (encoded_frame, bytes_read) = read_frame(&mut reader, position - offset)?;
+    let (frame, decoded_bytes_read) = decode_raw_frame(&encoded_frame)
+      .map_err(|error| anyhow::anyhow!("Invalid journal frame at offset {offset}: {error}"))?;
+    if decoded_bytes_read != bytes_read {
+      anyhow::bail!("Invalid journal frame length at offset {offset}");
+    }
+    if frame.scope == scope && frame.key == key {
+      let value = StateValue::parse_from_bytes(frame.payload)
+        .map_err(|error| anyhow::anyhow!("Invalid state value at offset {offset}: {error}"))?;
+      if let Some(bd_proto::protos::state::payload::state_value::Value_type::StringValue(value)) =
+        value.value_type
+        && !value.is_empty()
+        && seen_values.insert(value.clone())
+      {
+        values.push(value);
+        if values.len() > max_values {
+          anyhow::bail!(
+            "State snapshot exceeds distinct value limit: {} > {max_values}",
+            values.len()
+          );
+        }
+      }
+    }
+    offset += bytes_read;
+  }
+
+  // The journal is a memory-mapped file and may include trailing capacity after `position`.
+  // Drain it to validate the zlib stream and apply the output limit without retaining that padding.
+  drain_to_end(&mut reader)?;
+
+  Ok(values)
+}
+
+/// Boundedly decompress and decode a state-snapshot artifact.
+///
+/// The caller supplies the server's decompressed-size limit. A corrupted zlib stream, a stream
+/// that expands beyond that limit, or any malformed journal frame is rejected.
+pub fn decode_compressed_journal(
+  compressed: &[u8],
+  max_decompressed_bytes: usize,
+) -> anyhow::Result<Vec<DecodedStateChange>> {
+  let journal = decompress_journal(compressed, max_decompressed_bytes)?;
+  decode_journal(&journal)
 }
 
 impl VersionedRecovery {
@@ -177,23 +526,23 @@ fn replay_journal_to_timestamp(
     );
   }
 
-  // Decode frames from the journal data
+  // Decode frames from the journal data.
   let mut offset = 0;
   let data = &buffer[HEADER_SIZE .. position];
 
   while offset < data.len() {
     match Frame::<StateValue>::decode(&data[offset ..]) {
       Ok((frame, bytes_read)) => {
-        // Only apply entries up to target timestamp
+        // Only apply entries up to target timestamp.
         if frame.timestamp_micros > target_timestamp {
           break;
         }
 
         if frame.payload.value_type.is_none() {
-          // Deletion (StateValue with no value_type set)
+          // Deletion (StateValue with no value_type set).
           map.remove(&(frame.scope, frame.key.to_string()));
         } else {
-          // Insertion - store the protobuf StateValue with (scope, key) tuple
+          // Insertion - store the protobuf StateValue with (scope, key) tuple.
           map.insert(
             (frame.scope, frame.key.to_string()),
             TimestampedValue {
@@ -206,7 +555,7 @@ fn replay_journal_to_timestamp(
         offset += bytes_read;
       },
       Err(_) => {
-        // End of valid data or corrupted frame
+        // End of valid data or corrupted frame.
         break;
       },
     }


### PR DESCRIPTION
Adds bounded state-journal decoding and a raw-frame scanner for server-side consumers that need routing metadata without materializing or protobuf-decoding the full journal. The decoder validates frame boundaries and checksums, preserves typed changes and tombstones for full recovery, and enforces compressed and decompressed limits.

The streaming path now requires a complete zlib stream and rejects truncation or trailing data; direct tests cover malformed frames, invalid selected values, limits, mmap padding, and zlib corruption.