### PR TITLE
Stop event listeners during logger shutdown

### DIFF
--- a/bd-events/src/lib.rs
+++ b/bd-events/src/lib.rs
@@ -106,4 +106,17 @@ impl Listener {
       }
     }
   }
+
+  /// Stops the platform target when the owning logger is permanently shutting down.
+  ///
+  /// `run_with_shutdown` deliberately preserves an active target so a caller can restart its
+  /// listener future without re-registering platform callbacks. Logger teardown is terminal,
+  /// however, and must unregister those callbacks before the platform frees its logger handle.
+  pub fn shutdown(&mut self) {
+    if self.target_is_active {
+      log::debug!("events listener stop on shutdown");
+      self.target.stop();
+      self.target_is_active = false;
+    }
+  }
 }

--- a/bd-events/src/listener_test.rs
+++ b/bd-events/src/listener_test.rs
@@ -120,6 +120,35 @@ async fn starts_target_by_default() {
 }
 
 #[tokio::test]
+async fn shutdown_stops_active_target() {
+  let setup = Setup::new();
+
+  let target = Box::new(MockListenerTarget::default());
+  let state = target.state.clone();
+  let started = target.started.clone();
+
+  let listener = setup.create_listener(target);
+  let shutdown_trigger = ComponentShutdownTrigger::default();
+  let shutdown = shutdown_trigger.make_shutdown();
+
+  let listener_task = tokio::task::spawn(async move {
+    let mut listener = listener;
+    listener.run_with_shutdown(shutdown).await;
+    listener
+  });
+
+  started.notified().await;
+  shutdown_trigger.shutdown().await;
+
+  let mut listener = listener_task.await.unwrap();
+  listener.shutdown();
+
+  assert_eq!(1, state.lock().start_calls_count);
+  assert_eq!(1, state.lock().stop_calls_count);
+  assert!(!state.lock().is_active.unwrap());
+}
+
+#[tokio::test]
 async fn does_not_restart_an_active_target() {
   let setup = Setup::new();
 

--- a/bd-logger/src/async_log_buffer.rs
+++ b/bd-logger/src/async_log_buffer.rs
@@ -1176,6 +1176,9 @@ impl<R: LogReplay + Send + 'static> AsyncLogBuffer<R> {
       }
     }
 
+    // The listener future is cancelled when this loop exits, so it cannot run its own shutdown
+    // path. Stop platform callbacks while the logger and its platform handle are still alive.
+    self.events_listener.shutdown();
     self.event_buffer.close();
     self
   }


### PR DESCRIPTION
Stops the events listener target when `AsyncLogBuffer` exits during terminal logger shutdown, unregistering platform callbacks before the logger handle can be freed. This preserves restart behavior during normal listener runs and adds regression coverage for teardown.