### PR TITLE
Retain state when journal persistence fails

### DIFF
--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -2723,6 +2723,8 @@ fn remote_buffer_upload_with_streaming_matches_workflow_streaming_behavior() {
         ..Default::default()
       },
     });
+  // Wait until the remote action has installed its streaming route before emitting logs for it.
+  setup.wait_for_remote_streaming_action_processing();
 
   assert_matches!(setup.server.blocking_next_log_upload(), Some(log_upload) => {
     assert_eq!(log_upload.buffer_id(), "trigger_buffer_id");

--- a/bd-state/src/lib.rs
+++ b/bd-state/src/lib.rs
@@ -26,6 +26,7 @@ use bd_runtime::runtime::ConfigLoader;
 use bd_time::{OffsetDateTimeExt, TimeProvider};
 use bd_versioned_kv::{DataLoss, ScopedMaps, StateValue};
 pub use bd_versioned_kv::{
+  PersistenceMode,
   PersistentStoreConfig,
   RetentionHandle,
   RetentionRegistry,
@@ -540,6 +541,11 @@ impl Store {
     self
       .last_change_micros
       .load(std::sync::atomic::Ordering::Relaxed)
+  }
+
+  /// Returns whether state mutations are retained across process restarts.
+  pub async fn persistence_mode(&self) -> PersistenceMode {
+    self.inner.read().await.persistence_mode()
   }
 
   fn record_change(&self, timestamp: OffsetDateTime) {

--- a/bd-state/src/lib.rs
+++ b/bd-state/src/lib.rs
@@ -552,10 +552,12 @@ impl Store {
 
   /// Inserts a value into state.
   ///
-  /// If the persistent journal becomes unavailable, the state store retains the live value and
-  /// continues in in-memory mode. The update will not survive a restart, but all state readers
-  /// observe it during this process. A successful persistent-journal admission does not itself
-  /// perform an explicit disk sync.
+  /// If the persistent journal becomes unavailable, the state store retains live state and
+  /// continues in bounded in-memory mode. An update that fits is visible to all state readers for
+  /// the current process, but will not survive a restart. A successful persistent-journal
+  /// admission does not itself perform an explicit disk sync.
+  ///
+  /// Journal capacity rejections return an error without changing the live value or storage mode.
   pub async fn insert(
     &self,
     scope: Scope,

--- a/bd-state/src/lib.rs
+++ b/bd-state/src/lib.rs
@@ -550,6 +550,12 @@ impl Store {
       .fetch_max(micros, std::sync::atomic::Ordering::Relaxed);
   }
 
+  /// Inserts a value into state.
+  ///
+  /// If the persistent journal becomes unavailable, the state store retains the live value and
+  /// continues in in-memory mode. The update will not survive a restart, but all state readers
+  /// observe it during this process. A successful persistent-journal admission does not itself
+  /// perform an explicit disk sync.
   pub async fn insert(
     &self,
     scope: Scope,

--- a/bd-state/src/lib_test.rs
+++ b/bd-state/src/lib_test.rs
@@ -5,7 +5,7 @@
 // LICENSE.polyform file or at:
 // https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt
 
-use crate::{InitStrategy, SYSTEM_SESSION_ID_KEY, Scope, StateReader, Store};
+use crate::{InitStrategy, PersistenceMode, SYSTEM_SESSION_ID_KEY, Scope, StateReader, Store};
 use bd_client_stats_store::Collector;
 use bd_time::TimeProvider as _;
 use bd_versioned_kv::PersistentStoreConfig;
@@ -44,6 +44,31 @@ impl Setup {
       store,
     }
   }
+}
+
+#[tokio::test]
+async fn persistence_mode_matches_store_backend() {
+  let persistent = Setup::new().await;
+  assert_eq!(
+    persistent.store.persistence_mode().await,
+    PersistenceMode::Persistent
+  );
+
+  let in_memory_dir = tempfile::tempdir().unwrap();
+  let in_memory_runtime = bd_runtime::runtime::ConfigLoader::new(in_memory_dir.path());
+  let in_memory_collector = bd_client_stats_store::Collector::default();
+  let in_memory = Store::in_memory(
+    Arc::new(bd_time::TestTimeProvider::new(
+      datetime!(2024-01-01 00:00:00 UTC),
+    )),
+    None,
+    &in_memory_runtime,
+    &in_memory_collector.scope("test"),
+  );
+  assert_eq!(
+    in_memory.persistence_mode().await,
+    PersistenceMode::InMemory
+  );
 }
 
 #[tokio::test]

--- a/bd-versioned-kv/src/lib.rs
+++ b/bd-versioned-kv/src/lib.rs
@@ -49,7 +49,7 @@ pub use versioned_kv_journal::recovery::{
   extract_non_empty_string_values_from_compressed_journal,
 };
 pub use versioned_kv_journal::retention::{RetentionHandle, RetentionRegistry};
-pub use versioned_kv_journal::store::{DataLoss, ScopedMaps, VersionedKVStore};
+pub use versioned_kv_journal::store::{DataLoss, PersistenceMode, ScopedMaps, VersionedKVStore};
 pub use versioned_kv_journal::{
   HEADER_SIZE as VERSIONED_JOURNAL_HEADER_SIZE,
   PersistentStoreConfig,

--- a/bd-versioned-kv/src/tests/versioned_kv_store_dynamic_growth_test.rs
+++ b/bd-versioned-kv/src/tests/versioned_kv_store_dynamic_growth_test.rs
@@ -359,9 +359,9 @@ async fn insert_triggers_rotation_on_capacity_exceeded() -> anyhow::Result<()> {
   Ok(())
 }
 
-/// Test that inserting a value larger than max capacity still fails gracefully.
+/// Test that journal capacity failure preserves live state by falling back to memory.
 #[tokio::test]
-async fn insert_fails_when_exceeding_max_capacity() -> anyhow::Result<()> {
+async fn insert_falls_back_to_memory_when_exceeding_max_capacity() -> anyhow::Result<()> {
   use bd_client_stats_store::test::StatsHelper;
   use std::collections::BTreeMap;
 
@@ -379,28 +379,28 @@ async fn insert_fails_when_exceeding_max_capacity() -> anyhow::Result<()> {
   // Try to insert a value that's larger than max capacity
   let huge_value = "x".repeat(10 * 1024); // 10KB value, exceeds 8KB max
 
-  let result = store
+  store
     .insert(
       Scope::GlobalState,
       "huge_key".to_string(),
       make_string_value(&huge_value),
     )
-    .await;
+    .await?;
 
-  // Should fail with CapacityExceeded even after rotation attempt
-  assert!(
-    result.is_err(),
-    "Insert should fail when value exceeds max capacity"
-  );
-
-  // Verify nothing was inserted
-  assert_eq!(store.len(), 0);
-  assert!(!store.contains_key(Scope::GlobalState, "huge_key"));
+  // The value is available immediately, although it cannot survive a restart.
+  assert_eq!(store.len(), 1);
+  assert!(store.contains_key(Scope::GlobalState, "huge_key"));
+  assert!(store.journal_path().is_none());
 
   // Verify the metric was incremented
   setup.collector.assert_counter_eq(
     1,
     "test:kv:capacity_exceeded_unrecoverable",
+    BTreeMap::new(),
+  );
+  setup.collector.assert_counter_eq(
+    1,
+    "test:kv:persistence_fallbacks",
     BTreeMap::new(),
   );
 
@@ -467,11 +467,11 @@ async fn compaction_helps_at_max_capacity() -> anyhow::Result<()> {
   Ok(())
 }
 
-/// Test that rotation fails fast when even compaction wouldn't help.
+/// Test that a failed compaction keeps the new value available in memory.
 /// When buffer is at max capacity and compacted state plus new entry
 /// still wouldn't fit, we should fail immediately without attempting rotation.
 #[tokio::test]
-async fn fails_fast_when_compaction_wont_help() -> anyhow::Result<()> {
+async fn falls_back_to_memory_when_compaction_wont_help() -> anyhow::Result<()> {
   let setup = Setup::new();
 
   let config = PersistentStoreConfig {
@@ -498,23 +498,16 @@ async fn fails_fast_when_compaction_wont_help() -> anyhow::Result<()> {
   // Try to insert a large entry that wouldn't fit even after compaction
   let large_value = "y".repeat(4 * 1024); // 4KB value
 
-  let result = store
+  store
     .insert(
       Scope::GlobalState,
       "large_key".to_string(),
       make_string_value(&large_value),
     )
-    .await;
+    .await?;
 
-  // Should fail because compacted data (10 * ~512 bytes) + new entry (4KB)
-  // would exceed high water mark (8KB * 0.8 = 6.4KB)
-  assert!(
-    result.is_err(),
-    "Insert should fail when compaction wouldn't help"
-  );
-
-  // Verify nothing was inserted
-  assert!(!store.contains_key(Scope::GlobalState, "large_key"));
+  assert!(store.contains_key(Scope::GlobalState, "large_key"));
+  assert!(store.journal_path().is_none());
 
   Ok(())
 }

--- a/bd-versioned-kv/src/tests/versioned_kv_store_dynamic_growth_test.rs
+++ b/bd-versioned-kv/src/tests/versioned_kv_store_dynamic_growth_test.rs
@@ -9,7 +9,7 @@
 
 use crate::versioned_kv_journal::retention::RetentionRegistry;
 use crate::versioned_kv_journal::{PersistentStoreConfig, make_string_value};
-use crate::{Scope, VersionedKVStore};
+use crate::{Scope, UpdateError, VersionedKVStore};
 use bd_time::TestTimeProvider;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -359,9 +359,9 @@ async fn insert_triggers_rotation_on_capacity_exceeded() -> anyhow::Result<()> {
   Ok(())
 }
 
-/// Test that journal capacity failure preserves live state by falling back to memory.
+/// Journal capacity rejections retain the persistent backend and do not apply the new value.
 #[tokio::test]
-async fn insert_falls_back_to_memory_when_exceeding_max_capacity() -> anyhow::Result<()> {
+async fn oversized_value_keeps_persistent_store() -> anyhow::Result<()> {
   use bd_client_stats_store::test::StatsHelper;
   use std::collections::BTreeMap;
 
@@ -379,18 +379,18 @@ async fn insert_falls_back_to_memory_when_exceeding_max_capacity() -> anyhow::Re
   // Try to insert a value that's larger than max capacity
   let huge_value = "x".repeat(10 * 1024); // 10KB value, exceeds 8KB max
 
-  store
+  let error = store
     .insert(
       Scope::GlobalState,
       "huge_key".to_string(),
       make_string_value(&huge_value),
     )
-    .await?;
+    .await
+    .expect_err("an oversized value must be rejected");
 
-  // The value is available immediately, although it cannot survive a restart.
-  assert_eq!(store.len(), 1);
-  assert!(store.contains_key(Scope::GlobalState, "huge_key"));
-  assert!(store.journal_path().is_none());
+  assert!(matches!(error, UpdateError::CapacityExceeded));
+  assert!(store.is_empty());
+  assert!(store.journal_path().is_some());
 
   // Verify the metric was incremented
   setup.collector.assert_counter_eq(
@@ -398,11 +398,9 @@ async fn insert_falls_back_to_memory_when_exceeding_max_capacity() -> anyhow::Re
     "test:kv:capacity_exceeded_unrecoverable",
     BTreeMap::new(),
   );
-  setup.collector.assert_counter_eq(
-    1,
-    "test:kv:persistence_fallbacks",
-    BTreeMap::new(),
-  );
+  setup
+    .collector
+    .assert_counter_eq(0, "test:kv:persistence_fallbacks", BTreeMap::new());
 
   Ok(())
 }
@@ -467,11 +465,11 @@ async fn compaction_helps_at_max_capacity() -> anyhow::Result<()> {
   Ok(())
 }
 
-/// Test that a failed compaction keeps the new value available in memory.
+/// Test that a failed compaction retains persistent mode and rejects the new value.
 /// When buffer is at max capacity and compacted state plus new entry
 /// still wouldn't fit, we should fail immediately without attempting rotation.
 #[tokio::test]
-async fn falls_back_to_memory_when_compaction_wont_help() -> anyhow::Result<()> {
+async fn compaction_capacity_rejection_keeps_persistent_store() -> anyhow::Result<()> {
   let setup = Setup::new();
 
   let config = PersistentStoreConfig {
@@ -498,16 +496,18 @@ async fn falls_back_to_memory_when_compaction_wont_help() -> anyhow::Result<()> 
   // Try to insert a large entry that wouldn't fit even after compaction
   let large_value = "y".repeat(4 * 1024); // 4KB value
 
-  store
+  let error = store
     .insert(
       Scope::GlobalState,
       "large_key".to_string(),
       make_string_value(&large_value),
     )
-    .await?;
+    .await
+    .expect_err("an entry that cannot fit after compaction must be rejected");
 
-  assert!(store.contains_key(Scope::GlobalState, "large_key"));
-  assert!(store.journal_path().is_none());
+  assert!(matches!(error, UpdateError::CapacityExceeded));
+  assert!(!store.contains_key(Scope::GlobalState, "large_key"));
+  assert!(store.journal_path().is_some());
 
   Ok(())
 }

--- a/bd-versioned-kv/src/tests/versioned_kv_store_dynamic_growth_test.rs
+++ b/bd-versioned-kv/src/tests/versioned_kv_store_dynamic_growth_test.rs
@@ -9,7 +9,7 @@
 
 use crate::versioned_kv_journal::retention::RetentionRegistry;
 use crate::versioned_kv_journal::{PersistentStoreConfig, make_string_value};
-use crate::{Scope, UpdateError, VersionedKVStore};
+use crate::{PersistenceMode, Scope, UpdateError, VersionedKVStore};
 use bd_time::TestTimeProvider;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -376,17 +376,21 @@ async fn oversized_value_keeps_persistent_store() -> anyhow::Result<()> {
 
   let mut store = setup.open_store(config).await?;
 
+  assert_eq!(store.persistence_mode(), PersistenceMode::Persistent);
+
   // Try to insert a value that's larger than max capacity
   let huge_value = "x".repeat(10 * 1024); // 10KB value, exceeds 8KB max
 
-  let error = store
+  let Err(error) = store
     .insert(
       Scope::GlobalState,
       "huge_key".to_string(),
       make_string_value(&huge_value),
     )
     .await
-    .expect_err("an oversized value must be rejected");
+  else {
+    anyhow::bail!("an oversized value must be rejected");
+  };
 
   assert!(matches!(error, UpdateError::CapacityExceeded));
   assert!(store.is_empty());
@@ -496,14 +500,16 @@ async fn compaction_capacity_rejection_keeps_persistent_store() -> anyhow::Resul
   // Try to insert a large entry that wouldn't fit even after compaction
   let large_value = "y".repeat(4 * 1024); // 4KB value
 
-  let error = store
+  let Err(error) = store
     .insert(
       Scope::GlobalState,
       "large_key".to_string(),
       make_string_value(&large_value),
     )
     .await
-    .expect_err("an entry that cannot fit after compaction must be rejected");
+  else {
+    anyhow::bail!("an entry that cannot fit after compaction must be rejected");
+  };
 
   assert!(matches!(error, UpdateError::CapacityExceeded));
   assert!(!store.contains_key(Scope::GlobalState, "large_key"));

--- a/bd-versioned-kv/src/tests/versioned_kv_store_test.rs
+++ b/bd-versioned-kv/src/tests/versioned_kv_store_test.rs
@@ -640,6 +640,59 @@ async fn test_in_memory_size_limit_replacement() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_in_memory_size_limit_reclaims_replaced_and_removed_values() -> anyhow::Result<()> {
+  let collector = bd_client_stats_store::Collector::default();
+  let stats = collector.scope("test");
+  let time_provider = Arc::new(TestTimeProvider::new(datetime!(2024-01-01 00:00:00 UTC)));
+  let mut store = VersionedKVStore::new_in_memory(
+    time_provider,
+    Some(2_000),
+    &stats,
+    bd_runtime::runtime::IntWatch::new_for_testing(2),
+  );
+
+  let large_value = "x".repeat(1_200);
+  store
+    .insert(
+      Scope::FeatureFlagExposure,
+      "key1".to_string(),
+      make_string_value(&large_value),
+    )
+    .await?;
+
+  // Replacing a large value with a small one must reclaim the previous value's capacity.
+  store
+    .insert(
+      Scope::FeatureFlagExposure,
+      "key1".to_string(),
+      make_string_value("small"),
+    )
+    .await?;
+  store
+    .insert(
+      Scope::FeatureFlagExposure,
+      "key2".to_string(),
+      make_string_value(&large_value),
+    )
+    .await?;
+
+  // Removing the remaining large value must also make its capacity available to future writes.
+  store.remove(Scope::FeatureFlagExposure, "key2").await?;
+  store
+    .insert(
+      Scope::FeatureFlagExposure,
+      "key3".to_string(),
+      make_string_value(&large_value),
+    )
+    .await?;
+
+  assert!(store.contains_key(Scope::FeatureFlagExposure, "key1"));
+  assert!(store.contains_key(Scope::FeatureFlagExposure, "key3"));
+
+  Ok(())
+}
+
+#[tokio::test]
 async fn test_persistence_and_reload() -> anyhow::Result<()> {
   let collector = bd_client_stats_store::Collector::default();
   let stats = collector.scope("test");

--- a/bd-versioned-kv/src/tests/versioned_kv_store_test.rs
+++ b/bd-versioned-kv/src/tests/versioned_kv_store_test.rs
@@ -11,7 +11,7 @@ use crate::tests::decompress_zlib;
 use crate::versioned_kv_journal::retention::{RetentionHandle, RetentionRegistry};
 use crate::versioned_kv_journal::store::PersistentStoreConfig;
 use crate::versioned_kv_journal::{TimestampedValue, make_string_value};
-use crate::{DataLoss, Scope, UpdateError, VersionedKVStore};
+use crate::{DataLoss, PersistenceMode, Scope, UpdateError, VersionedKVStore};
 use bd_proto::protos::state::payload::StateValue;
 use bd_time::TestTimeProvider;
 use rstest::rstest;
@@ -569,6 +569,8 @@ async fn test_in_memory_no_size_limit() -> anyhow::Result<()> {
     &stats,
     bd_runtime::runtime::IntWatch::new_for_testing(2),
   );
+
+  assert_eq!(store.persistence_mode(), PersistenceMode::InMemory);
 
   // Should be able to insert many large values without limit
   for i in 0 .. 100 {
@@ -1444,7 +1446,7 @@ async fn extend_triggers_rotation_and_succeeds() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn extend_falls_back_to_memory_when_journal_capacity_is_exceeded() -> anyhow::Result<()> {
+async fn extend_capacity_rejection_keeps_persistent_store() -> anyhow::Result<()> {
   let collector = bd_client_stats_store::Collector::default();
   let stats = collector.scope("test");
   let temp_dir = TempDir::new()?;
@@ -1478,12 +1480,14 @@ async fn extend_falls_back_to_memory_when_journal_capacity_is_exceeded() -> anyh
     ));
   }
 
-  store.extend(entries).await?;
+  let Err(error) = store.extend(entries).await else {
+    anyhow::bail!("a batch that cannot fit after compaction must be rejected");
+  };
 
-  // The batch is visible to current-process readers after persistence degrades.
-  assert!(store.journal_path().is_none());
+  assert!(matches!(error, UpdateError::CapacityExceeded));
+  assert!(store.journal_path().is_some());
   for i in 0 .. 50 {
-    assert!(store.contains_key(Scope::FeatureFlagExposure, &format!("key_{i}")));
+    assert!(!store.contains_key(Scope::FeatureFlagExposure, &format!("key_{i}")));
   }
 
   Ok(())

--- a/bd-versioned-kv/src/tests/versioned_kv_store_test.rs
+++ b/bd-versioned-kv/src/tests/versioned_kv_store_test.rs
@@ -1391,7 +1391,7 @@ async fn extend_triggers_rotation_and_succeeds() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn extend_triggers_rotation_but_fails_capacity() -> anyhow::Result<()> {
+async fn extend_falls_back_to_memory_when_journal_capacity_is_exceeded() -> anyhow::Result<()> {
   let collector = bd_client_stats_store::Collector::default();
   let stats = collector.scope("test");
   let temp_dir = TempDir::new()?;
@@ -1415,8 +1415,6 @@ async fn extend_triggers_rotation_but_fails_capacity() -> anyhow::Result<()> {
   )
   .await?;
 
-  let initial_len = store.len();
-
   // Try to insert a batch that's too large for max capacity
   let mut entries = Vec::new();
   for i in 0 .. 50 {
@@ -1427,14 +1425,12 @@ async fn extend_triggers_rotation_but_fails_capacity() -> anyhow::Result<()> {
     ));
   }
 
-  // This should fail with CapacityExceeded even after rotation
-  let result = store.extend(entries).await;
-  assert!(matches!(result, Err(UpdateError::CapacityExceeded)));
+  store.extend(entries).await?;
 
-  // Verify atomicity - no partial writes
-  assert_eq!(store.len(), initial_len);
+  // The batch is visible to current-process readers after persistence degrades.
+  assert!(store.journal_path().is_none());
   for i in 0 .. 50 {
-    assert!(!store.contains_key(Scope::FeatureFlagExposure, &format!("key_{i}")));
+    assert!(store.contains_key(Scope::FeatureFlagExposure, &format!("key_{i}")));
   }
 
   Ok(())

--- a/bd-versioned-kv/src/tests/versioned_kv_store_test.rs
+++ b/bd-versioned-kv/src/tests/versioned_kv_store_test.rs
@@ -1493,6 +1493,136 @@ async fn extend_capacity_rejection_keeps_persistent_store() -> anyhow::Result<()
   Ok(())
 }
 
+async fn persistent_store_for_post_update_rotation_failure()
+-> anyhow::Result<(VersionedKVStore, bd_client_stats_store::Collector, TempDir)> {
+  let collector = bd_client_stats_store::Collector::default();
+  let stats = collector.scope("test");
+  let temp_dir = TempDir::new()?;
+  let time_provider = Arc::new(TestTimeProvider::new(datetime!(2024-01-01 00:00:00 UTC)));
+  let registry = Arc::new(RetentionRegistry::new(
+    bd_runtime::runtime::IntWatch::new_for_testing(2),
+  ));
+
+  let (store, _) = VersionedKVStore::new(
+    temp_dir.path(),
+    "test",
+    PersistentStoreConfig::default(),
+    time_provider,
+    registry,
+    &stats,
+  )
+  .await?;
+
+  Ok((store, collector, temp_dir))
+}
+
+#[tokio::test]
+async fn post_update_rotation_failure_preserves_insert_result() -> anyhow::Result<()> {
+  use bd_client_stats_store::test::StatsHelper;
+  use std::collections::BTreeMap;
+
+  let (mut store, collector, _temp_dir) =
+    persistent_store_for_post_update_rotation_failure().await?;
+  let old_value = make_string_value("old");
+  let new_value = make_string_value("new");
+  store
+    .insert(Scope::GlobalState, "key".to_string(), old_value.clone())
+    .await?;
+
+  store.fail_next_post_update_rotation_for_testing();
+  let (_, previous_value) = store
+    .insert(Scope::GlobalState, "key".to_string(), new_value.clone())
+    .await?;
+
+  assert_eq!(previous_value, Some(old_value));
+  assert_eq!(store.get(Scope::GlobalState, "key"), Some(&new_value));
+  assert_eq!(store.persistence_mode(), PersistenceMode::InMemory);
+  collector.assert_counter_eq(1, "test:kv:persistence_fallbacks", BTreeMap::new());
+
+  Ok(())
+}
+
+#[tokio::test]
+async fn post_update_rotation_failure_preserves_extend_result() -> anyhow::Result<()> {
+  use bd_client_stats_store::test::StatsHelper;
+  use std::collections::BTreeMap;
+
+  let (mut store, collector, _temp_dir) =
+    persistent_store_for_post_update_rotation_failure().await?;
+  store
+    .insert(
+      Scope::GlobalState,
+      "replaced".to_string(),
+      make_string_value("old"),
+    )
+    .await?;
+  store
+    .insert(
+      Scope::GlobalState,
+      "removed".to_string(),
+      make_string_value("old"),
+    )
+    .await?;
+
+  store.fail_next_post_update_rotation_for_testing();
+  store
+    .extend(vec![
+      (
+        Scope::GlobalState,
+        "replaced".to_string(),
+        make_string_value("new"),
+      ),
+      (
+        Scope::GlobalState,
+        "added".to_string(),
+        make_string_value("value"),
+      ),
+      (
+        Scope::GlobalState,
+        "removed".to_string(),
+        StateValue::default(),
+      ),
+    ])
+    .await?;
+
+  assert_eq!(
+    store.get(Scope::GlobalState, "replaced"),
+    Some(&make_string_value("new"))
+  );
+  assert_eq!(
+    store.get(Scope::GlobalState, "added"),
+    Some(&make_string_value("value"))
+  );
+  assert!(store.get(Scope::GlobalState, "removed").is_none());
+  assert_eq!(store.persistence_mode(), PersistenceMode::InMemory);
+  collector.assert_counter_eq(1, "test:kv:persistence_fallbacks", BTreeMap::new());
+
+  Ok(())
+}
+
+#[tokio::test]
+async fn post_update_rotation_failure_preserves_remove_result() -> anyhow::Result<()> {
+  use bd_client_stats_store::test::StatsHelper;
+  use std::collections::BTreeMap;
+
+  let (mut store, collector, _temp_dir) =
+    persistent_store_for_post_update_rotation_failure().await?;
+  let old_value = make_string_value("old");
+  store
+    .insert(Scope::GlobalState, "key".to_string(), old_value.clone())
+    .await?;
+
+  store.fail_next_post_update_rotation_for_testing();
+  let removed = store.remove(Scope::GlobalState, "key").await?;
+
+  assert!(removed.is_some_and(|(_, value)| value == old_value));
+  assert!(store.get(Scope::GlobalState, "key").is_none());
+  assert_eq!(store.persistence_mode(), PersistenceMode::InMemory);
+  collector.assert_counter_eq(1, "test:kv:persistence_fallbacks", BTreeMap::new());
+
+  Ok(())
+}
+
 #[tokio::test]
 async fn extend_atomicity_on_capacity_exceeded() -> anyhow::Result<()> {
   use bd_client_stats_store::test::StatsHelper;

--- a/bd-versioned-kv/src/versioned_kv_journal/store.rs
+++ b/bd-versioned-kv/src/versioned_kv_journal/store.rs
@@ -261,6 +261,31 @@ impl PendingScopedValues {
   }
 }
 
+//
+// TestHooks
+//
+
+#[cfg(test)]
+trait TestHooks: Send + Sync {
+  fn before_post_update_rotation(&self) -> anyhow::Result<()> {
+    Ok(())
+  }
+}
+
+//
+// FailNextPostUpdateRotation
+//
+
+#[cfg(test)]
+struct FailNextPostUpdateRotation;
+
+#[cfg(test)]
+impl TestHooks for FailNextPostUpdateRotation {
+  fn before_post_update_rotation(&self) -> anyhow::Result<()> {
+    anyhow::bail!("test-injected post-update rotation failure");
+  }
+}
+
 /// Persistent storage implementation using a memory-mapped journal.
 struct PersistentStore {
   journal: MemMappedVersionedJournal<StateValue>,
@@ -276,9 +301,9 @@ struct PersistentStore {
   max_capacity_bytes: usize,
   // Stats
   stats: CommonStats,
-  // Keeps post-mutation rotation failures deterministic without relying on filesystem faults.
+  // Test-only hooks make persistence failures deterministic without filesystem faults.
   #[cfg(test)]
-  fail_next_post_update_rotation: bool,
+  test_hooks: Option<Arc<dyn TestHooks>>,
 }
 
 /// The result of a persistent mutation, including a failure that occurred after it committed.
@@ -366,7 +391,7 @@ impl PersistentStore {
         max_capacity_bytes: config.max_capacity_bytes,
         stats,
         #[cfg(test)]
-        fail_next_post_update_rotation: false,
+        test_hooks: None,
       },
       data_loss,
     ))
@@ -565,8 +590,8 @@ impl PersistentStore {
   /// Rotates after a committed mutation has advanced the journal high-water mark.
   async fn rotate_after_update(&mut self) -> anyhow::Result<()> {
     #[cfg(test)]
-    if std::mem::take(&mut self.fail_next_post_update_rotation) {
-      anyhow::bail!("test-injected post-update rotation failure");
+    if let Some(test_hooks) = &self.test_hooks {
+      test_hooks.before_post_update_rotation()?;
     }
 
     if self.journal.is_high_water_mark_triggered() {
@@ -1276,7 +1301,7 @@ impl VersionedKVStore {
   #[cfg(test)]
   pub(crate) fn fail_next_post_update_rotation_for_testing(&mut self) {
     if let StoreBackend::Persistent(store) = &mut self.backend {
-      store.fail_next_post_update_rotation = true;
+      store.test_hooks = Some(Arc::new(FailNextPostUpdateRotation));
     }
   }
 

--- a/bd-versioned-kv/src/versioned_kv_journal/store.rs
+++ b/bd-versioned-kv/src/versioned_kv_journal/store.rs
@@ -953,11 +953,11 @@ impl InMemoryStore {
             .saturating_add(new_entry_size);
 
           // Check capacity before replacing
-          if let Some(max_bytes) = self.max_bytes {
-            if new_size > max_bytes {
-              self.stats.capacity_exceeded_unrecoverable.inc();
-              return Err(UpdateError::CapacityExceeded);
-            }
+          if let Some(max_bytes) = self.max_bytes
+            && new_size > max_bytes
+          {
+            self.stats.capacity_exceeded_unrecoverable.inc();
+            return Err(UpdateError::CapacityExceeded);
           }
 
           // Replace the value
@@ -1101,6 +1101,15 @@ impl InMemoryStore {
 enum StoreBackend {
   Persistent(PersistentStore),
   InMemory(InMemoryStore),
+}
+
+/// Indicates whether successful mutations are retained across process restarts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PersistenceMode {
+  /// Mutations are written to the journal and available after restart.
+  Persistent,
+  /// Mutations are retained only for the lifetime of the current process.
+  InMemory,
 }
 
 /// A key-value store with timestamp tracking and optional persistence.
@@ -1470,6 +1479,15 @@ impl VersionedKVStore {
     match &self.backend {
       StoreBackend::Persistent(store) => Some(store.journal_path()),
       StoreBackend::InMemory(_) => None,
+    }
+  }
+
+  /// Returns whether future successful mutations are persistent or memory-only.
+  #[must_use]
+  pub fn persistence_mode(&self) -> PersistenceMode {
+    match &self.backend {
+      StoreBackend::Persistent(_) => PersistenceMode::Persistent,
+      StoreBackend::InMemory(_) => PersistenceMode::InMemory,
     }
   }
 

--- a/bd-versioned-kv/src/versioned_kv_journal/store.rs
+++ b/bd-versioned-kv/src/versioned_kv_journal/store.rs
@@ -875,15 +875,21 @@ impl InMemoryStore {
 
   /// Preserves the live state when persistence is no longer available.
   ///
-  /// The fallback deliberately has no memory cap: state is correctness-critical for the
-  /// remainder of this process, while the persistent journal's capacity has already proved
-  /// unavailable. The state will be lost on the next process restart.
+  /// The fallback keeps the persistent store's configured capacity. A journal I/O failure must
+  /// not remove state from the running process, but it must not turn a bounded store into an
+  /// unbounded memory consumer either. The state will be lost on the next process restart.
   fn from_persistent(store: PersistentStore) -> Self {
+    let current_size_bytes = store
+      .cached_map
+      .iter()
+      .map(|(_, key, value)| Self::estimate_entry_size(key, &value.value))
+      .sum();
+
     Self {
       time_provider: store.journal.time_provider.clone(),
       cached_map: store.cached_map,
-      max_bytes: None,
-      current_size_bytes: 0,
+      max_bytes: Some(store.max_capacity_bytes),
+      current_size_bytes,
       stats: store.stats,
     }
   }
@@ -941,11 +947,13 @@ impl InMemoryStore {
           // Replacing existing entry - calculate size delta
           let old_value = entry.get().value.clone();
           let old_size = Self::estimate_entry_size(key, &old_value);
-          let size_delta = new_entry_size.saturating_sub(old_size);
+          let new_size = self
+            .current_size_bytes
+            .saturating_sub(old_size)
+            .saturating_add(new_entry_size);
 
           // Check capacity before replacing
           if let Some(max_bytes) = self.max_bytes {
-            let new_size = self.current_size_bytes.saturating_add(size_delta);
             if new_size > max_bytes {
               self.stats.capacity_exceeded_unrecoverable.inc();
               return Err(UpdateError::CapacityExceeded);
@@ -957,7 +965,7 @@ impl InMemoryStore {
             value: value.clone(),
             timestamp,
           });
-          self.current_size_bytes = self.current_size_bytes.saturating_add(size_delta);
+          self.current_size_bytes = new_size;
           Ok((timestamp, Some(old_value)))
         },
         Entry::Vacant(entry) => {
@@ -1080,7 +1088,12 @@ impl InMemoryStore {
     let timestamp = self.current_timestamp();
     let old_value = self.cached_map.remove(scope, key);
 
-    old_value.map(|v| (timestamp, v.value))
+    old_value.map(|value| {
+      self.current_size_bytes = self
+        .current_size_bytes
+        .saturating_sub(Self::estimate_entry_size(key, &value.value));
+      (timestamp, value.value)
+    })
   }
 }
 
@@ -1191,20 +1204,21 @@ impl VersionedKVStore {
     }
   }
 
-  /// Switches a failed persistent store to in-memory operation without losing its live state.
+  /// Switches a persistently failed store to bounded in-memory operation without losing live state.
   ///
   /// A journal failure must not make runtime state disappear: callers such as workflow matching
   /// and state consumers need the update even when it cannot survive a restart.
-  fn fallback_to_in_memory(&mut self, error: &UpdateError) {
+  fn fallback_to_in_memory(&mut self, error: &anyhow::Error) {
     let fallback = match &self.backend {
       StoreBackend::Persistent(store) => {
         store.stats.persistence_fallbacks.inc();
         log::warn!(
-          "disabling state persistence after journal write failure; retaining state in memory: {error}"
+          "disabling state persistence after journal write failure; retaining state in memory: \
+           {error}"
         );
         InMemoryStore::new(
           store.journal.time_provider.clone(),
-          None,
+          Some(store.max_capacity_bytes),
           store.stats.clone(),
         )
       },
@@ -1248,15 +1262,19 @@ impl VersionedKVStore {
   ///
   /// Note: Inserting `Value::Null` is equivalent to removing the key.
   ///
-  /// If persistent journal admission fails, the store transitions to unbounded in-memory mode and
-  /// still applies the update. The state remains available to the current process, but will not
-  /// survive a restart. This degradation is logged and counted in `kv:persistence_fallbacks`.
+  /// If the persistent journal encounters a system error, the store transitions to bounded
+  /// in-memory mode and still applies the update when it fits. The state remains available to the
+  /// current process, but will not survive a restart. This degradation is logged and counted in
+  /// `kv:persistence_fallbacks`.
+  ///
+  /// Journal capacity rejections do not change storage mode or apply the update.
   ///
   /// While the persistent journal is healthy, a successful return means it accepted the update;
   /// callers that require an explicit disk sync must call [`Self::sync`].
   ///
   /// # Errors
-  /// Returns `UpdateError::CapacityExceeded` only for an explicitly bounded in-memory store.
+  /// Returns `UpdateError::CapacityExceeded` when either persistent or in-memory admission rejects
+  /// the update.
   pub async fn insert(
     &mut self,
     scope: Scope,
@@ -1266,7 +1284,8 @@ impl VersionedKVStore {
     if let StoreBackend::Persistent(store) = &mut self.backend {
       match store.insert(scope, &key, value.clone()).await {
         Ok(result) => return Ok(result),
-        Err(error) => self.fallback_to_in_memory(&error),
+        Err(UpdateError::System(error)) => self.fallback_to_in_memory(&error),
+        Err(error) => return Err(error),
       }
     }
 
@@ -1281,8 +1300,9 @@ impl VersionedKVStore {
 
   /// Insert multiple key-value pairs with a shared timestamp.
   ///
-  /// All entries are written with the same timestamp. If a persistent journal write fails, the
-  /// store transitions to in-memory mode and applies the entire batch there.
+  /// All entries are written with the same timestamp. If a persistent journal encounters a system
+  /// error, the store transitions to bounded in-memory mode and applies the entire batch there
+  /// when it fits. Capacity rejections leave the persistent store unchanged.
   ///
   /// For persistent stores, this operation handles rotation and retries automatically if needed.
   /// If empty, this is a no-op that returns the current timestamp.
@@ -1290,7 +1310,8 @@ impl VersionedKVStore {
   /// Note: Entries with `Value::Null` are treated as deletions.
   ///
   /// # Errors
-  /// Returns `UpdateError::CapacityExceeded` only for an explicitly bounded in-memory store.
+  /// Returns `UpdateError::CapacityExceeded` when either persistent or in-memory admission rejects
+  /// the batch.
   pub async fn extend(
     &mut self,
     entries: Vec<(Scope, String, StateValue)>,
@@ -1298,7 +1319,8 @@ impl VersionedKVStore {
     if let StoreBackend::Persistent(store) = &mut self.backend {
       match store.extend_entries(entries.clone()).await {
         Ok(timestamp) => return Ok(timestamp),
-        Err(error) => self.fallback_to_in_memory(&error),
+        Err(UpdateError::System(error)) => self.fallback_to_in_memory(&error),
+        Err(error) => return Err(error),
       }
     }
 
@@ -1316,8 +1338,8 @@ impl VersionedKVStore {
   /// Returns `None` if the key didn't exist, otherwise returns the timestamp and old value.
   ///
   /// # Errors
-  /// If persistent journal admission fails, the store transitions to in-memory mode and removes
-  /// the value from the live state.
+  /// If the persistent journal encounters a system error, the store transitions to bounded
+  /// in-memory mode and removes the value from the live state.
   pub async fn remove(
     &mut self,
     scope: Scope,
@@ -1326,7 +1348,8 @@ impl VersionedKVStore {
     if let StoreBackend::Persistent(store) = &mut self.backend {
       match store.remove(scope, key).await {
         Ok(result) => return Ok(result),
-        Err(error) => self.fallback_to_in_memory(&error),
+        Err(UpdateError::System(error)) => self.fallback_to_in_memory(&error),
+        Err(error) => return Err(error),
       }
     }
 

--- a/bd-versioned-kv/src/versioned_kv_journal/store.rs
+++ b/bd-versioned-kv/src/versioned_kv_journal/store.rs
@@ -276,6 +276,15 @@ struct PersistentStore {
   max_capacity_bytes: usize,
   // Stats
   stats: CommonStats,
+  // Keeps post-mutation rotation failures deterministic without relying on filesystem faults.
+  #[cfg(test)]
+  fail_next_post_update_rotation: bool,
+}
+
+/// The result of a persistent mutation, including a failure that occurred after it committed.
+enum PersistentOperation<T> {
+  Persisted(T),
+  CommittedWithRotationFailure { result: T, error: anyhow::Error },
 }
 
 impl PersistentStore {
@@ -356,6 +365,8 @@ impl PersistentStore {
         initial_buffer_size: config.initial_buffer_size,
         max_capacity_bytes: config.max_capacity_bytes,
         stats,
+        #[cfg(test)]
+        fail_next_post_update_rotation: false,
       },
       data_loss,
     ))
@@ -442,11 +453,14 @@ impl PersistentStore {
     scope: Scope,
     key: &str,
     value: StateValue,
-  ) -> Result<(u64, Option<StateValue>), UpdateError> {
+  ) -> Result<PersistentOperation<(u64, Option<StateValue>)>, UpdateError> {
     let (timestamp, old_value) = if value.value_type.is_none() {
       // Deletion
       if !self.cached_map.contains_key(scope, key) {
-        return Ok((self.current_timestamp(), None));
+        return Ok(PersistentOperation::Persisted((
+          self.current_timestamp(),
+          None,
+        )));
       }
       let timestamp = self
         .try_insert_with_rotation(scope, key, &StateValue::default())
@@ -457,7 +471,10 @@ impl PersistentStore {
       if let Some(existing) = self.cached_map.get(scope, key)
         && existing.value == value
       {
-        return Ok((existing.timestamp, Some(existing.value.clone())));
+        return Ok(PersistentOperation::Persisted((
+          existing.timestamp,
+          Some(existing.value.clone()),
+        )));
       }
       // Insert/update
       let timestamp = self.try_insert_with_rotation(scope, key, &value).await?;
@@ -475,25 +492,25 @@ impl PersistentStore {
       (timestamp, old_value)
     };
 
-    if self.journal.is_high_water_mark_triggered() {
-      self.rotate_journal().await?;
+    let result = (timestamp, old_value);
+    match self.rotate_after_update().await {
+      Ok(()) => Ok(PersistentOperation::Persisted(result)),
+      Err(error) => Ok(PersistentOperation::CommittedWithRotationFailure { result, error }),
     }
-
-    Ok((timestamp, old_value))
   }
 
   async fn extend_entries(
     &mut self,
     entries: Vec<(Scope, String, StateValue)>,
-  ) -> Result<u64, UpdateError> {
+  ) -> Result<PersistentOperation<u64>, UpdateError> {
     if entries.is_empty() {
       // Return zero timestamp for empty batch (no-op)
-      return Ok(self.current_timestamp());
+      return Ok(PersistentOperation::Persisted(self.current_timestamp()));
     }
 
     let entries = self.filter_noop_entries(entries);
     if entries.is_empty() {
-      return Ok(self.current_timestamp());
+      return Ok(PersistentOperation::Persisted(self.current_timestamp()));
     }
 
     // Try to insert all entries with rotation handling, preserving order
@@ -515,20 +532,22 @@ impl PersistentStore {
     }
 
     // Check if rotation is needed after extend
-    if self.journal.is_high_water_mark_triggered() {
-      self.rotate_journal().await?;
+    match self.rotate_after_update().await {
+      Ok(()) => Ok(PersistentOperation::Persisted(timestamp)),
+      Err(error) => Ok(PersistentOperation::CommittedWithRotationFailure {
+        result: timestamp,
+        error,
+      }),
     }
-
-    Ok(timestamp)
   }
 
   async fn remove(
     &mut self,
     scope: Scope,
     key: &str,
-  ) -> Result<Option<(u64, StateValue)>, UpdateError> {
+  ) -> Result<PersistentOperation<Option<(u64, StateValue)>>, UpdateError> {
     if !self.cached_map.contains_key(scope, key) {
-      return Ok(None);
+      return Ok(PersistentOperation::Persisted(None));
     }
 
     let timestamp = self
@@ -536,11 +555,25 @@ impl PersistentStore {
       .await?;
     let old_value = self.cached_map.remove(scope, key);
 
+    let result = old_value.map(|v| (timestamp, v.value));
+    match self.rotate_after_update().await {
+      Ok(()) => Ok(PersistentOperation::Persisted(result)),
+      Err(error) => Ok(PersistentOperation::CommittedWithRotationFailure { result, error }),
+    }
+  }
+
+  /// Rotates after a committed mutation has advanced the journal high-water mark.
+  async fn rotate_after_update(&mut self) -> anyhow::Result<()> {
+    #[cfg(test)]
+    if std::mem::take(&mut self.fail_next_post_update_rotation) {
+      anyhow::bail!("test-injected post-update rotation failure");
+    }
+
     if self.journal.is_high_water_mark_triggered() {
       self.rotate_journal().await?;
     }
 
-    Ok(old_value.map(|v| (timestamp, v.value)))
+    Ok(())
   }
 
   fn sync(&self) -> anyhow::Result<()> {
@@ -1240,6 +1273,13 @@ impl VersionedKVStore {
     }
   }
 
+  #[cfg(test)]
+  pub(crate) fn fail_next_post_update_rotation_for_testing(&mut self) {
+    if let StoreBackend::Persistent(store) = &mut self.backend {
+      store.fail_next_post_update_rotation = true;
+    }
+  }
+
   /// Get a value by key.
   ///
   /// This operation is O(1) as it reads from the in-memory cache.
@@ -1292,7 +1332,11 @@ impl VersionedKVStore {
   ) -> Result<(u64, Option<StateValue>), UpdateError> {
     if let StoreBackend::Persistent(store) = &mut self.backend {
       match store.insert(scope, &key, value.clone()).await {
-        Ok(result) => return Ok(result),
+        Ok(PersistentOperation::Persisted(result)) => return Ok(result),
+        Ok(PersistentOperation::CommittedWithRotationFailure { result, error }) => {
+          self.fallback_to_in_memory(&error);
+          return Ok(result);
+        },
         Err(UpdateError::System(error)) => self.fallback_to_in_memory(&error),
         Err(error) => return Err(error),
       }
@@ -1327,7 +1371,14 @@ impl VersionedKVStore {
   ) -> Result<u64, UpdateError> {
     if let StoreBackend::Persistent(store) = &mut self.backend {
       match store.extend_entries(entries.clone()).await {
-        Ok(timestamp) => return Ok(timestamp),
+        Ok(PersistentOperation::Persisted(timestamp)) => return Ok(timestamp),
+        Ok(PersistentOperation::CommittedWithRotationFailure {
+          result: timestamp,
+          error,
+        }) => {
+          self.fallback_to_in_memory(&error);
+          return Ok(timestamp);
+        },
         Err(UpdateError::System(error)) => self.fallback_to_in_memory(&error),
         Err(error) => return Err(error),
       }
@@ -1356,7 +1407,11 @@ impl VersionedKVStore {
   ) -> Result<Option<(u64, StateValue)>, UpdateError> {
     if let StoreBackend::Persistent(store) = &mut self.backend {
       match store.remove(scope, key).await {
-        Ok(result) => return Ok(result),
+        Ok(PersistentOperation::Persisted(result)) => return Ok(result),
+        Ok(PersistentOperation::CommittedWithRotationFailure { result, error }) => {
+          self.fallback_to_in_memory(&error);
+          return Ok(result);
+        },
         Err(UpdateError::System(error)) => self.fallback_to_in_memory(&error),
         Err(error) => return Err(error),
       }

--- a/bd-versioned-kv/src/versioned_kv_journal/store.rs
+++ b/bd-versioned-kv/src/versioned_kv_journal/store.rs
@@ -24,12 +24,14 @@ use std::sync::Arc;
 #[derive(Clone)]
 struct CommonStats {
   capacity_exceeded_unrecoverable: bd_client_stats_store::Counter,
+  persistence_fallbacks: bd_client_stats_store::Counter,
 }
 
 impl CommonStats {
   fn new(stats: &bd_client_stats_store::Scope) -> Self {
     Self {
       capacity_exceeded_unrecoverable: stats.scope("kv").counter("capacity_exceeded_unrecoverable"),
+      persistence_fallbacks: stats.scope("kv").counter("persistence_fallbacks"),
     }
   }
 }
@@ -871,6 +873,21 @@ impl InMemoryStore {
     }
   }
 
+  /// Preserves the live state when persistence is no longer available.
+  ///
+  /// The fallback deliberately has no memory cap: state is correctness-critical for the
+  /// remainder of this process, while the persistent journal's capacity has already proved
+  /// unavailable. The state will be lost on the next process restart.
+  fn from_persistent(store: PersistentStore) -> Self {
+    Self {
+      time_provider: store.journal.time_provider.clone(),
+      cached_map: store.cached_map,
+      max_bytes: None,
+      current_size_bytes: 0,
+      stats: store.stats,
+    }
+  }
+
   /// Estimate the size in bytes of a key-value entry.
   ///
   /// This provides a conservative estimate of memory usage including:
@@ -1174,6 +1191,32 @@ impl VersionedKVStore {
     }
   }
 
+  /// Switches a failed persistent store to in-memory operation without losing its live state.
+  ///
+  /// A journal failure must not make runtime state disappear: callers such as workflow matching
+  /// and state consumers need the update even when it cannot survive a restart.
+  fn fallback_to_in_memory(&mut self, error: &UpdateError) {
+    let fallback = match &self.backend {
+      StoreBackend::Persistent(store) => {
+        store.stats.persistence_fallbacks.inc();
+        log::warn!(
+          "disabling state persistence after journal write failure; retaining state in memory: {error}"
+        );
+        InMemoryStore::new(
+          store.journal.time_provider.clone(),
+          None,
+          store.stats.clone(),
+        )
+      },
+      StoreBackend::InMemory(_) => return,
+    };
+
+    let previous = std::mem::replace(&mut self.backend, StoreBackend::InMemory(fallback));
+    if let StoreBackend::Persistent(store) = previous {
+      self.backend = StoreBackend::InMemory(InMemoryStore::from_persistent(store));
+    }
+  }
+
   /// Get a value by key.
   ///
   /// This operation is O(1) as it reads from the in-memory cache.
@@ -1205,26 +1248,41 @@ impl VersionedKVStore {
   ///
   /// Note: Inserting `Value::Null` is equivalent to removing the key.
   ///
+  /// If persistent journal admission fails, the store transitions to unbounded in-memory mode and
+  /// still applies the update. The state remains available to the current process, but will not
+  /// survive a restart. This degradation is logged and counted in `kv:persistence_fallbacks`.
+  ///
+  /// While the persistent journal is healthy, a successful return means it accepted the update;
+  /// callers that require an explicit disk sync must call [`Self::sync`].
+  ///
   /// # Errors
-  /// - Returns `UpdateError::CapacityExceeded` if the in-memory store would exceed its size limit
-  /// - Returns `UpdateError::System` if the value cannot be written to the journal (persistent
-  ///   mode)
+  /// Returns `UpdateError::CapacityExceeded` only for an explicitly bounded in-memory store.
   pub async fn insert(
     &mut self,
     scope: Scope,
     key: String,
     value: StateValue,
   ) -> Result<(u64, Option<StateValue>), UpdateError> {
-    match &mut self.backend {
-      StoreBackend::Persistent(store) => store.insert(scope, &key, value).await,
-      StoreBackend::InMemory(store) => store.insert(scope, &key, &value),
+    if let StoreBackend::Persistent(store) = &mut self.backend {
+      match store.insert(scope, &key, value.clone()).await {
+        Ok(result) => return Ok(result),
+        Err(error) => self.fallback_to_in_memory(&error),
+      }
     }
+
+    if let StoreBackend::InMemory(store) = &mut self.backend {
+      return store.insert(scope, &key, &value);
+    }
+
+    Err(UpdateError::System(anyhow::anyhow!(
+      "state store did not transition to in-memory mode after a journal failure"
+    )))
   }
 
   /// Insert multiple key-value pairs with a shared timestamp.
   ///
-  /// All entries are written with the same timestamp. If any entry fails to write to the journal,
-  /// the operation is rolled back and an error is returned.
+  /// All entries are written with the same timestamp. If a persistent journal write fails, the
+  /// store transitions to in-memory mode and applies the entire batch there.
   ///
   /// For persistent stores, this operation handles rotation and retries automatically if needed.
   /// If empty, this is a no-op that returns the current timestamp.
@@ -1232,16 +1290,25 @@ impl VersionedKVStore {
   /// Note: Entries with `Value::Null` are treated as deletions.
   ///
   /// # Errors
-  /// - Returns `UpdateError::CapacityExceeded` if the batch would exceed capacity limits
-  /// - Returns `UpdateError::System` if the batch cannot be written (persistent mode)
+  /// Returns `UpdateError::CapacityExceeded` only for an explicitly bounded in-memory store.
   pub async fn extend(
     &mut self,
     entries: Vec<(Scope, String, StateValue)>,
   ) -> Result<u64, UpdateError> {
-    match &mut self.backend {
-      StoreBackend::Persistent(store) => store.extend_entries(entries).await,
-      StoreBackend::InMemory(store) => store.extend_entries(entries),
+    if let StoreBackend::Persistent(store) = &mut self.backend {
+      match store.extend_entries(entries.clone()).await {
+        Ok(timestamp) => return Ok(timestamp),
+        Err(error) => self.fallback_to_in_memory(&error),
+      }
     }
+
+    if let StoreBackend::InMemory(store) = &mut self.backend {
+      return store.extend_entries(entries);
+    }
+
+    Err(UpdateError::System(anyhow::anyhow!(
+      "state store did not transition to in-memory mode after a journal failure"
+    )))
   }
 
   /// Remove a key and return the timestamp and old value.
@@ -1249,16 +1316,27 @@ impl VersionedKVStore {
   /// Returns `None` if the key didn't exist, otherwise returns the timestamp and old value.
   ///
   /// # Errors
-  /// Returns an error if the deletion cannot be written to the journal (persistent mode only).
+  /// If persistent journal admission fails, the store transitions to in-memory mode and removes
+  /// the value from the live state.
   pub async fn remove(
     &mut self,
     scope: Scope,
     key: &str,
   ) -> Result<Option<(u64, StateValue)>, UpdateError> {
-    match &mut self.backend {
-      StoreBackend::Persistent(store) => store.remove(scope, key).await,
-      StoreBackend::InMemory(store) => Ok(store.remove(scope, key)),
+    if let StoreBackend::Persistent(store) = &mut self.backend {
+      match store.remove(scope, key).await {
+        Ok(result) => return Ok(result),
+        Err(error) => self.fallback_to_in_memory(&error),
+      }
     }
+
+    if let StoreBackend::InMemory(store) = &mut self.backend {
+      return Ok(store.remove(scope, key));
+    }
+
+    Err(UpdateError::System(anyhow::anyhow!(
+      "state store did not transition to in-memory mode after a journal failure"
+    )))
   }
 
   /// Clear all keys in a given scope with a shared timestamp.
@@ -1269,7 +1347,8 @@ impl VersionedKVStore {
   /// This is implemented using `extend()` for efficiency.
   ///
   /// # Errors
-  /// Returns an error if the deletions cannot be written to the journal (persistent mode only).
+  /// If persistent journal admission fails, the store transitions to in-memory mode and clears
+  /// the live state.
   pub async fn clear(&mut self, scope: Scope) -> Result<Option<u64>, UpdateError> {
     // Collect all keys in this scope
     let keys: Vec<String> = self


### PR DESCRIPTION
Retains live state if journaling fails by transitioning the persistent store to bounded in-memory operation at its configured capacity. Workflows and state consumers continue to observe accepted updates during the current process; restart persistence is explicitly degraded and counted.