### PR TITLE
Add CRITICAL log level to bd-log-primitives

### DIFF
--- a/bd-log-primitives/src/lib.rs
+++ b/bd-log-primitives/src/lib.rs
@@ -487,6 +487,7 @@ pub type LogLevel = u32;
 pub mod log_level {
   use crate::LogLevel;
 
+  pub const CRITICAL: LogLevel = 5;
   pub const ERROR: LogLevel = 4;
   pub const WARNING: LogLevel = 3;
   pub const INFO: LogLevel = 2;
@@ -495,20 +496,25 @@ pub mod log_level {
 }
 
 /// A convenience enum that can be used to represent log levels in a more type-safe manner.
+///
+/// The discriminants match the wire values in `log_level`, so `as u32` and
+/// `as_u32` agree.
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TypedLogLevel {
-  Error,
-  Warning,
-  Info,
-  Debug,
-  Trace,
+  Critical = log_level::CRITICAL,
+  Error    = log_level::ERROR,
+  Warning  = log_level::WARNING,
+  Info     = log_level::INFO,
+  Debug    = log_level::DEBUG,
+  Trace    = log_level::TRACE,
 }
 
 impl TypedLogLevel {
   #[must_use]
   pub fn as_u32(&self) -> LogLevel {
     match self {
+      Self::Critical => log_level::CRITICAL,
       Self::Error => log_level::ERROR,
       Self::Warning => log_level::WARNING,
       Self::Info => log_level::INFO,

--- a/bd-log-primitives/src/lib_test.rs
+++ b/bd-log-primitives/src/lib_test.rs
@@ -7,7 +7,7 @@
 
 #![allow(clippy::cast_possible_truncation, clippy::unwrap_used)]
 
-use crate::{DataValue, EncodableLog, Log, LogFieldValue, LogType};
+use crate::{DataValue, EncodableLog, Log, LogFieldValue, LogType, TypedLogLevel, log_level};
 use ahash::AHashMap;
 use bd_proto::protos::logging::payload::data::Data_type;
 use bd_proto::protos::logging::payload::log::Field;
@@ -381,4 +381,19 @@ fn field_value_returns_numeric_types_as_strings() {
   );
   assert!(fields_ref.field_value("bool_field").is_none());
   assert!(fields_ref.field_value("nonexistent").is_none());
+}
+
+#[test]
+fn typed_log_level_discriminants_match_wire_values() {
+  for (typed, wire) in [
+    (TypedLogLevel::Critical, log_level::CRITICAL),
+    (TypedLogLevel::Error, log_level::ERROR),
+    (TypedLogLevel::Warning, log_level::WARNING),
+    (TypedLogLevel::Info, log_level::INFO),
+    (TypedLogLevel::Debug, log_level::DEBUG),
+    (TypedLogLevel::Trace, log_level::TRACE),
+  ] {
+    assert_eq!(typed.as_u32(), wire);
+    assert_eq!(typed as u32, wire);
+  }
 }


### PR DESCRIPTION
**Stack position: 3 of 6.** Independent of parts 1–2 to compile, but should merge after them so the read path lands first.

Linear: [BIT-7808](https://linear.app/bitdrift/issue/BIT-7808/support-critical-log-level)

## What

- `log_level::CRITICAL = 5`, one step above `ERROR`.
- `TypedLogLevel::Critical`.

`LogLevel` is already a `u32`, so nothing on the wire changes shape — this is purely giving the value a name.

## One thing that fell out of adding a variant

`TypedLogLevel` is `#[repr(u32)]` but had implicit discriminants, so `TypedLogLevel::Error as u32` was `0`, not `4`. Nothing relies on that today — every caller across all five repos goes through `as_u32()` — but adding a variant at the top of the enum would have silently renumbered the existing ones. Discriminants are now pinned to the `log_level` constants, with a test asserting `as u32` and `as_u32()` agree.

## Deliberately not in this PR

The `api` submodule pin is **not** bumped here. `CRITICAL` reaches the `api` repo through the proto-internal public-export sync, so that bump plus `make protos` is a follow-up commit on this branch once part 1 merges. I validated the regeneration locally against a simulated sync — it touches only `bd-proto/src/protos/public_api/logs.rs` and `public_api_with_source/logs.rs`.

## Validation

- `./bazelw test //shared-core/bd-log-primitives:test //shared-core/bd-log-matcher:test` — pass
- `./bazelw test --config=clippy //shared-core/bd-log-primitives/... //shared-core/bd-log-matcher/...` — pass
- `./bazelw test //shared-core/bd-logger/... //shared-core/bd-workflows/... //shared-core/bd-crash-handler/... //shared-core/bd-event-buffer/...` — pass

Pre-existing on `main`, unrelated, and reproduced with this change stashed: `//shared-core/fuzz:fuzz` fails to compile (`unresolved import bd_log_matcher::matcher::resolve_json_path_for_testing`).

## Stack

1. proto-internal — bitdriftlabs/proto-internal#821
2. internal-core — bitdriftlabs/internal-core#1184
3. **shared-core — this PR**
4. loop-api — bitdriftlabs/loop-api#3908
5. bd-cli — bitdriftlabs/bd-cli#248
6. capture-sdk — bitdriftlabs/capture-sdk#1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvWR7suPGYSK17BN81QpGo