### PR TITLE
Deflake remote streaming activation test

### DIFF
--- a/bd-logger/src/consumer_test.rs
+++ b/bd-logger/src/consumer_test.rs
@@ -42,7 +42,7 @@ use bd_test_helpers::runtime::{ValueKind, make_simple_update};
 use bd_time::{OffsetDateTimeExt as _, TimeDurationExt};
 use bd_versioned_kv::{RetentionHandle, RetentionRegistry};
 use bd_workflows::config::FlushBufferId;
-use bd_workflows::engine::ProcessLocalPendingFlushState;
+use bd_workflows::engine::{PendingFlushStateTestHook, ProcessLocalPendingFlushState};
 use core::panic;
 use futures_util::poll;
 use protobuf::{CodedOutputStream, Message};
@@ -51,7 +51,14 @@ use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
 use time::ext::NumericalDuration;
-use tokio::sync::mpsc::{Receiver, Sender, channel};
+use tokio::sync::mpsc::{
+  Receiver,
+  Sender,
+  UnboundedReceiver,
+  UnboundedSender,
+  channel,
+  unbounded_channel,
+};
 
 fn make_flags(runtime_loader: &ConfigLoader) -> Flags {
   Flags {
@@ -670,12 +677,23 @@ fn make_test_log(t: time::OffsetDateTime) -> Vec<u8> {
   output
 }
 
+struct PendingFlushStateTestEvents {
+  state_changed_tx: UnboundedSender<(FlushBufferId, bool)>,
+}
+
+impl PendingFlushStateTestHook for PendingFlushStateTestEvents {
+  fn flush_state_changed(&self, flush_id: FlushBufferId, is_pending: bool) {
+    let _ignored = self.state_changed_tx.send((flush_id, is_pending));
+  }
+}
+
 struct SetupMultiConsumer {
   log_upload_rx: Receiver<DataUpload>,
   shutdown_trigger: ComponentShutdownTrigger,
   buffer_event_tx: Sender<BufferEventWithResponse>,
   trigger_upload_tx: Sender<TriggerUpload>,
   process_local_pending_flush_state: Arc<ProcessLocalPendingFlushState>,
+  pending_flush_state_rx: UnboundedReceiver<(FlushBufferId, bool)>,
   runtime_loader: Arc<ConfigLoader>,
   stats: Collector,
   sdk_directory: PathBuf,
@@ -696,7 +714,12 @@ impl SetupMultiConsumer {
 
     let (log_upload_tx, log_upload_rx) = tokio::sync::mpsc::channel(1);
     let (trigger_upload_tx, trigger_upload_rx) = tokio::sync::mpsc::channel(1);
-    let process_local_pending_flush_state = Arc::new(ProcessLocalPendingFlushState::default());
+    let (pending_flush_state_tx, pending_flush_state_rx) = unbounded_channel();
+    let process_local_pending_flush_state = Arc::new(
+      ProcessLocalPendingFlushState::new_with_test_hook(Arc::new(PendingFlushStateTestEvents {
+        state_changed_tx: pending_flush_state_tx,
+      })),
+    );
 
     let shutdown_trigger = ComponentShutdownTrigger::default();
     let config_loader = ConfigLoader::new(&sdk_directory);
@@ -745,6 +768,7 @@ impl SetupMultiConsumer {
       buffer_event_tx,
       trigger_upload_tx,
       process_local_pending_flush_state,
+      pending_flush_state_rx,
       runtime_loader: config_loader,
       stats,
       sdk_directory,
@@ -846,6 +870,15 @@ impl SetupMultiConsumer {
 
   fn flush_is_pending(&self, flush_id: &FlushBufferId) -> bool {
     self.process_local_pending_flush_state.is_pending(flush_id)
+  }
+
+  async fn wait_for_flush_state(&mut self, flush_id: &FlushBufferId, expected_pending: bool) {
+    loop {
+      let (changed_flush_id, is_pending) = self.pending_flush_state_rx.recv().await.unwrap();
+      if &changed_flush_id == flush_id && is_pending == expected_pending {
+        return;
+      }
+    }
   }
 
   async fn next_upload(&mut self) -> Tracked<ApiRequest, UploadResponse> {
@@ -2176,6 +2209,8 @@ async fn remote_streaming_activation_channel_closure_preserves_flush_completion(
     .await
     .unwrap();
 
+  setup.wait_for_flush_state(&flush_id, true).await;
+  assert!(setup.flush_is_pending(&flush_id));
   let upload = setup.next_upload().await;
   assert!(setup.flush_is_pending(&flush_id));
 
@@ -2287,6 +2322,8 @@ async fn remote_streaming_activation_waits_for_channel_capacity_before_completin
     .await
     .unwrap();
 
+  setup.wait_for_flush_state(&flush_id, true).await;
+  assert!(setup.flush_is_pending(&flush_id));
   let upload = setup.next_upload().await;
   assert!(setup.flush_is_pending(&flush_id));
   upload
@@ -2297,9 +2334,6 @@ async fn remote_streaming_activation_waits_for_channel_capacity_before_completin
     })
     .unwrap();
 
-  for _ in 0 .. 100 {
-    tokio::task::yield_now().await;
-  }
   assert!(setup.flush_is_pending(&flush_id));
 
   let queued_request = remote_flush_streaming_rx.recv().await.unwrap();
@@ -2309,16 +2343,10 @@ async fn remote_streaming_activation_waits_for_channel_capacity_before_completin
   assert_eq!(activated_request.id, "flush-1");
   assert_eq!(activated_request.buffer_ids, vec!["buffer".to_string()]);
 
-  for _ in 0 .. 100 {
-    if !setup.flush_is_pending(&flush_id) {
-      setup.shutdown().await;
-      return;
-    }
+  setup.wait_for_flush_state(&flush_id, false).await;
+  assert!(!setup.flush_is_pending(&flush_id));
 
-    tokio::task::yield_now().await;
-  }
-
-  panic!("expected flush completion tracker to clear once remote streaming activation was sent");
+  setup.shutdown().await;
 }
 
 #[tokio::test]

--- a/bd-logger/src/test/logger_integration.rs
+++ b/bd-logger/src/test/logger_integration.rs
@@ -2731,10 +2731,8 @@ fn remote_buffer_upload_with_streaming_matches_workflow_streaming_behavior() {
   // Wait until the remote action has installed its streaming route before emitting logs for it.
   setup.wait_for_remote_streaming_action_processing();
 
-  // Streaming becomes active only after the originating trigger upload completes. Its log-count
-  // termination is also intentionally held until that completion is visible to the workflow
-  // engine, so synchronize both sides before exercising the steady-state behavior.
-  setup.wait_for_remote_streaming_action_processing();
+  // Activation is delivered before the originating trigger upload is marked complete. Wait for
+  // that completion before exercising the steady-state streaming behavior.
   setup.wait_for_remote_streaming_trigger_upload_completion();
 
   assert_matches!(setup.server.blocking_next_log_upload(), Some(log_upload) => {

--- a/bd-workflows/src/engine.rs
+++ b/bd-workflows/src/engine.rs
@@ -83,22 +83,57 @@ pub const WORKFLOWS_STATE_FILE_NAME: &str = "workflows_state_snapshot.12.bin";
 /// `PendingTriggerUploadsStore` remains the durable source of truth across restart. The logger
 /// projects that persisted state into this in-memory set during startup so the workflow engine can
 /// cheaply decide whether streaming is still waiting on its originating flush to complete.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct ProcessLocalPendingFlushState {
   pending_flushes: RwLock<HashSet<FlushBufferId>>,
+  #[cfg(feature = "test")]
+  test_hook: Option<Arc<dyn PendingFlushStateTestHook>>,
+}
+
+#[cfg(feature = "test")]
+pub trait PendingFlushStateTestHook: Send + Sync {
+  fn flush_state_changed(&self, flush_id: FlushBufferId, is_pending: bool);
 }
 
 impl ProcessLocalPendingFlushState {
+  #[cfg(feature = "test")]
+  pub fn new_with_test_hook(test_hook: Arc<dyn PendingFlushStateTestHook>) -> Self {
+    Self {
+      pending_flushes: RwLock::default(),
+      test_hook: Some(test_hook),
+    }
+  }
+
   pub fn replace_pending_flushes(&self, flush_ids: impl IntoIterator<Item = FlushBufferId>) {
     *self.pending_flushes.write() = flush_ids.into_iter().collect();
   }
 
   pub fn mark_pending(&self, flush_id: FlushBufferId) {
-    self.pending_flushes.write().insert(flush_id);
+    #[cfg(feature = "test")]
+    {
+      let changed = self.pending_flushes.write().insert(flush_id.clone());
+      if changed && let Some(test_hook) = &self.test_hook {
+        test_hook.flush_state_changed(flush_id, true);
+      }
+    }
+    #[cfg(not(feature = "test"))]
+    {
+      self.pending_flushes.write().insert(flush_id);
+    }
   }
 
   pub fn mark_completed(&self, flush_id: &FlushBufferId) {
-    self.pending_flushes.write().remove(flush_id);
+    #[cfg(feature = "test")]
+    {
+      let changed = self.pending_flushes.write().remove(flush_id);
+      if changed && let Some(test_hook) = &self.test_hook {
+        test_hook.flush_state_changed(flush_id.clone(), false);
+      }
+    }
+    #[cfg(not(feature = "test"))]
+    {
+      self.pending_flushes.write().remove(flush_id);
+    }
   }
 
   pub fn is_pending(&self, flush_id: &FlushBufferId) -> bool {


### PR DESCRIPTION
Replace scheduler-yield polling in remote streaming activation tests with lifecycle events from a test-only pending-flush hook. The hook is enabled only by the bd-workflows test feature, so release builds retain the direct state-set implementation.