### PR TITLE
Expose state snapshot artifact constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,7 @@ dependencies = [
  "ctor",
  "flatbuffers",
  "flate2",
+ "fs2",
  "itertools 0.15.0",
  "log",
  "mockall",

--- a/bd-artifact-upload/src/uploader.rs
+++ b/bd-artifact-upload/src/uploader.rs
@@ -13,6 +13,7 @@ use bd_api::upload::{IntentDecision, TrackedArtifactIntent, TrackedArtifactUploa
 use bd_api::{DataUpload, RuntimeBackoffPolicy};
 use bd_backoff::{ExponentialBackoff, InfiniteBackoff};
 use bd_bounded_buffer::SendCounters;
+use bd_client_common::artifact::{CLIENT_REPORT_ARTIFACT_TYPE_ID, STATE_SNAPSHOT_ARTIFACT_TYPE_ID};
 use bd_client_common::error::InvariantError;
 use bd_client_common::file::{
   async_write_checksummed_data,
@@ -61,8 +62,8 @@ pub enum ArtifactType {
 impl ArtifactType {
   fn to_type_id(self) -> &'static str {
     match self {
-      Self::Report => "client_report",
-      Self::StateSnapshot => "state_snapshot",
+      Self::Report => CLIENT_REPORT_ARTIFACT_TYPE_ID,
+      Self::StateSnapshot => STATE_SNAPSHOT_ARTIFACT_TYPE_ID,
     }
   }
 }
@@ -911,7 +912,7 @@ impl Uploader {
           type_id: type_id.clone(),
           artifact_id: id.clone(),
           intent_uuid: upload_uuid.clone(),
-          session_id: Some(session_id.clone()),
+          session_id: (!session_id.is_empty()).then(|| session_id.clone()),
           time: timestamp.into_proto(),
           metadata: state_metadata.clone(),
           ..Default::default()

--- a/bd-client-common/src/artifact.rs
+++ b/bd-client-common/src/artifact.rs
@@ -1,0 +1,14 @@
+// shared-core - bitdrift's common client/server libraries
+// Copyright Bitdrift, Inc. All rights reserved.
+//
+// Use of this source code is governed by a source available license that can be found in the
+// LICENSE.polyform file or at:
+// https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
+
+//! Shared conventions for client artifact uploads.
+
+/// Artifact type ID used for crash reports uploaded by the client.
+pub const CLIENT_REPORT_ARTIFACT_TYPE_ID: &str = "client_report";
+
+/// Artifact type ID used for uploaded versioned state snapshots.
+pub const STATE_SNAPSHOT_ARTIFACT_TYPE_ID: &str = "state_snapshot";

--- a/bd-client-common/src/lib.rs
+++ b/bd-client-common/src/lib.rs
@@ -18,6 +18,7 @@ use bd_proto::protos::client::api::{self, ApiRequest, HandshakeRequest};
 use std::future::{Future, pending};
 use tokio::time::Interval;
 
+pub mod artifact;
 pub mod error;
 pub mod file;
 pub mod file_system;

--- a/bd-crash-handler/src/lib.rs
+++ b/bd-crash-handler/src/lib.rs
@@ -23,6 +23,7 @@ mod file_watcher;
 pub mod global_state;
 
 use bd_artifact_upload::{SnappedFeatureFlag, UploadSource};
+use bd_client_common::artifact::CLIENT_REPORT_ARTIFACT_TYPE_ID;
 use bd_client_common::debug_check_lifecycle_less_than;
 use bd_client_common::init_lifecycle::{InitLifecycle, InitLifecycleState};
 use bd_error_reporter::reporter::handle_unexpected;
@@ -604,7 +605,7 @@ impl Monitor {
 
     let Ok(artifact_id) = self.artifact_client.enqueue_upload(
       UploadSource::File(file),
-      "client_report".to_string(),
+      CLIENT_REPORT_ARTIFACT_TYPE_ID.to_string(),
       state_fields.clone(),
       timestamp,
       session_id.to_string(),

--- a/bd-logger/src/state_upload.rs
+++ b/bd-logger/src/state_upload.rs
@@ -38,6 +38,7 @@
 mod tests;
 
 use bd_artifact_upload::{Client as ArtifactClient, EnqueueError, UploadSource};
+use bd_client_common::artifact::STATE_SNAPSHOT_ARTIFACT_TYPE_ID;
 use bd_client_stats_store::{Counter, Scope};
 use bd_log_primitives::LogFields;
 use bd_proto::protos::client::key_value::StateSnapshotRange;
@@ -374,10 +375,10 @@ impl StateUploadWorker {
       let (persisted_tx, persisted_rx) = tokio::sync::oneshot::channel();
       match self.artifact_client.enqueue_upload(
         UploadSource::Path(snapshot_ref.path.clone()),
-        "state_snapshot".to_string(),
+        STATE_SNAPSHOT_ARTIFACT_TYPE_ID.to_string(),
         LogFields::new(),
         timestamp,
-        "state_snapshot".to_string(),
+        String::new(),
         vec![],
         Some(persisted_tx),
       ) {


### PR DESCRIPTION
Centralizes the client-report and state-snapshot artifact type IDs in bd-client-common and updates the existing crash-report and state-snapshot upload paths to use them. State snapshots now carry no outer session ID, so the artifact intent omits it; the existing fs2 lockfile record remains for reproducible --locked builds.